### PR TITLE
feat(dashboard): 커스터마이징 모니터링 대시보드 위젯 시스템 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ node_modules
 # git worktrees
 .worktrees/
 front/test-results/
+.claude/

--- a/front/assets/js/common/dashboard/dashboard_storage.js
+++ b/front/assets/js/common/dashboard/dashboard_storage.js
@@ -1,0 +1,49 @@
+/**
+ * dashboard_storage.js — 사용자별 대시보드 레이아웃 저장/로드
+ */
+
+var STORAGE_PREFIX = 'dashboard_layout_';
+var LAYOUT_VERSION = 1;
+
+var DEFAULT_LAYOUT = {
+  version: LAYOUT_VERSION,
+  widgets: [
+    { id: 'default-cpu', type: 'WIDGET-CPU', x: 0, y: 0, w: 6, h: 3,
+      config: { nsId: '', mciId: '', vmId: '', measurement: 'cpu', metric: 'usage_idle', range: '1h', refreshInterval: '30s' } },
+    { id: 'default-mem', type: 'WIDGET-MEM', x: 6, y: 0, w: 6, h: 3,
+      config: { nsId: '', mciId: '', vmId: '', measurement: 'mem', metric: 'used_percent', range: '1h', refreshInterval: '30s' } },
+    { id: 'default-net', type: 'WIDGET-NET', x: 0, y: 3, w: 12, h: 3,
+      config: { nsId: '', mciId: '', vmId: '', measurement: 'net', metric: 'bytes_sent', range: '1h', refreshInterval: '30s' } },
+  ],
+};
+
+export function getUserId() {
+  try {
+    var userInfo = webconsolejs['common/cookie/authcookie'].getUserInfo();
+    return userInfo && userInfo.userId ? userInfo.userId : 'anonymous';
+  } catch (e) { return 'anonymous'; }
+}
+
+function getStorageKey() { return STORAGE_PREFIX + getUserId(); }
+
+export function saveLayout(widgetDataList) {
+  try {
+    var layoutData = { version: LAYOUT_VERSION, updatedAt: new Date().toISOString(), widgets: widgetDataList };
+    localStorage.setItem(getStorageKey(), JSON.stringify(layoutData));
+    return true;
+  } catch (error) { console.error('Dashboard layout save error:', error); return false; }
+}
+
+export function loadLayout() {
+  try {
+    var raw = localStorage.getItem(getStorageKey());
+    if (!raw) return getDefaultLayout();
+    var data = JSON.parse(raw);
+    if (!data || !data.widgets || !Array.isArray(data.widgets)) { localStorage.removeItem(getStorageKey()); return getDefaultLayout(); }
+    return data;
+  } catch (error) { console.error('Dashboard layout load error:', error); localStorage.removeItem(getStorageKey()); return getDefaultLayout(); }
+}
+
+export function clearLayout() { localStorage.removeItem(getStorageKey()); }
+export function getDefaultLayout() { return JSON.parse(JSON.stringify(DEFAULT_LAYOUT)); }
+export function generateWidgetId() { return 'widget-' + Date.now() + '-' + Math.random().toString(36).substr(2, 6); }

