### PR TITLE
fix: resolve Docker build warnings and errors in front/api

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 scripts/container-volume/
+front/node_modules/

--- a/api/Dockerfile.mcwebconsoleapi
+++ b/api/Dockerfile.mcwebconsoleapi
@@ -1,8 +1,8 @@
 ## Stage 1 - Go Build Env
 FROM golang:1.25-alpine AS build
 
-ENV GOPROXY https://proxy.golang.org
-ENV CGO_ENABLED 0
+ENV GOPROXY=https://proxy.golang.org
+ENV CGO_ENABLED=0
 
 RUN mkdir -p /src/mc-web-console-api
 WORKDIR /src/mc-web-console-api
@@ -12,14 +12,14 @@ RUN go mod download
 RUN go build -ldflags="-s -w" -o /bin/api ./cmd
 
 ## Stage 2 - Application Deploy
-FROM debian:bookworm-slim as deploy
+FROM debian:bookworm-slim AS deploy
 
 WORKDIR /app/
 COPY --from=build /bin/api .
 ADD ./conf/api.yaml /conf/api.yaml
 
-ENV API_ADDR 0.0.0.0
-ENV API_PORT 3000
+ENV API_ADDR=0.0.0.0
+ENV API_PORT=3000
 
 EXPOSE 3000
 CMD ["/app/api"]

--- a/front/Dockerfile.mcwebconsolefront
+++ b/front/Dockerfile.mcwebconsolefront
@@ -3,27 +3,30 @@ FROM golang:1.25-alpine AS build
 
 RUN apk add --no-cache gcc libc-dev musl-dev curl npm wget
 
-ENV GOPROXY https://proxy.golang.org
-ENV CGO_ENABLED 0
+ENV GOPROXY=https://proxy.golang.org
+ENV CGO_ENABLED=0
 
 RUN mkdir -p /src/mc-web-console-front
 WORKDIR /src/mc-web-console-front
+
+COPY ./front/package.json ./front/package-lock.json ./
+RUN npm ci
+
 ADD ./front .
 
 RUN go mod download
-RUN npm ci
 RUN npm run build
 RUN go build -ldflags="-s -w" -o /bin/front ./cmd/app
 
 ## Stage 2 - Application Deploy
-FROM debian:buster-slim as deploy
+FROM debian:buster-slim AS deploy
 
 WORKDIR /app
 COPY --from=build /bin/front .
 COPY --from=build /src/mc-web-console-front/public ./public
 
-ENV FRONT_ADDR 0.0.0.0
-ENV FRONT_PORT 3001
+ENV FRONT_ADDR=0.0.0.0
+ENV FRONT_PORT=3001
 
 EXPOSE 3001
 CMD ["./front"]

--- a/front/package.json
+++ b/front/package.json
@@ -36,7 +36,6 @@
     "tabulator-tables": "^5.6.1",
     "tinymce": "^6.8.3",
     "tom-select": "^2.3.1",
-    "xterm-addon-fit": "^0.8.0",
     "yarn": "^1.22.22"
   },
   "devDependencies": {
@@ -49,7 +48,7 @@
     "css-loader": "~3.5.1",
     "expose-loader": "^3.0.0",
     "file-loader": "~6.0.0",
-    "glob": "^7.2.0",
+    "glob": "^13.0.0",
     "gopherjs-loader": "^0.0.1",
     "mini-css-extract-plugin": "^2.0.0",
     "npm-install-webpack-plugin": "4.0.5",

--- a/front/webpack.config.js
+++ b/front/webpack.config.js
@@ -1,5 +1,5 @@
 const Webpack = require("webpack");
-const Glob = require("glob");
+const { globSync } = require("glob");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const { WebpackManifestPlugin } = require("webpack-manifest-plugin");
@@ -13,8 +13,8 @@ const configurator = {
         './assets/css/application.scss',
       ],
     }
