### PR TITLE
fix: remove package-lock.json dependency from front Dockerfile

### DIFF
--- a/front/Dockerfile.mcwebconsolefront
+++ b/front/Dockerfile.mcwebconsolefront
@@ -9,8 +9,8 @@ ENV CGO_ENABLED=0
 RUN mkdir -p /src/mc-web-console-front
 WORKDIR /src/mc-web-console-front
 
-COPY ./front/package.json ./front/package-lock.json ./
-RUN npm ci
+COPY ./front/package.json ./
+RUN npm install
 
 ADD ./front .
 


### PR DESCRIPTION
## Summary

- `front/package-lock.json`이 `.gitignore`에 포함되어 있어 저장소를 새로 클론하면 파일이 없어 Docker 빌드 실패
- `COPY package-lock.json` + `npm ci` → `COPY package.json` + `npm install` 로 변경

## Test plan

- [ ] 저장소 fresh clone 후 Docker build 성공 확인