--- a/front/assets/js/common/dashboard/widget_catalog.js
+++ b/front/assets/js/common/dashboard/widget_catalog.js
@@ -1,0 +1,121 @@
+/**
+ * widget_catalog.js — 모니터링 대시보드 위젯 카탈로그 정의
+ * FR-DASHBOARD-001-01: 위젯 카탈로그 조회
+ */
+
+export const WIDGET_CATEGORIES = [
+  { id: 'compute', name: 'Compute', icon: 'ti-cpu' },
+  { id: 'storage', name: 'Storage', icon: 'ti-database' },
+  { id: 'network', name: 'Network', icon: 'ti-network' },
+  { id: 'etc', name: 'Etc', icon: 'ti-dots' },
+];
+
+export const WIDGET_CATALOG = [
+  {
+    id: 'WIDGET-CPU',
+    name: 'CPU Usage',
+    category: 'compute',
+    measurement: 'cpu',
+    defaultMetric: 'usage_idle',
+    icon: 'ti-cpu',
+    description: 'VM CPU usage time-series chart',
+    minW: 4, minH: 3, defaultW: 6, defaultH: 3,
+    color: '#206bc4',
+  },
+  {
+    id: 'WIDGET-MEM',
+    name: 'Memory Usage',
+    category: 'compute',
+    measurement: 'mem',
+    defaultMetric: 'used_percent',
+    icon: 'ti-database',
+    description: 'VM memory usage time-series chart',
+    minW: 4, minH: 3, defaultW: 6, defaultH: 3,
+    color: '#2fb344',
+  },
+  {
+    id: 'WIDGET-DISK',
+    name: 'Disk Usage',
+    category: 'storage',
+    measurement: 'disk',
+    defaultMetric: 'used_percent',
+    icon: 'ti-device-floppy',
+    description: 'Disk usage time-series chart',
+    minW: 4, minH: 3, defaultW: 6, defaultH: 3,
+    color: '#f76707',
+  },
+  {
+    id: 'WIDGET-DISKIO',
+    name: 'Disk I/O',
+    category: 'storage',
+    measurement: 'diskio',
+    defaultMetric: 'read_bytes',
+    icon: 'ti-arrows-transfer-down',
+    description: 'Disk read/write bytes chart',
+    minW: 4, minH: 3, defaultW: 6, defaultH: 3,
+    color: '#d63939',
+  },
+  {
+    id: 'WIDGET-NET',
+    name: 'Network Traffic',
+    category: 'network',
+    measurement: 'net',
+    defaultMetric: 'bytes_sent',
+    icon: 'ti-network',
+    description: 'Network send/receive traffic chart',
+    minW: 4, minH: 3, defaultW: 12, defaultH: 3,
+    color: '#ae3ec9',
+  },
+  {
+    id: 'WIDGET-SYSLOG',
+    name: 'System Log',
+    category: 'compute',
+    measurement: 'log',
+    defaultMetric: 'syslog',
+    icon: 'ti-file-text',
+    description: 'VM system log viewer',
+    minW: 4, minH: 3, defaultW: 6, defaultH: 3,
+    color: '#0ca678',
+  },
+  {
+    id: 'WIDGET-EVENTALARM',
+    name: 'Event Alarm',
+    category: 'etc',
+    measurement: 'event',
+    defaultMetric: 'alarm',
+    icon: 'ti-bell',
+    description: 'Event alarm history and notifications',
+    minW: 4, minH: 3, defaultW: 6, defaultH: 3,
+    color: '#e8590c',
+  },
+];
+
+export const MAX_WIDGETS = 12;
+
+export const TIME_RANGES = [
+  { value: '1h', label: '1시간' },
+  { value: '6h', label: '6시간' },
+  { value: '24h', label: '24시간' },
+  { value: '7d', label: '7일' },
+];
+
+export const REFRESH_INTERVALS = [
+  { value: '10s', label: '10초', ms: 10000 },
+  { value: '30s', label: '30초', ms: 30000 },
+  { value: '1m', label: '1분', ms: 60000 },
+  { value: '5m', label: '5분', ms: 300000 },
+  { value: 'off', label: '끄기', ms: 0 },
+];
+
+export function getWidgetDef(typeId) {
+  return WIDGET_CATALOG.find(w => w.id === typeId);
+}
+
+export function getWidgetsByCategory(categoryId) {
+  return WIDGET_CATALOG.filter(w => w.category === categoryId);
+}
+
+export function parseRefreshInterval(interval) {
+  var def = REFRESH_INTERVALS.find(r => r.value === interval);
+  return def ? def.ms : 0;
+}