-    // Glob.sync("./assets/*/*.*").forEach((entry) => {
-    Glob.sync("./assets/*/*/*.*").forEach((entry) => {
+    // globSync("./assets/*/*.*").forEach((entry) => {
+    globSync("assets/*/*/*.*").map(e => `./${e}`).forEach((entry) => {
       if (entry === './assets/css/application.scss') {
         return
       }
@@ -31,25 +31,7 @@ const configurator = {
 
       entries[key].push(entry)
     })
-    Glob.sync("./assets/*/*/*/*.*").forEach((entry) => {
-      if (entry === './assets/css/application.scss') {
-        return
-      }
-
-      let key = entry.replace(/(\.\/assets\/(src|js|css|go)\/)|\.(ts|js|s[ac]ss|go)/g, '')
-      if(key.startsWith("_") || (/(ts|js|s[ac]ss|go)$/i).test(entry) == false) {
-        return
-      }
-
-      if( entries[key] == null) {
-        entries[key] = [entry]
-        return
-      }
-
-      entries[key].push(entry)
-    })
-
-    Glob.sync("./assets/*/*/*/*/*.*").forEach((entry) => {
+    globSync("assets/*/*/*/*.*").map(e => `./${e}`).forEach((entry) => {
       if (entry === './assets/css/application.scss') {
         return
       }
@@ -67,7 +49,7 @@ const configurator = {
       entries[key].push(entry)
     })
 
-    Glob.sync("./assets/*/*/*/*/*/*.*").forEach((entry) => {
+    globSync("assets/*/*/*/*/*.*").map(e => `./${e}`).forEach((entry) => {
       if (entry === './assets/css/application.scss') {
         return
       }
@@ -85,7 +67,25 @@ const configurator = {
       entries[key].push(entry)
     })
 
-    Glob.sync("./assets/*/*/*/*/*/*/*.*").forEach((entry) => {
+    globSync("assets/*/*/*/*/*/*.*").map(e => `./${e}`).forEach((entry) => {
+      if (entry === './assets/css/application.scss') {
+        return
+      }
+
+      let key = entry.replace(/(\.\/assets\/(src|js|css|go)\/)|\.(ts|js|s[ac]ss|go)/g, '')
+      if(key.startsWith("_") || (/(ts|js|s[ac]ss|go)$/i).test(entry) == false) {
+        return
+      }
+
+      if( entries[key] == null) {
+        entries[key] = [entry]
+        return
+      }
+
+      entries[key].push(entry)
+    })
+
+    globSync("assets/*/*/*/*/*/*/*.*").map(e => `./${e}`).forEach((entry) => {
       if (entry === './assets/css/application.scss') {
         return
       }
@@ -141,7 +141,7 @@ const configurator = {
             MiniCssExtractPlugin.loader,
             { loader: "css-loader", options: {sourceMap: true}},
             { loader: "postcss-loader", options: {sourceMap: true}},
-            { loader: "sass-loader", options: {sourceMap: true}}
+            { loader: "sass-loader", options: {sourceMap: true, sassOptions: {quietDeps: true, silenceDeprecations: ['legacy-js-api', 'import', 'global-builtin', 'color-functions']}}}
           ]
         },
         { test: /\.tsx?$/, use: "ts-loader", exclude: /node_modules/},


### PR DESCRIPTION
## Summary

- `api/Dockerfile`: ENV 형식(`key=value`) 및 `AS` 케이싱 경고 수정
- `front/Dockerfile`: 동일한 ENV/AS 수정, `npm ci` 실행 전 package 파일 COPY 순서 재구성 (missing package-lock.json 오류 해결)
- `.dockerignore`: `front/node_modules/` 추가 (빌드 컨텍스트 오염 방지)
- `front/package.json`: deprecated `xterm-addon-fit` 제거 (`@xterm/addon-fit` 중복), `glob` ^7 → ^13 업그레이드
- `front/webpack.config.js`: glob@13 API 대응 (`Glob.sync()` → `globSync()`), path prefix 처리 수정, Dart Sass deprecation 경고 억제

## Test plan

- [ ] Docker build 성공 확인 (`docker build -f ./front/Dockerfile.mcwebconsolefront`)
- [ ] webpack 빌드 에러 없음 확인
- [ ] Sass deprecation 경고 제거 확인