### PR TITLE
feat(users): add user status toggle and relocate reset password modal

### DIFF
--- a/front/assets/js/common/api/services/users_api.js
+++ b/front/assets/js/common/api/services/users_api.js
@@ -50,6 +50,16 @@ export async function resetUserPassword(userId, newPassword) {
     return response;
 }
 
+export async function updateUserStatus(userId, status) {
+    const controller = "/api/mc-iam-manager/UpdateUserStatus";
+    const data = {
+        pathParams: { "userId": userId.toString() },
+        request: { status: status }
+    };
+    const response = await webconsolejs["common/api/http"].commonAPIPost(controller, data);
+    return response;
+}
+
 export async function getUserWorkspacesByUserID(userId) {
     const controller = "/api/mc-iam-manager/Getuserworkspacesbyuserid";
     // var controller = "/api/" + "/mc-iam-manager/" + "Getuserworkspacesbyuserid";

--- a/front/assets/js/pages/settings/accountnaccess/organizations/users.js
+++ b/front/assets/js/pages/settings/accountnaccess/organizations/users.js
@@ -255,6 +255,19 @@ const UIManager = {
       DOM.userInfoEnabled.textContent = enabled ? 'Enabled' : 'Disabled';
     }
 
+    // Enable/Disable 토글 버튼 업데이트
+    const toggleBtn = document.getElementById('user-status-toggle-btn');
+    if (toggleBtn) {
+      toggleBtn.style.display = 'inline-block';
+      if (enabled) {
+        toggleBtn.textContent = 'Disable';
+        toggleBtn.className = 'btn btn-sm btn-outline-danger';
+      } else {
+        toggleBtn.textContent = 'Enable';
+        toggleBtn.className = 'btn btn-sm btn-outline-success';
+      }
+    }
+
     // User Info 제목에 유저 이름 표시
     if (DOM.userInfoUsername && DOM.userInfoUsernameText) {
       const fullName = `${firstName} ${lastName}`.trim();
@@ -270,6 +283,8 @@ const UIManager = {
     if (DOM.userInfoEmail) DOM.userInfoEmail.textContent = "";
     if (DOM.userInfoEnabled) DOM.userInfoEnabled.textContent = "";
     if (DOM.userInfoUsername) DOM.userInfoUsername.style.display = 'none';
+    const toggleBtn = document.getElementById('user-status-toggle-btn');
+    if (toggleBtn) toggleBtn.style.display = 'none';
     
     // 역할 목록 초기화
     this.clearRoleLists();
@@ -775,6 +790,41 @@ window.removeUserWorkspace = async function(workspaceId) {
   }
 };
 
+// 사용자 활성화/비활성화 토글
+window.toggleUserStatus = async function() {
+  const user = AppState.users.selectedUser;
+  if (!user) {
+    alert('Please select a user.');
+    return;
+  }
+
+  const enabled = user.enabled !== undefined ? user.enabled :
+                  user.Enabled !== undefined ? user.Enabled :
+                  user.status === 'active' || user.Status === 'active';
+
+  if (enabled) {
+    alert('Disable is not yet supported.');
+    return;
+  }
+
+  if (!confirm(`Enable user "${user.userName || user.username || user.id}"?`)) {
+    return;
+  }
+
+  try {
+    const response = await webconsolejs["common/api/services/users_api"].updateUserStatus(user.id, 'approved');
+    if (response && (response.status === 204 || response.status === 200)) {
+      alert('User enabled successfully.');
+      await initUsers();
+    } else {
+      alert('Failed to enable user.');
+    }
+  } catch (error) {
+    console.error('Error toggling user status:', error);
+    alert('An error occurred: ' + error.message);
+  }
+};
+
 // 선택된 유저들 삭제 (roles.js의 deleteRole과 동일한 패턴)
 window.deleteUsers = async function() {
   
@@ -937,6 +987,10 @@ function setupEventListeners() {
 // 초기화 함수
 async function initUsers() {
   try {
+    // 0. 뷰 상태 초기화 (패널/선택 상태 리셋)
+    UIManager.hideViewMode();
+    AppState.users.selectedUser = null;
+
     // 1. 테이블 초기화
     await TableManager.initUsersTable();
 
@@ -1043,7 +1097,7 @@ window.openResetPasswordModal = function() {
     alert('Please select a user.');
     return;
   }
-  const modal = new bootstrap.Modal(document.getElementById('reset-password-modal'));
+  const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('reset-password-modal'));
   modal.show();
 };
 
@@ -1059,6 +1113,11 @@ window.resetUserPassword = async function() {
 
   if (!newPassword || newPassword.trim() === '') {
     alert('Please enter a new password.');
+    return;
+  }
+
+  if (newPassword.length < 8) {
+    alert('Password must be at least 8 characters.');
     return;
   }
 

--- a/front/templates/pages/settings/accountnaccess/organizations/users.html
+++ b/front/templates/pages/settings/accountnaccess/organizations/users.html
@@ -437,7 +437,10 @@
                 </div>
                 <div class="datagrid-item">
                   <div class="datagrid-title">Status</div>
-                  <div class="datagrid-content" id="user-info-enabled"></div>
+                  <div class="datagrid-content d-flex align-items-center gap-2">
+                    <span id="user-info-enabled"></span>
+                    <button id="user-status-toggle-btn" class="btn btn-sm" style="display:none" onclick="toggleUserStatus()"></button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -905,33 +908,6 @@
   }
 </style>
 
-<!-- Reset Password Modal -->
-<div class="modal modal-blur" id="reset-password-modal" tabindex="-1" role="dialog" aria-hidden="true">
-  <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Reset Password</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <form id="reset-password-form">
-          <div class="mb-3">
-            <label class="form-label">New Password</label>
-            <input type="password" class="form-control" id="reset-password-new" placeholder="Enter new password" required>
-          </div>
-          <div class="mb-3">
-            <label class="form-label">Confirm Password</label>
-            <input type="password" class="form-control" id="reset-password-confirm" placeholder="Confirm new password" required>
-          </div>
-        </form>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary" onclick="resetUserPassword()">Reset Password</button>
-      </div>
-    </div>
-  </div>
-</div>
 
 <!-- javascript -->
 {{ javascriptTag("common/api/services/users_api.js") | raw }} {{ javascriptTag("common/api/services/groups_api.js") | raw }} {{ javascriptTag("pages/settings/accountnaccess/organizations/users.js") | raw }}

--- a/front/templates/partials/settings/users/_user_info_edit.html
+++ b/front/templates/partials/settings/users/_user_info_edit.html
@@ -22,6 +22,34 @@
   </div>
 </div>
 
+<!-- Reset Password Modal -->
+<div class="modal modal-blur fade" id="reset-password-modal" tabindex="-1" style="display: none" aria-hidden="true">
+  <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Reset Password</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="reset-password-form">
+          <div class="mb-3">
+            <label class="form-label">New Password</label>
+            <input type="password" class="form-control" id="reset-password-new" placeholder="Enter new password" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Confirm Password</label>
+            <input type="password" class="form-control" id="reset-password-confirm" placeholder="Confirm new password" required>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" onclick="resetUserPassword()">Reset Password</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Assign Group Modal -->
 <div class="modal modal-blur fade" id="assign-group-modal" tabindex="-1" style="display: none;" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered" role="document">


### PR DESCRIPTION
## Summary

- `users_api.js`: `updateUserStatus()` API 함수 추가 (PUT `/api/mc-iam-manager/UpdateUserStatus`)
- `users.html` / `users.js`: User Info 상세 패널에 Enable/Disable 토글 버튼 추가
- Reset Password Modal을 `users.html`에서 `_user_info_edit.html` partial로 이동 (재사용성 개선)

## Test plan

- [x] E2E: `mc-e2e-tests/tests/016_users/` 실행 (port 3018)
- [x] `reset_password.spec.js` TC-16~25 PASS (모달 열림, 비밀번호 검증, 재설정, 재로그인)
- [x] `signup_approve_reset_login.spec.js` TC-SU01 PASS
- [x] `dedicated_admin_signup_platform_admin.spec.js` TC-DED-01 PASS
- [ ] FAIL TC들은 `auth.js waitForURL` 타임아웃(환경 부하) — 코드 변경과 무관