--- a/front/assets/js/common/dashboard/widget_renderer.js
+++ b/front/assets/js/common/dashboard/widget_renderer.js
@@ -1,0 +1,126 @@
+/**
+ * widget_renderer.js — ApexCharts 기반 위젯 렌더링
+ */
+
+import ApexCharts from "apexcharts";
+import { parseRefreshInterval } from "./widget_catalog";
+
+var chartInstances = {};
+var refreshTimers = {};
+
+export function createWidgetChart(widgetId, containerId, config) {
+  var el = document.querySelector('#' + containerId);
+  if (!el) return null;
+
+  // 컨테이너의 실제 높이를 픽셀로 계산 (부모 grid-stack-item 기준)
+  var gridItem = el.closest('.grid-stack-item');
+  var cardHeader = gridItem ? gridItem.querySelector('.card-header') : null;
+  var itemHeight = gridItem ? gridItem.offsetHeight : 240;
+  var headerHeight = cardHeader ? cardHeader.offsetHeight : 40;
+  var chartHeight = Math.max(itemHeight - headerHeight - 16, 100); // 16px = padding
+
+  var options = {
+    chart: {
+      type: 'area',
+      height: chartHeight,
+      toolbar: { show: true, tools: { download: true, zoom: true, zoomin: true, zoomout: true, pan: false, reset: true } },
+      animations: { enabled: false },
+      parentHeightOffset: 0,
+    },
+    series: [],
+    xaxis: { type: 'datetime', labels: { format: 'HH:mm:ss' } },
+    yaxis: { labels: { formatter: function (val) { return val !== null && val !== undefined ? val.toFixed(2) : ''; } } },
+    stroke: { curve: 'smooth', width: 2 },
+    fill: { type: 'gradient', gradient: { opacityFrom: 0.4, opacityTo: 0.05 } },
+    colors: [config.color || '#206bc4'],
+    tooltip: { theme: 'dark', x: { format: 'yyyy-MM-dd HH:mm:ss' } },
+    grid: { strokeDashArray: 4, padding: { top: 0, right: 10, bottom: 0, left: 10 } },
+    noData: { text: '데이터 로딩 중...', align: 'center', verticalAlign: 'middle',
+      style: { fontSize: '14px', color: '#888' } },
+  };
+
+  var chart = new ApexCharts(el, options);
+  chart.render();
+  chartInstances[widgetId] = chart;
+  return chart;
+}
+
+export async function loadWidgetData(widgetId, config) {
+  var chart = chartInstances[widgetId];
+  if (!chart) return;
+
+  try {
+    var data = {
+      pathParams: { nsId: config.nsId, mciId: config.mciId, vmId: config.vmId },
+      Request: {
+        measurement: config.measurement,
+        range: config.range || '1h',
+        group_time: '1m',
+        group_by: ['vm_id'],
+        limit: 20,
+        fields: [{ function: 'mean', field: config.metric }],
+        conditions: [],
+      },
+    };
+
+    var controller = '/api/mc-observability/GetMetricsByVMId';
+    var response = await webconsolejs['common/api/http'].commonAPIPost(controller, data);
+
+    if (response && response.data && response.data.responseData) {
+      var seriesData = transformMetricData(response.data.responseData, config.metric);
+      chart.updateSeries(seriesData);
+    } else {
+      chart.updateOptions({ noData: { text: '데이터 없음' } });
+    }
+  } catch (error) {
+    console.error('Widget data load error:', widgetId, error);
+    chart.updateOptions({ noData: { text: '데이터 조회 실패' } });
+  }
+}
+
+function transformMetricData(responseData, metricField) {
+  if (!responseData || !responseData.data) return [];
+  var dataMap = {};
+  if (Array.isArray(responseData.data)) {
+    responseData.data.forEach(function (item) {
+      var vmId = item.vm_id || 'default';
+      if (!dataMap[vmId]) dataMap[vmId] = [];
+      dataMap[vmId].push({ x: new Date(item.time).getTime(), y: item[metricField] !== undefined ? item[metricField] : null });
+    });
+  }
+  var series = [];
+  Object.keys(dataMap).forEach(function (vmId) { series.push({ name: vmId, data: dataMap[vmId] }); });
+  return series.length > 0 ? series : [{ name: metricField, data: [] }];
+}
+
+export function setupAutoRefresh(widgetId, config, intervalValue) {
+  clearAutoRefresh(widgetId);
+  var ms = parseRefreshInterval(intervalValue);
+  if (ms > 0) {
+    refreshTimers[widgetId] = setInterval(function () { loadWidgetData(widgetId, config); }, ms);
+  }
+}
+
+export function clearAutoRefresh(widgetId) {
+  if (refreshTimers[widgetId]) { clearInterval(refreshTimers[widgetId]); delete refreshTimers[widgetId]; }
+}
+
+export function destroyWidget(widgetId) {
+  clearAutoRefresh(widgetId);
+  if (chartInstances[widgetId]) { chartInstances[widgetId].destroy(); delete chartInstances[widgetId]; }
+}
+
+export function resizeChart(widgetId) {
+  var chart = chartInstances[widgetId];
+  if (!chart) return;
+  // 리사이즈 후 새로운 높이 계산
+  var chartEl = chart.el;
+  if (chartEl) {
+    var gridItem = chartEl.closest('.grid-stack-item');
+    var cardHeader = gridItem ? gridItem.querySelector('.card-header') : null;
+    var itemHeight = gridItem ? gridItem.offsetHeight : 240;
+    var headerHeight = cardHeader ? cardHeader.offsetHeight : 40;
+    var newHeight = Math.max(itemHeight - headerHeight - 16, 100);
+    chart.updateOptions({ chart: { height: newHeight } }, false, false);
+  }
+}

