### PR TITLE
chore(conf): api.yaml 테스트 IP 플레이스홀더 롤백 (fr-004)

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -12,13 +12,13 @@ services:
 
   mc-iam-manager:
     version: 0.2.11
-    baseurl: http://52.79.163.111:5006
+    baseurl: http://mc-iam-manager_url:5006
     auth:
       type: bearer
 
   mc-infra-manager:
     version: 0.9.11
-    baseurl: http://52.79.163.111:1323/tumblebug
+    baseurl: http://tumblebug_url:1323/tumblebug
 
     auth:
       type: basic


### PR DESCRIPTION
## Summary

- `conf/api.yaml`의 테스트용 고정 IP(`52.79.163.111`)를 플레이스홀더로 롤백
  - `mc-iam-manager` baseurl: `http://52.79.163.111:5006` → `http://mc-iam-manager_url:5006`
  - `mc-infra-manager` baseurl: `http://52.79.163.111:1323/tumblebug` → `http://tumblebug_url:1323/tumblebug`

## Test plan

- [ ] `grep "baseurl" conf/api.yaml | grep "52\."` 출력 없음 확인