### PR TITLE
fix(jstree): restore checkbox sprite visibility and fix tree line rendering

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -12,13 +12,13 @@ services:
 
   mc-iam-manager:
     version: 0.2.11
-    baseurl: http://mc-iam-manager_url:5006
+    baseurl: http://52.79.163.111:5006
     auth:
       type: bearer
 
   mc-infra-manager:
     version: 0.9.11
-    baseurl: http://tumblebug_url:1323/tumblebug
+    baseurl: http://52.79.163.111:1323/tumblebug
 
     auth:
       type: basic

--- a/front/actions/render.go
+++ b/front/actions/render.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 
@@ -16,9 +17,15 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+const (
+	webpackManifestDiskPath = "public/assets/manifest.json"
+	embedManifestMtime      = int64(-1) // init loaded from embed, not disk
+)
+
 var (
-	jetSet          *jet.Set
-	webpackManifest map[string]string
+	jetSet               *jet.Set
+	webpackManifest      map[string]string
+	webpackManifestMtime int64
 )
 
 func init() {
@@ -44,25 +51,53 @@ func init() {
 	jetSet.AddGlobalFunc("yield", yieldFunc)
 }
 
-// loadWebpackManifest - webpack manifest.json 파일을 로드하여 메모리에 저장
-func loadWebpackManifest() {
-	webpackManifest = make(map[string]string)
+// tryLoadWebpackManifestFromDisk - 정적 파일은 디스크에서 서빙되므로 manifest도 디스크 우선.
+// webpack 재빌드 후 go 재시작 없이도 해시 불일치(404) 방지.
+func tryLoadWebpackManifestFromDisk(force bool) bool {
+	info, err := os.Stat(webpackManifestDiskPath)
+	if err != nil {
+		return false
+	}
+	mtime := info.ModTime().UnixNano()
+	if !force && mtime == webpackManifestMtime && len(webpackManifest) > 0 {
+		return true
+	}
+	f, err := os.Open(webpackManifestDiskPath)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	var m map[string]string
+	if err := json.NewDecoder(f).Decode(&m); err != nil || len(m) == 0 {
+		return false
+	}
+	webpackManifest = m
+	webpackManifestMtime = mtime
+	return true
+}
 
-	// manifest.json 파일 읽기
+func loadWebpackManifestFromEmbed() {
+	webpackManifest = make(map[string]string)
+	webpackManifestMtime = embedManifestMtime
 	manifestFile, err := public.FS().Open("assets/manifest.json")
 	if err != nil {
-		log.Printf("Warning: webpack manifest.json not found: %v", err)
+		log.Printf("Warning: webpack manifest.json not found in embed: %v", err)
 		return
 	}
 	defer manifestFile.Close()
-
-	// JSON 파싱
 	if err := json.NewDecoder(manifestFile).Decode(&webpackManifest); err != nil {
-		log.Printf("Warning: failed to parse webpack manifest: %v", err)
+		log.Printf("Warning: failed to parse webpack manifest (embed): %v", err)
 		return
 	}
+	log.Printf("Loaded webpack manifest from embed with %d entries", len(webpackManifest))
+}
 
-	log.Printf("Loaded webpack manifest with %d entries", len(webpackManifest))
+func loadWebpackManifest() {
+	if tryLoadWebpackManifestFromDisk(true) {
+		log.Printf("Loaded webpack manifest from disk (%s) with %d entries", webpackManifestDiskPath, len(webpackManifest))
+		return
+	}
+	loadWebpackManifestFromEmbed()
 }
 
 // Jet 렌더러 구조체
@@ -187,6 +222,7 @@ type SafeHTML string
 
 // resolveAssetPath - webpack manifest를 사용하여 실제 asset 경로 반환
 func resolveAssetPath(entryName string, extension string) string {
+	tryLoadWebpackManifestFromDisk(false)
 	// 확장자가 없으면 추가
 	if !strings.HasSuffix(entryName, extension) {
 		entryName = entryName + extension

--- a/front/assets/css/application.scss
+++ b/front/assets/css/application.scss
@@ -10,7 +10,9 @@
 // tabulator Custom CSS
 @import "./tabulator_for_tabler.scss";
 
-// jstree Custom CSS: application.js에서 jstree 테마 직후 require하여 로드 (우선순위 확보)
+// jsTree: 기본 테마 직후 프로젝트 오버라이드 (체크박스 스프라이트·행 높이 등, Tabler 다음)
+@import "~jstree/src/themes/default/style.css";
+@import "./jstree_for_tabler.scss";
 
 // tomselect Custom CSS
 @import "./tomselect_for_tabler.scss";

--- a/front/assets/css/jstree_for_tabler.scss
+++ b/front/assets/css/jstree_for_tabler.scss
@@ -9,54 +9,52 @@
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
   }
 
-  // jstree 기본 테마(.jstree-default)보다 우선 — 행 높이·여백 최소화 (24px → 18px)
-  // 한 줄 가로 배치: ocl 아이콘 + anchor가 세로로 쌓이지 않도록 flex row
-  // 직계 자식(ocl, anchor)이 여백으로 행 높이를 늘리지 않도록
+  // jsTree 기본: .jstree-node는 block — flex로 바꾸면 32px.png 세로/가지 선 배경이 깨짐
   .jstree-default .jstree-node,
   .jstree.jstree-default .jstree-node,
   .jstree-default > .jstree-container-ul .jstree-node,
   .jstree-node,
   li.jstree-node {
-    display: flex !important;
-    flex-direction: row !important;
-    flex-wrap: wrap !important;
-    align-items: center !important;
-    min-height: 18px !important;
+    display: block !important;
+    min-height: 24px !important;
     height: auto !important;
-    line-height: 18px !important;
+    line-height: 24px !important;
     margin-bottom: 0 !important;
     margin-top: 0 !important;
     padding: 0 !important;
     box-sizing: border-box !important;
+    white-space: nowrap;
   }
   .jstree-node > .jstree-ocl,
   .jstree-node > .jstree-anchor {
     margin: 0 !important;
-    flex: 0 0 auto !important;
+    vertical-align: top;
   }
   .jstree-node > .jstree-ocl {
-    display: inline-flex !important;
-    align-items: center !important;
-    justify-content: center !important;
+    display: inline-block !important;
   }
   .jstree-node > .jstree-anchor {
     padding: 0 8px !important;
     white-space: nowrap;
   }
 
+  // 체크박스(.jstree-checkbox)는 테마 스프라이트 24×24 기준 — anchor를 18px로 고정하면
+  // 잘리거나 보이지 않는 것처럼 보일 수 있음
   .jstree-default .jstree-anchor,
   .jstree-anchor {
     color: #333;
     padding: 0 8px !important;
-    line-height: 18px !important;
-    height: 18px !important;
-    min-height: 18px !important;
+    line-height: 24px !important;
+    min-height: 24px !important;
+    height: auto !important;
     border-radius: 4px;
-    display: flex !important;
+    display: inline-flex !important;
     align-items: center;
     gap: 6px;
     text-decoration: none;
     box-sizing: border-box !important;
+    overflow: visible !important;
+    vertical-align: top;
   }
 
   .jstree-anchor {
@@ -72,9 +70,9 @@
     }
   }
 
-  // 접기/펼치기 추가 시 삽입된 jstree-icon(ocl)이 행 높이를 늘리지 않도록 고정
-  .jstree-default .jstree-icon,
-  .jstree-icon {
+  // Tabler 커스텀 아이콘(폰트 등)용 — ocl·체크박스는 32px.png 24×24 그리드 유지 (트리 선·+/-)
+  .jstree-default .jstree-icon:not(.jstree-checkbox):not(.jstree-ocl),
+  .jstree-icon:not(.jstree-checkbox):not(.jstree-ocl) {
     width: 18px !important;
     height: 18px !important;
     min-width: 18px !important;
@@ -90,7 +88,7 @@
     background-color: transparent !important;
     box-sizing: border-box !important;
   }
-  .jstree-icon:empty {
+  .jstree-icon:empty:not(.jstree-checkbox):not(.jstree-ocl) {
     width: 18px !important;
     height: 18px !important;
     min-width: 18px !important;
@@ -100,23 +98,16 @@
     line-height: 0 !important;
   }
 
-  // 스프라이트 경로 깨짐 시 보이도록: ocl(펼침/접힘) 아이콘 — 행 높이 추가 금지
-  .jstree-ocl {
+  // 펼침/접힘: 테마 스프라이트 그대로 (오버라이드 제거)
+  .jstree-default .jstree-ocl {
+    width: 24px !important;
+    height: 24px !important;
+    min-width: 24px !important;
+    line-height: 24px !important;
     margin: 0 !important;
     padding: 0 !important;
-    background-color: rgba(0, 0, 0, 0.15) !important;
-    border-radius: 2px;
-  }
-  .jstree-open > .jstree-ocl {
-    background-image: none !important;
-    background-color: rgba(0, 0, 0, 0.2) !important;
-  }
-  .jstree-closed > .jstree-ocl {
-    background-image: none !important;
-    background-color: rgba(0, 0, 0, 0.2) !important;
-  }
-  .jstree-leaf > .jstree-ocl {
-    background-image: none !important;
+    flex-shrink: 0 !important;
+    background-image: url('~jstree/src/themes/default/32px.png') !important;
     background-color: transparent !important;
   }
   // themeicon(폴더 등)이 하얗게 보일 때 대비 — 배경을 더 진하게, 행 높이 추가 금지
@@ -132,19 +123,30 @@
     border-radius: 2px;
   }
   
-  // 체크박스 커스터마이징
-  .jstree-checkbox {
+  // 체크박스: jsTree default 테마 스프라이트(32px.png)의 background-position은
+  // .jstree-default .jstree-icon 기본 크기(24×24)에 맞춰져 있음.
+  // 위의 공통 .jstree-icon 18×18 강제 시 스프라이트가 잘려 체크/빈 칸이 구분 안 되는
+  // 작은 네모(또는 얼룩)로만 보이는 현상이 남 — 체크박스만 원래 그리드 크기 유지.
+  .jstree-checkbox.jstree-icon,
+  .jstree-icon.jstree-checkbox {
+    width: 24px !important;
+    height: 24px !important;
+    min-width: 24px !important;
+    max-height: 24px !important;
+    line-height: 24px !important;
     margin-right: 6px;
-    transform: scale(1.1);
+    flex-shrink: 0;
+    // style.css의 상대 url("32px.png")가 번들/배포 경로에서 깨질 때 대비
+    background-image: url('~jstree/src/themes/default/32px.png') !important;
+    background-repeat: no-repeat !important;
   }
   
-  // 하위 노드 들여쓰기 (세로 간격 없음) — 자식 트리는 항상 다음 줄에 배치
+  // 들여쓰기: 테마 margin-left(24px)와 겹치지 않게 과도한 추가 margin 피함
   .jstree-node > .jstree-children {
-    flex-basis: 100% !important;
-    width: 100% !important;
+    display: block;
   }
   .jstree-children {
-    margin-left: 12px;
+    margin-left: 0;
     margin-top: 0 !important;
     margin-bottom: 0 !important;
     padding: 0 !important;
@@ -153,15 +155,79 @@
   // 전체 행(wholerow) 높이 — 행 간격 축소
   .jstree-default .jstree-wholerow,
   .jstree-wholerow {
-    height: 18px !important;
+    min-height: 24px !important;
+    height: auto !important;
     border-radius: 4px;
   }
 
+  // max-width: 768px — jstree responsive 테마는 40px 스프라이트 사용
+  @media (max-width: 768px) {
+    .jstree-default-responsive .jstree-checkbox.jstree-icon,
+    .jstree-default-responsive .jstree-icon.jstree-checkbox {
+      width: 40px !important;
+      height: 40px !important;
+      min-width: 40px !important;
+      max-height: 40px !important;
+      line-height: 40px !important;
+      background-image: url('~jstree/src/themes/default/40px.png') !important;
+    }
+  }
+
+// li.jstree-node에 margin:0 !important를 주면 테마의 margin-left(깊이 들여쓰기·세로선)가 막혀 계층이 한 줄로 보임
 .jstree,
-.jstree ul,
-.jstree li,
-.jstree li.jstree-node {
+.jstree ul {
   list-style: none !important;
   margin: 0 !important;
   padding: 0 !important;
+}
+.jstree li:not(.jstree-node) {
+  list-style: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+.jstree li.jstree-node {
+  list-style: none !important;
+  padding: 0 !important;
+}
+
+// Roles — Platform access 트리: Tabler reboot `ul { padding-left: 2rem }`·UA 불릿이 남거나
+// `.jstree-no-checkboxes`로 체크박스가 숨겨진 경우에도 ID 특이도로 복구
+#platform-menu-edit-tree.jstree,
+#platform-menu-create-tree.jstree,
+#platform-menu-tree.jstree {
+  ul,
+  ol,
+  li {
+    list-style: none !important;
+    list-style-type: none !important;
+    list-style-image: none !important;
+  }
+
+  > ul.jstree-container-ul,
+  ul.jstree-children {
+    padding-left: 0 !important;
+  }
+
+  // 테마: .jstree-default .jstree-no-checkboxes .jstree-checkbox { display: none !important; }
+  .jstree-checkbox.jstree-icon {
+    display: inline-flex !important;
+    visibility: visible !important;
+    box-sizing: border-box !important;
+    min-width: 24px !important;
+    min-height: 24px !important;
+    border: 1px solid rgba(0, 84, 166, 0.22);
+    border-radius: 2px;
+    background-image: url('~jstree/src/themes/default/32px.png') !important;
+    background-repeat: no-repeat !important;
+  }
+}
+
+@media (max-width: 768px) {
+  #platform-menu-edit-tree.jstree.jstree-default-responsive .jstree-checkbox.jstree-icon,
+  #platform-menu-create-tree.jstree.jstree-default-responsive .jstree-checkbox.jstree-icon,
+  #platform-menu-tree.jstree.jstree-default-responsive .jstree-checkbox.jstree-icon {
+    min-width: 40px !important;
+    min-height: 40px !important;
+    background-image: url('~jstree/src/themes/default/40px.png') !important;
+  }
 }

--- a/front/assets/js/application.js
+++ b/front/assets/js/application.js
@@ -3,7 +3,3 @@ const bootstrap = require("bootstrap/dist/js/bootstrap.bundle.js");
 window.bootstrap = bootstrap;
 require("@fortawesome/fontawesome-free/js/all.js");
 require("jquery-ujs/src/rails.js");
-require("~jquery/dist/jquery.js");
-require("jstree/disk/themes/default/style.css");
-// jstree 오버라이드: 테마 직후 로드해 flex/행높이 등 우리 스타일이 적용되도록 함
-require("../css/jstree_for_tabler.scss");

--- a/front/assets/js/pages/operation/workspace/roles.js
+++ b/front/assets/js/pages/operation/workspace/roles.js
@@ -1573,6 +1573,7 @@ async function initPlatformMenuTree() {
         },
         "plugins": ["types", "checkbox"],
         "checkbox": {
+          "visible": true,
           "keep_selected_style": true,
           "three_state": false
         },
@@ -1585,8 +1586,12 @@ async function initPlatformMenuTree() {
 
       // View 모드 체크박스를 readonly로 만들기 위한 CSS 적용
       $("#platform-menu-tree").on("ready.jstree", function () {
+        const inst = $('#platform-menu-tree').jstree(true);
+        if (inst && inst.show_checkboxes) {
+          inst.show_checkboxes();
+        }
         // 모든 노드를 펼쳐놓기
-        $('#platform-menu-tree').jstree(true).open_all();
+        inst.open_all();
 
         // 체크박스를 readonly로 만들기
         $("#platform-menu-tree .jstree-checkbox").css({
@@ -1649,6 +1654,7 @@ async function initPlatformMenuCreateTree() {
         },
         "plugins": ["types", "checkbox"],
         "checkbox": {
+          "visible": true,
           "keep_selected_style": true,
           "three_state": true,
           "cascade": "up"
@@ -1661,11 +1667,15 @@ async function initPlatformMenuCreateTree() {
       });
       // 트리 초기화 완료 후 이벤트 바인딩
       $("#platform-menu-create-tree").on("ready.jstree", function () {
+        const inst = $('#platform-menu-create-tree').jstree(true);
+        if (inst && inst.show_checkboxes) {
+          inst.show_checkboxes();
+        }
         // 모든 노드를 펼쳐놓기
-        $('#platform-menu-create-tree').jstree(true).open_all();
+        inst.open_all();
 
-        // 펼치기/접기 아이콘 숨기기
-        $('#platform-menu-create-tree .jstree-ocl').hide();
+        // ocl을 display:none/visibility:hidden 하면 32px.png 가로/접점 스프라이트가 사라져 트리 선이 깨짐
+        // 펼침 막기는 아래 click.jstree 핸들러로만 처리
 
         // 노드 클릭 시 펼치기/접기 방지
         $('#platform-menu-create-tree').on('click.jstree', function (e, data) {
@@ -1718,6 +1728,7 @@ async function initPlatformMenuEditTree() {
         },
         "plugins": ["types", "checkbox"],
         "checkbox": {
+          "visible": true,
           "keep_selected_style": true,
           "three_state": true,
           "cascade": "up"
@@ -1731,11 +1742,12 @@ async function initPlatformMenuEditTree() {
 
       // 트리 초기화 완료 후 이벤트 바인딩
       $("#platform-menu-edit-tree").on("ready.jstree", function () {
+        const inst = $('#platform-menu-edit-tree').jstree(true);
+        if (inst && inst.show_checkboxes) {
+          inst.show_checkboxes();
+        }
         // 모든 노드를 펼쳐놓기
-        $('#platform-menu-edit-tree').jstree(true).open_all();
-
-        // 펼치기/접기 아이콘 숨기기
-        $('#platform-menu-edit-tree .jstree-ocl').hide();
+        inst.open_all();
 
         // 노드 클릭 시 펼치기/접기 방지
         $('#platform-menu-edit-tree').on('click.jstree', function (e, data) {


### PR DESCRIPTION
## Summary

- jsTree 체크박스(32px.png 스프라이트) 잘림 현상 수정 — flex/18px 강제가 원인이었으며, `block` 레이아웃 + 24px 그리드로 복구
- `ocl.hide()` 호출 제거 — 숨기면 32px.png 가지 선/펼침 스프라이트까지 사라지는 문제 수정
- `checkbox.visible: true` + `show_checkboxes()` 명시 호출로 세 플랫폼 트리(view/create/edit) 체크박스 강제 표시
- jsTree CSS 로딩을 JS 번들에서 SCSS 파이프라인(`application.scss`)으로 이동
- webpack manifest 핫리로드 구현 — 디스크 파일을 mtime 기준으로 캐싱, go 재시작 없이 webpack 재빌드 반영

## Test plan

- [ ] Platform 메뉴 트리(view/create/edit) 체크박스가 정상 표시되는지 확인
- [ ] 트리 가지 선 및 펼침/접힘 아이콘이 정상 렌더링되는지 확인
- [ ] 체크박스 선택/해제 동작이 정상인지 확인
- [ ] webpack 재빌드 후 go 재시작 없이 asset 해시가 반영되는지 확인