--- a/front/assets/js/pages/operation/analytics/dashboard.js
+++ b/front/assets/js/pages/operation/analytics/dashboard.js
@@ -1,0 +1,294 @@
+/**
+ * dashboard.js — 커스터마이징 모니터링 대시보드 메인 로직
+ */
+
+import { GridStack } from 'gridstack';
+import { WIDGET_CATALOG, MAX_WIDGETS, TIME_RANGES, REFRESH_INTERVALS, getWidgetDef, getWidgetsByCategory } from '../../../common/dashboard/widget_catalog';
+import { createWidgetChart, loadWidgetData, setupAutoRefresh, destroyWidget, resizeChart } from '../../../common/dashboard/widget_renderer';
+import { saveLayout, loadLayout, clearLayout, getDefaultLayout, generateWidgetId } from '../../../common/dashboard/dashboard_storage';
+
+var grid = null;
+var widgetConfigs = {};
+var saveDebounceTimer = null;
+var currentWorkspaceProject = null;
+
+document.addEventListener('DOMContentLoaded', initDashboard);
+
+async function initDashboard() {
+  try {
+    currentWorkspaceProject = await webconsolejs['partials/layout/navbar'].workspaceProjectInit();
+  } catch (e) { console.warn('Workspace init skipped:', e); }
+  initGrid();
+  bindEvents();
+  restoreLayout();
+}
+
+function initGrid() {
+  grid = GridStack.init({
+    column: 12, cellHeight: 80, minRow: 1, margin: 8, float: false, animate: true,
+    resizable: { handles: 'se' },
+    disableOneColumnMode: false,
+  }, '#dashboard-grid');
+  grid.on('change', function () { debounceSave(); });
+  grid.on('resizestop', function (event, el) {
+    var wid = el.getAttribute('data-widget-id');
+    if (wid) setTimeout(function () { resizeChart(wid); }, 100);
+  });
+}
+
+function bindEvents() {
+  $('#btn-add-widget, #btn-add-widget-empty').on('click', openCatalogModal);
+  $('#btn-save-layout').on('click', manualSave);
+  $('#btn-reset-layout').on('click', resetLayout);
+  $('#catalog-category-tabs .nav-link').on('click', function (e) {
+    e.preventDefault();
+    filterCatalog($(this).data('category'));
+  });
+}
+
+// === FR-DASHBOARD-001-01: 위젯 카탈로그 ===
+export function openCatalogModal() {
+  if (Object.keys(widgetConfigs).length >= MAX_WIDGETS) { showToast('warning', 'Maximum ' + MAX_WIDGETS + ' widgets allowed.'); return; }
+  renderCatalog('all');
+  var modal = new bootstrap.Modal(document.getElementById('widgetCatalogModal'));
+  modal.show();
+}
+
+function renderCatalog(categoryFilter) {
+  var $container = $('#catalog-widget-list').empty();
+  var widgets = categoryFilter === 'all' ? WIDGET_CATALOG : getWidgetsByCategory(categoryFilter);
+  widgets.forEach(function (w) {
+    var $card = $('<div class="col-md-4 mb-3"><div class="card card-sm cursor-pointer catalog-widget-card" data-widget-type="' + w.id + '">' +
+      '<div class="card-body text-center"><i class="' + w.icon + '" style="font-size:2rem;color:' + w.color + '"></i>' +
+      '<h4 class="mt-2 mb-1">' + w.name + '</h4><p class="text-muted small mb-0">' + w.description + '</p></div></div></div>');
+    $card.find('.catalog-widget-card').on('click', function () {
+      bootstrap.Modal.getInstance(document.getElementById('widgetCatalogModal')).hide();
+      openResourceSelector(w.id);
+    });
+    $container.append($card);
+  });
+}
+
+function filterCatalog(category) {
+  $('#catalog-category-tabs .nav-link').removeClass('active');
+  $('#catalog-category-tabs .nav-link[data-category="' + category + '"]').addClass('active');
+  renderCatalog(category);
+}
+
+// === FR-DASHBOARD-001-02: 위젯 추가 ===
+function openResourceSelector(widgetTypeId) {
+  $('#resource-widget-type').val(widgetTypeId);
+  loadNamespaceList();
+  var modal = new bootstrap.Modal(document.getElementById('resourceSelectorModal'));
+  modal.show();
+}
+
+async function loadNamespaceList() {
+  var $sel = $('#resource-ns-select').empty().append('<option value="">Select</option>');
+
+  // 항상 최신 세션값에서 nsId 읽기
+  var nsId = '';
+  try {
+    // 1순위: sessionStorage의 currentProject.NsId (navbar에서 프로젝트 선택 시 저장됨)
+    var curProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
+    if (curProject && curProject.NsId) {
+      nsId = curProject.NsId;
+    }
+    // 2순위: navbar select box에서 직접 읽기
+    if (!nsId) {
+      var prjSelect = document.getElementById('select-current-project');
+      if (prjSelect && prjSelect.selectedIndex > 0) {
+        nsId = prjSelect.options[prjSelect.selectedIndex].text;
+      }
+    }
+  } catch (e) { console.warn('getCurrentProject error:', e); }
+
+  if (!nsId) {
+    showToast('warning', 'Please select a workspace/project from the navbar first.');
+    return;
+  }
+
+  $sel.append('<option value="' + nsId + '" selected>' + nsId + '</option>');
+  await loadMciList(nsId);
+}
+
+async function loadMciList(nsId) {
+  var $mciSel = $('#resource-mci-select').empty().append('<option value="">Select</option>');
+  $('#resource-vm-select').empty().append('<option value="">Select</option>');
+  if (!nsId) return;
+  try {
+    var result = await webconsolejs['common/api/services/mci_api'].getMciList(nsId);
+    // getMciList returns responseData which is { mci: [...] } or array
+    var mciList = Array.isArray(result) ? result : (result && result.mci ? result.mci : []);
+    mciList.forEach(function (mci) {
+      var id = mci.id || mci.mciId || mci.name;
+      $mciSel.append('<option value="' + id + '">' + (mci.name || id) + '</option>');
+    });
+  } catch (e) { console.error('MCI list error:', e); }
+}
+
+$(document).on('change', '#resource-ns-select', async function () {
+  await loadMciList($(this).val());
+});
+
+$(document).on('change', '#resource-mci-select', async function () {
+  var nsId = $('#resource-ns-select').val(), mciId = $(this).val();
+  var $vmSel = $('#resource-vm-select').empty().append('<option value="">선택</option>');
+  if (!nsId || !mciId) return;
+  try {
+    var mciData = await webconsolejs['common/api/services/mci_api'].getMci(nsId, mciId);
+    if (mciData && mciData.responseData && mciData.responseData.vm) {
+      mciData.responseData.vm.forEach(function (vm) {
+        var id = vm.id || vm.vmId;
+        $vmSel.append('<option value="' + id + '">' + (vm.name || id) + '</option>');
+      });
+    }
+  } catch (e) { console.error('VM list error:', e); }
+});
+
+export function confirmAddWidget() {
+  var widgetTypeId = $('#resource-widget-type').val();
+  var nsId = $('#resource-ns-select').val(), mciId = $('#resource-mci-select').val(), vmId = $('#resource-vm-select').val();
+  if (!nsId || !mciId || !vmId) { showToast('warning', 'Please select a target resource.'); return; }
+  bootstrap.Modal.getInstance(document.getElementById('resourceSelectorModal')).hide();
+  var widgetDef = getWidgetDef(widgetTypeId);
+  addWidgetToGrid(generateWidgetId(), widgetDef, {
+    type: widgetTypeId, nsId: nsId, mciId: mciId, vmId: vmId,
+    measurement: widgetDef.measurement, metric: widgetDef.defaultMetric,
+    range: '1h', refreshInterval: '30s', color: widgetDef.color,
+  });
+}
+
+function addWidgetToGrid(widgetId, widgetDef, config) {
+  var chartId = 'chart-' + widgetId;
+
+  var widgetHtml =
+    '<div class="grid-stack-item" data-widget-id="' + widgetId + '">' +
+    '<div class="grid-stack-item-content">' +
+    '<div class="card h-100">' +
+    '<div class="card-header" style="cursor:move;padding:0.5rem 0.75rem;">' +
+    '<h3 class="card-title" style="font-size:0.85rem;"><i class="' + widgetDef.icon + '" style="color:' + widgetDef.color + '"></i> ' +
+    widgetDef.name + '<small class="text-muted ms-2">' + (config.vmId || '') + '</small></h3>' +
+    '<div class="card-actions">' +
+    '<button class="btn btn-ghost-secondary btn-icon btn-sm widget-config-btn" data-widget-id="' + widgetId + '" title="설정"><i class="ti ti-settings"></i></button>' +
+    '<button class="btn btn-ghost-danger btn-icon btn-sm widget-remove-btn" data-widget-id="' + widgetId + '" title="삭제"><i class="ti ti-x"></i></button>' +
+    '</div></div>' +
+    '<div class="card-body p-2" style="min-height:0;overflow:hidden;"><div id="' + chartId + '" style="width:100%;height:100%;"></div></div>' +
+    '</div></div></div>';
+
+  var el = grid.addWidget(widgetHtml, {
+    w: widgetDef.defaultW, h: widgetDef.defaultH,
+    minW: widgetDef.minW, minH: widgetDef.minH, maxW: 12, maxH: 6,
+    id: widgetId,
+  });
+
+  widgetConfigs[widgetId] = config;
+
+  setTimeout(function () {
+    createWidgetChart(widgetId, chartId, config);
+    loadWidgetData(widgetId, config);
+    setupAutoRefresh(widgetId, config, config.refreshInterval);
+  }, 200);
+
+  $(el).find('.widget-remove-btn').on('click', function () { confirmRemoveWidget($(this).data('widget-id')); });
+  $(el).find('.widget-config-btn').on('click', function () { openWidgetConfig($(this).data('widget-id')); });
+  updateEmptyState();
+  debounceSave();
+}
+
+// === FR-DASHBOARD-001-03: 위젯 제거 ===
+function confirmRemoveWidget(widgetId) {
+  $('#remove-widget-id').val(widgetId);
+  var modal = new bootstrap.Modal(document.getElementById('confirmRemoveModal'));
+  modal.show();
+}
+
+export function executeRemoveWidget() {
+  var widgetId = $('#remove-widget-id').val();
+  bootstrap.Modal.getInstance(document.getElementById('confirmRemoveModal')).hide();
+  destroyWidget(widgetId);
+  delete widgetConfigs[widgetId];
+  var el = document.querySelector('.grid-stack-item[data-widget-id="' + widgetId + '"]');
+  if (el) grid.removeWidget(el);
+  updateEmptyState();
+  debounceSave();
+}
+
+// === FR-DASHBOARD-001-04: 위젯 설정 ===
+function openWidgetConfig(widgetId) {
+  var config = widgetConfigs[widgetId];
+  if (!config) return;
+  $('#config-widget-id').val(widgetId);
+  var $range = $('#config-range-select').empty();
+  TIME_RANGES.forEach(function (r) { $range.append('<option value="' + r.value + '">' + r.label + '</option>'); });
+  $range.val(config.range);
+  var $refresh = $('#config-refresh-select').empty();
+  REFRESH_INTERVALS.forEach(function (r) { $refresh.append('<option value="' + r.value + '">' + r.label + '</option>'); });
+  $refresh.val(config.refreshInterval);
+  var modal = new bootstrap.Modal(document.getElementById('widgetConfigModal'));
+  modal.show();
+}
+
+export function applyWidgetConfig() {
+  var widgetId = $('#config-widget-id').val(), config = widgetConfigs[widgetId];
+  if (!config) return;
+  config.range = $('#config-range-select').val();
+  config.refreshInterval = $('#config-refresh-select').val();
+  bootstrap.Modal.getInstance(document.getElementById('widgetConfigModal')).hide();
+  loadWidgetData(widgetId, config);
+  setupAutoRefresh(widgetId, config, config.refreshInterval);
+  debounceSave();
+  showToast('success', 'Settings applied.');
+}
+
+// === FR-DASHBOARD-002-03: 저장 ===
+function debounceSave() { if (saveDebounceTimer) clearTimeout(saveDebounceTimer); saveDebounceTimer = setTimeout(executeSave, 3000); }
+function manualSave() { if (saveDebounceTimer) clearTimeout(saveDebounceTimer); executeSave(); showToast('success', 'Dashboard saved.'); }
+function executeSave() {
+  var items = grid.getGridItems();
+  var list = items.map(function (el) {
+    var node = el.gridstackNode, wid = el.getAttribute('data-widget-id'), cfg = widgetConfigs[wid] || {};
+    return { id: wid, type: cfg.type, x: node.x, y: node.y, w: node.w, h: node.h,
+      config: { nsId: cfg.nsId, mciId: cfg.mciId, vmId: cfg.vmId, measurement: cfg.measurement, metric: cfg.metric, range: cfg.range, refreshInterval: cfg.refreshInterval } };
+  });
+  saveLayout(list);
+}
+
+// === FR-DASHBOARD-002-04: 로드 ===
+function restoreLayout() {
+  var layoutData = loadLayout();
+  if (!layoutData || !layoutData.widgets || layoutData.widgets.length === 0) { updateEmptyState(); return; }
+  layoutData.widgets.forEach(function (w) {
+    var def = getWidgetDef(w.type);
+    if (!def) return;
+    addWidgetToGrid(w.id || generateWidgetId(), def, Object.assign({}, w.config || {}, { type: w.type, color: def.color }));
+  });
+  updateEmptyState();
+}
+
+function resetLayout() {
+  if (!confirm('Reset dashboard to default layout?')) return;
+  Object.keys(widgetConfigs).forEach(function (wid) { destroyWidget(wid); });
+  grid.removeAll(); widgetConfigs = {}; clearLayout();
+  getDefaultLayout().widgets.forEach(function (w) {
+    var def = getWidgetDef(w.type);
+    if (def) addWidgetToGrid(w.id, def, Object.assign({}, w.config, { type: w.type, color: def.color }));
+  });
+  updateEmptyState();
+  showToast('success', 'Dashboard reset to default layout.');
+}
+
+function updateEmptyState() {
+  if (Object.keys(widgetConfigs).length === 0) { $('#dashboard-grid').addClass('d-none'); $('#empty-dashboard').removeClass('d-none'); }
+  else { $('#dashboard-grid').removeClass('d-none'); $('#empty-dashboard').addClass('d-none'); }
+}
+
+function showToast(type, message) {
+  var bg = type === 'success' ? 'bg-success' : type === 'warning' ? 'bg-warning' : 'bg-danger';
+  var $t = $('<div class="toast show position-fixed bottom-0 end-0 m-3" role="alert" style="z-index:9999;">' +
+    '<div class="toast-header ' + bg + ' text-white"><strong class="me-auto">대시보드</strong>' +
+    '<button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast"></button></div>' +
+    '<div class="toast-body">' + message + '</div></div>');
+  $('body').append($t);
+  setTimeout(function () { $t.remove(); }, 3000);
+}

