### PR TITLE
feat(fr-006): organization management 구현 및 api.yaml 테스트 IP 롤백

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -12,13 +12,13 @@ services:
 
   mc-iam-manager:
     version: 0.2.11
-    baseurl: http://52.79.163.111:5006
+    baseurl: http://mc-iam-manager_url:5006
     auth:
       type: bearer
 
   mc-infra-manager:
     version: 0.9.11
-    baseurl: http://52.79.163.111:1323/tumblebug
+    baseurl: http://tumblebug_url:1323/tumblebug
 
     auth:
       type: basic
@@ -1012,6 +1012,46 @@ serviceActions:
       method: put
       resourcePath: /api/users/me/password
       description: "사용자 본인 비밀번호 변경"
+    Createorganization:
+      method: post
+      resourcePath: /api/organizations
+      description: "그룹 생성"
+    Getorganizations:
+      method: get
+      resourcePath: /api/organizations
+      description: "그룹 목록/트리 조회 (query: tree=true면 중첩 구조)"
+    Getorganizationbyid:
+      method: get
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 단건 조회 by ID"
+    Getorganizationbycode:
+      method: get
+      resourcePath: /api/organizations/code/{code}
+      description: "그룹 단건 조회 by code"
+    Updateorganization:
+      method: put
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 수정 (부모 변경 시 하위 코드 자동 재생성)"
+    Deleteorganization:
+      method: delete
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 삭제 (하위 그룹·소속 사용자 있으면 400)"
+    Getorganizationusers:
+      method: get
+      resourcePath: /api/organizations/id/{organizationId}/users
+      description: "그룹 소속 사용자 목록"
+    Assignuserorganizations:
+      method: post
+      resourcePath: /api/users/id/{userId}/organizations
+      description: "사용자 그룹 할당 (다중)"
+    Getuserorganizations:
+      method: get
+      resourcePath: /api/users/id/{userId}/organizations
+      description: "사용자 소속 그룹 목록"
+    Removeuserorganization:
+      method: delete
+      resourcePath: /api/users/id/{userId}/organizations/{organizationId}
+      description: "사용자 그룹 제거"
 
   mc-infra-manager:
     Lookupspeclist:


### PR DESCRIPTION
## Summary

- `conf/api.yaml` 테스트용 고정 IP(`52.79.163.111`) 플레이스홀더로 롤백
  - `mc-iam-manager` baseurl: `http://52.79.163.111:5006` → `http://mc-iam-manager_url:5006`
  - `mc-infra-manager` baseurl: `http://52.79.163.111:1323/tumblebug` → `http://tumblebug_url:1323/tumblebug`
- Organization(그룹) 관리 기능 구현 (생성/조회/수정/삭제, 사용자 할당)
- `conf/api.yaml`에 organization 관련 serviceActions 추가

## Test plan

- [ ] `grep "baseurl" conf/api.yaml | grep "52\."` 출력 없음 확인
- [ ] 그룹 생성/조회/수정/삭제 동작 확인
- [ ] 사용자 그룹 할당/해제 동작 확인