### PR TITLE
fix(auth): Refresh Token 자동 갱신 버그 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ scripts/container-volume
 conf/api.yaml
 bin/mc-web-console-front
 node_modules
+
+# git worktrees
+.worktrees/

--- a/api/internal/handler/auth.go
+++ b/api/internal/handler/auth.go
@@ -39,9 +39,14 @@ type LoginResponse struct {
 	Role             string  `json:"role"`
 }
 
-// RefreshRequest 토큰 갱신 요청
+// RefreshRequest 토큰 갱신 요청 (flat 형식)
 type RefreshRequest struct {
 	RefreshToken string `json:"refresh_token"`
+}
+
+// RefreshRequestWrapper CommonRequest 래퍼 형식 (authcookie.js 호환)
+type RefreshRequestWrapper struct {
+	Request RefreshRequest `json:"request"`
 }
 
 // Login 로그인 핸들러
@@ -139,23 +144,38 @@ func loginLocal(c echo.Context, id, password string) error {
 
 // Refresh 토큰 갱신 핸들러
 // POST /api/auth/refresh
+// {"refresh_token": "..."} 또는 {"request": {"refresh_token": "..."}} 형식 모두 지원
 func Refresh(c echo.Context) error {
-	var req RefreshRequest
-	if err := c.Bind(&req); err != nil {
+	body, err := io.ReadAll(c.Request().Body)
+	if err != nil {
 		return errors.NewBadRequest("Invalid request body")
 	}
 
-	if req.RefreshToken == "" {
+	var refreshToken string
+
+	// request 래퍼 형식 시도
+	var wrapper RefreshRequestWrapper
+	if jsonErr := json.Unmarshal(body, &wrapper); jsonErr == nil && wrapper.Request.RefreshToken != "" {
+		refreshToken = wrapper.Request.RefreshToken
+	} else {
+		// flat 형식 시도
+		var req RefreshRequest
+		if jsonErr := json.Unmarshal(body, &req); jsonErr == nil {
+			refreshToken = req.RefreshToken
+		}
+	}
+
+	if refreshToken == "" {
 		return errors.NewBadRequest("Refresh token is required")
 	}
 
 	cfg, _ := c.Get("config").(*config.Config)
 	if cfg != nil && cfg.MCIAM.Use {
-		return refreshViaMCIAM(c, req.RefreshToken, cfg)
+		return refreshViaMCIAM(c, refreshToken, cfg)
 	}
 
 	// 로컬 모드: refresh token으로 새 access token 발급
-	userID, err := jwt.ExtractUserID(req.RefreshToken)
+	userID, err := jwt.ExtractUserID(refreshToken)
 	if err != nil {
 		return errors.NewUnauthorized("Invalid refresh token")
 	}


### PR DESCRIPTION
## Summary

- `POST /api/auth/refresh` 핸들러가 `authcookie.js`의 CommonRequest 래퍼 형식을 처리하지 못해 Access Token 자동 갱신이 항상 실패하는 버그 수정
- `authcookie.js`는 `{"request": {"refresh_token": "..."}}` 형식으로 전송하지만, 핸들러는 `{"refresh_token": "..."}` flat 형식만 처리 → 항상 400 "Refresh token is required" 반환
- 두 형식 모두 지원하도록 수정하여 Access Token 만료 시 자동 갱신 정상화

## Changes

- `api/internal/handler/auth.go`
  - `RefreshRequestWrapper` 타입 추가 (CommonRequest 래퍼 형식)
  - `Refresh` 핸들러가 래퍼 형식(`{"request": {"refresh_token": "..."}}`)과 flat 형식(`{"refresh_token": "..."}`) 모두 처리

## Test plan

- [ ] 로그인 후 Access Token 만료 대기 (또는 쿠키 수동 만료)
- [ ] API 호출 시 401 응답 → 자동으로 `/api/auth/refresh` 호출되는지 확인
- [ ] 갱신 성공 시 원래 API 요청이 재시도되는지 확인
- [ ] 갱신 실패(RefreshToken 없음) 시 로그인 페이지로 리다이렉트되는지 확인