--- a/front/assets/js/pages/operation/analytics/monitoringconfig.js
+++ b/front/assets/js/pages/operation/analytics/monitoringconfig.js
@@ -293,23 +293,21 @@ function initMonitorConfigTable() {
 
   // 행 클릭 시
   monitorConfigListTable.on("rowClick", function (e, row) {
-    selectedServerNode = row.getData(); 
-    //var workloadType = row.getCell("workloadType").getValue();    
-    var tempServernodeId = currentServernodeId;    
-    currentServernodeId = row.getCell("id").getValue();
-    // console.log("row ", row.getData())
-    // console.log("currentServernodeId ", currentServernodeId)
+    selectedServerNode = row.getData();
+    var clickedId = row.getCell("id").getValue();
 
-    // 상세 정보 표시 여부
-    if (tempServernodeId === currentServernodeId) {
+    // 같은 행 재클릭 → 토글 OFF
+    if (currentServernodeId === clickedId) {
       webconsolejs["partials/layout/navigatePages"].deactiveElement(document.getElementById("monitoring_configuration"))
       this.deselectRow();
+      currentServernodeId = "-1"; // 리셋하여 다음 클릭 시 토글 ON 가능
       return
     } else {
+      // 다른 행 클릭 → 토글 ON
+      currentServernodeId = clickedId;
       webconsolejs["partials/layout/navigatePages"].activeElement(document.getElementById("monitoring_configuration"))
       this.deselectRow();
       this.selectRow(currentServernodeId);
-      // 표에서 선택된 Servernode
       getSelectedMonitorConfigData(currentServernodeId)
       return
     }
@@ -566,7 +564,7 @@ async function setMonitorConfigInfoData() {
         $(this).prop('checked', false);
       }
       // 토글 OFF 시: 에이전트가 활성화된 경우 비활성화 확인 (선택사항)
-      else if (!isChecked && currentAgentStatus === "ACTIVE") {
+      else if (!isChecked && currentMonitoringAgentStatus === "SUCCESS") {
         // 필요시 에이전트 비활성화 로직 추가 가능
       }
     });

--- a/front/package.json
+++ b/front/package.json
@@ -22,6 +22,7 @@
     "countup.js": "^2.8.0",
     "dropzone": "^6.0.0-beta.2",
     "fslightbox": "^3.4.1",
+    "gridstack": "^7.3.0",
     "jquery": "^3.6.0",
     "jquery-ujs": "^1.2.2",
     "jstree": "^3.3.17",

--- a/front/templates/pages/operations/analytics/monitorings/dashboard.html
+++ b/front/templates/pages/operations/analytics/monitorings/dashboard.html
@@ -1,0 +1,124 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@7.3.0/dist/gridstack.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridstack@7.3.0/dist/gridstack-extra.min.css" />
+<style>
+  .grid-stack-item-content {
+    display: flex; flex-direction: column; overflow: hidden;
+  }
+  .grid-stack-item-content > .card {
+    display: flex; flex-direction: column; flex: 1; min-height: 0; overflow: hidden;
+  }
+  .grid-stack-item-content > .card > .card-header {
+    flex-shrink: 0;
+  }
+  .grid-stack-item-content > .card > .card-body {
+    flex: 1; min-height: 0; overflow: hidden; position: relative;
+    padding: 4px !important;
+  }
+  .grid-stack-item-content > .card > .card-body > div {
+    position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+  }
+  /* ApexCharts 내부 여백 최소화 */
+  .grid-stack-item-content .apexcharts-canvas { width: 100% !important; }
+  .grid-stack-item-content .apexcharts-legend { padding: 0 !important; }
+</style>
+
+<div class="page-body">
+  <div class="container-xl">
+    <div class="row row-cards">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header">
+            <h3 class="card-title">Monitoring Dashboard / Workload</h3>
+            <div class="card-actions">
+              <button class="btn btn-primary btn-sm" id="btn-add-widget"><i class="ti ti-plus"></i> Add Widget</button>
+              <button class="btn btn-outline-secondary btn-sm" id="btn-save-layout"><i class="ti ti-device-floppy"></i> Save</button>
+              <button class="btn btn-outline-danger btn-sm" id="btn-reset-layout"><i class="ti ti-refresh"></i> Reset</button>
+            </div>
+          </div>
+          <div class="card-body">
+            <div class="grid-stack" id="dashboard-grid"></div>
+            <div class="empty d-none" id="empty-dashboard">
+              <div class="empty-icon"><i class="ti ti-chart-area-line" style="font-size:3rem;color:#206bc4;"></i></div>
+              <p class="empty-title mt-3">No widgets configured</p>
+              <p class="empty-subtitle text-muted">Add widgets to build your monitoring dashboard.</p>
+              <div class="empty-action"><button class="btn btn-primary" id="btn-add-widget-empty"><i class="ti ti-plus"></i> Add Widget</button></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 위젯 카탈로그 모달 -->
+<div class="modal modal-blur fade" id="widgetCatalogModal" tabindex="-1">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header"><h5 class="modal-title">Add Widget</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+      <div class="modal-body">
+        <ul class="nav nav-tabs mb-3" id="catalog-category-tabs">
+          <li class="nav-item"><a class="nav-link active" href="#" data-category="all">All</a></li>
+          <li class="nav-item"><a class="nav-link" href="#" data-category="compute">Compute</a></li>
+          <li class="nav-item"><a class="nav-link" href="#" data-category="storage">Storage</a></li>
+          <li class="nav-item"><a class="nav-link" href="#" data-category="network">Network</a></li>
+          <li class="nav-item"><a class="nav-link" href="#" data-category="etc">Etc</a></li>
+        </ul>
+        <div class="row" id="catalog-widget-list"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 자원 선택 모달 -->
+<div class="modal modal-blur fade" id="resourceSelectorModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header"><h5 class="modal-title">Select Target Resource</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+      <div class="modal-body">
+        <input type="hidden" id="resource-widget-type" />
+        <div class="mb-3"><label class="form-label required">Namespace</label><select class="form-select" id="resource-ns-select"><option value="">Select</option></select></div>
+        <div class="mb-3"><label class="form-label required">MCI (Workload)</label><select class="form-select" id="resource-mci-select"><option value="">Select</option></select></div>
+        <div class="mb-3"><label class="form-label required">VM</label><select class="form-select" id="resource-vm-select"><option value="">Select</option></select></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" onclick="webconsolejs['pages/operation/analytics/dashboard'].confirmAddWidget()">Add</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 위젯 설정 모달 -->
+<div class="modal modal-blur fade" id="widgetConfigModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header"><h5 class="modal-title">Widget Settings</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+      <div class="modal-body">
+        <input type="hidden" id="config-widget-id" />
+        <div class="mb-3"><label class="form-label">Time Range</label><select class="form-select" id="config-range-select"></select></div>
+        <div class="mb-3"><label class="form-label">Refresh Interval</label><select class="form-select" id="config-refresh-select"></select></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" onclick="webconsolejs['pages/operation/analytics/dashboard'].applyWidgetConfig()">Apply</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 위젯 삭제 확인 모달 -->
+<div class="modal modal-blur fade" id="confirmRemoveModal" tabindex="-1">
+  <div class="modal-dialog modal-sm">
+    <div class="modal-content">
+      <div class="modal-header"><h5 class="modal-title">Remove Widget</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+      <div class="modal-body"><input type="hidden" id="remove-widget-id" /><p>Are you sure you want to remove this widget?</p></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger" onclick="webconsolejs['pages/operation/analytics/dashboard'].executeRemoveWidget()">Remove</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+{{ javascriptTag("pages/operation/analytics/dashboard.js") | raw }}
+{{ javascriptTag("common/api/services/mci_api.js") | raw }}
+{{ javascriptTag("common/api/services/monitoring_api.js") | raw }}

--- a/front/templates/partials/layout/_navbar.html
+++ b/front/templates/partials/layout/_navbar.html
@@ -115,10 +115,9 @@
 
             <div class="nav-item dropdown">
                 <a href="#" class="nav-link d-flex lh-1 text-reset p-0" data-bs-toggle="dropdown" aria-label="Open user menu">
-                <span class="avatar avatar-sm" style="background-image: url(/#)"></span>
-                <div class="d-none d-xl-block ps-2">
-                    <!-- <div class="mt-1 small text-secondary">UI Designer</div> -->
-                </div>
+                <span class="avatar avatar-sm">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 7m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0" /><path d="M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" /></svg>
+                </span>
                 </a>
                 <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow">
                 <!-- <a href="#" class="dropdown-item">Status</a> -->


### PR DESCRIPTION
## Summary
- GridStack v7 기반 드래그앤드롭 대시보드와 ApexCharts 시계열 차트를 활용한 커스터마이징 모니터링 위젯 시스템 구현
- 위젯 카탈로그 7종 정의 (CPU, Memory, Disk, DiskIO, Network, Syslog, EventAlarm)
- localStorage 기반 사용자별 레이아웃 저장/복원
- monitoringconfig.js 행 클릭 토글 버그 수정 및 navbar 아바타 SVG 아이콘 개선

## Changes
| 파일 | 설명 |
|------|------|
| `front/assets/js/common/dashboard/widget_catalog.js` | 위젯 카탈로그 정의 (7종) |
| `front/assets/js/common/dashboard/widget_renderer.js` | ApexCharts 기반 위젯 렌더링 |
| `front/assets/js/common/dashboard/dashboard_storage.js` | localStorage 레이아웃 저장/복원 |
| `front/assets/js/pages/operation/analytics/dashboard.js` | 대시보드 페이지 메인 로직 |
| `front/templates/pages/operations/analytics/monitorings/dashboard.html` | 대시보드 HTML 템플릿 |
| `front/assets/js/pages/operation/analytics/monitoringconfig.js` | 토글 버그 수정 |
| `front/templates/partials/layout/_navbar.html` | 아바타 SVG 아이콘 개선 |
| `front/package.json` | gridstack v7.3.0 의존성 추가 |

## Test plan
- [ ] 대시보드 페이지 접근 및 기본 레이아웃 표시 확인
- [ ] 위젯 추가/제거 동작 확인
- [ ] 위젯 드래그 이동 및 리사이즈 동작 확인
- [ ] 레이아웃 저장 후 새로고침 시 복원 확인
- [ ] Monitoring Config 페이지 토글 버그 수정 확인