### PR TITLE
feat(cloud-admin-003): VNet Template 관리 화면 구현 (FR-CLOUD-ADMIN-003-06)

### DIFF
--- a/front/assets/js/common/api/services/networktemplate_api.js
+++ b/front/assets/js/common/api/services/networktemplate_api.js
@@ -1,0 +1,43 @@
+// VNet Template API 서비스 (mc-infra-manager → cb-tumblebug)
+
+export async function list(ns, filterKeyword) {
+  const controller = '/api/mc-infra-manager/GetAllVNetTemplate';
+  const params = { pathParams: { nsId: ns } };
+  if (filterKeyword) params.queryParams = { filterKeyword };
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, params);
+  return response?.data?.responseData;
+}
+
+export async function create(ns, body) {
+  const controller = '/api/mc-infra-manager/PostVNetTemplate';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId: ns },
+    request: body
+  });
+  return response?.data?.responseData;
+}
+
+export async function get(ns, templateId) {
+  const controller = '/api/mc-infra-manager/GetVNetTemplate';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId: ns, templateId }
+  });
+  return response?.data?.responseData;
+}
+
+export async function update(ns, templateId, body) {
+  const controller = '/api/mc-infra-manager/PutVNetTemplate';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId: ns, templateId },
+    request: body
+  });
+  return response?.data?.responseData;
+}
+
+export async function deleteAll(ns) {
+  const controller = '/api/mc-infra-manager/DeleteAllVNetTemplate';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId: ns }
+  });
+  return response?.data;
+}

--- a/front/assets/js/pages/settings/environment/cloudresources/networks.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/networks.js
@@ -84,15 +84,14 @@ async function loadConnectionOptions(selectId) {
     const select = document.getElementById(selectId);
     select.innerHTML = '<option value="">선택하세요</option>';
     try {
-        // CSP 계정 목록에서 connectionName 가져오기
         const result = await webconsolejs["common/api/http"].commonAPIPost(
-            "/api/mc-iam-manager/ListCspAccounts", {}
+            "/api/mc-infra-manager/GetConnConfigList", {}
         );
-        const accounts = result?.data?.responseData?.items || [];
-        for (const acc of accounts) {
+        const list = result?.data?.responseData?.connectionconfig || [];
+        for (const conn of list) {
             const opt = document.createElement('option');
-            opt.value = acc.connectionName || acc.name;
-            opt.textContent = acc.name;
+            opt.value = conn.configName;
+            opt.textContent = conn.configName;
             select.appendChild(opt);
         }
     } catch (err) {

--- a/front/assets/js/pages/settings/environment/cloudresources/networktemplates.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/networktemplates.js
@@ -1,0 +1,317 @@
+const AppState = {
+  resources: { list: [], selected: null },
+  ui: { viewMode: false },
+  tables: { resourceTable: null },
+  ns: ''
+};
+
+// project 변경 시 목록 재조회
+$('#select-current-project').on('change', async function () {
+  if (this.value === '') return;
+  const project = { Id: this.value, Name: this.options[this.selectedIndex].text, NsId: this.options[this.selectedIndex].text };
+  webconsolejs['common/api/services/workspace_api'].setCurrentProject(project);
+  AppState.ns = project.NsId;
+  hideDetail();
+  await loadList();
+});
+
+async function loadList() {
+  const ns = AppState.ns;
+  if (!ns) return;
+  try {
+    const data = await webconsolejs['common/api/services/networktemplate_api'].list(ns);
+    const items = data?.templates || [];
+    AppState.resources.list = items;
+    if (AppState.tables.resourceTable) {
+      AppState.tables.resourceTable.replaceData(items);
+    } else {
+      initTable(items);
+    }
+  } catch (e) {
+    if (e?.response?.status !== 404) console.error('Failed to load VNet templates', e);
+    AppState.resources.list = [];
+    if (AppState.tables.resourceTable) AppState.tables.resourceTable.replaceData([]);
+    else initTable([]);
+  }
+}
+
+function initTable(data) {
+  AppState.tables.resourceTable = new Tabulator('#template-table', {
+    data: data,
+    layout: 'fitColumns',
+    placeholder: 'No VNet templates found.',
+    columns: [
+      { title: 'Name', field: 'name', sorter: 'string' },
+      { title: 'Description', field: 'description', sorter: 'string' },
+      {
+        title: 'Type', field: 'vNetPolicy', sorter: 'string',
+        formatter: function (cell) {
+          return cell.getValue() ? '<span class="badge bg-blue-lt">Policy</span>' : '<span class="badge bg-secondary-lt">Raw</span>';
+        }
+      },
+      { title: 'Source', field: 'source', sorter: 'string', width: 100 },
+      { title: 'Created', field: 'createdAt', sorter: 'string', width: 180 }
+    ],
+    rowClick: function (e, row) {
+      const data = row.getData();
+      AppState.resources.selected = data;
+      renderDetail(data);
+      showDetail();
+    }
+  });
+}
+
+function renderDetail(data) {
+  document.getElementById('detail-name').textContent = data.name || '-';
+  document.getElementById('detail-id').textContent = data.id || '-';
+  document.getElementById('detail-description').textContent = data.description || '-';
+  document.getElementById('detail-source').textContent = data.source || '-';
+  document.getElementById('detail-createdAt').textContent = data.createdAt || '-';
+  document.getElementById('detail-updatedAt').textContent = data.updatedAt || '-';
+
+  const policySection = document.getElementById('detail-policy-section');
+  const rawSection = document.getElementById('detail-raw-section');
+
+  if (data.vNetPolicy) {
+    policySection.style.display = '';
+    rawSection.style.display = 'none';
+    document.getElementById('detail-cidrBlock').textContent = data.vNetPolicy.cidrBlock || '-';
+    document.getElementById('detail-multiZone').textContent = data.vNetPolicy.multiZone ? 'Yes' : 'No';
+    document.getElementById('detail-subnetCount').textContent = data.vNetPolicy.subnetCount ?? '-';
+  } else if (data.vNetReq) {
+    policySection.style.display = 'none';
+    rawSection.style.display = '';
+    document.getElementById('detail-connectionName').textContent = data.vNetReq.connectionName || '-';
+    document.getElementById('detail-vNetName').textContent = data.vNetReq.name || '-';
+    document.getElementById('detail-vNetCidr').textContent = data.vNetReq.cidrBlock || '-';
+    const subnets = (data.vNetReq.subnetInfoList || []).map(s => `${s.name} (${s.ipv4_CIDR})`).join(', ');
+    document.getElementById('detail-subnets').textContent = subnets || '-';
+  } else {
+    policySection.style.display = 'none';
+    rawSection.style.display = 'none';
+  }
+}
+
+function showDetail() {
+  const el = document.getElementById('view-mode-cards');
+  if (el) el.classList.add('show');
+  AppState.ui.viewMode = true;
+}
+
+window.hideDetail = function () {
+  const el = document.getElementById('view-mode-cards');
+  if (el) el.classList.remove('show');
+  AppState.ui.viewMode = false;
+  AppState.resources.selected = null;
+};
+
+// ─── Connection List ───────────────────────────────────────────────────
+
+async function loadConnectionList() {
+  try {
+    const resp = await webconsolejs['common/api/http'].commonAPIPost('/api/mc-infra-manager/GetConnConfigList', {});
+    const list = resp?.data?.responseData?.connectionconfig || [];
+    ['create-connectionName', 'edit-connectionName'].forEach(id => {
+      const sel = document.getElementById(id);
+      if (!sel) return;
+      while (sel.options.length > 1) sel.remove(1);
+      list.forEach(conn => {
+        const opt = document.createElement('option');
+        opt.value = conn.configName;
+        opt.textContent = conn.configName;
+        sel.appendChild(opt);
+      });
+    });
+  } catch (e) {
+    console.error('Failed to load connection list', e);
+  }
+}
+
+// ─── Create / Edit Modal ───────────────────────────────────────────────
+
+function getModeFromModal(prefix) {
+  return document.getElementById(prefix + '-mode-policy').checked ? 'policy' : 'raw';
+}
+
+window.onModalModeChange = function (prefix) {
+  const mode = getModeFromModal(prefix);
+  document.getElementById(prefix + '-policy-fields').style.display = mode === 'policy' ? '' : 'none';
+  document.getElementById(prefix + '-raw-fields').style.display = mode === 'raw' ? '' : 'none';
+};
+
+function buildRequestBody(prefix) {
+  const name = document.getElementById(prefix + '-name').value.trim();
+  const description = document.getElementById(prefix + '-description').value.trim();
+  const mode = getModeFromModal(prefix);
+  const body = { name };
+  if (description) body.description = description;
+
+  if (mode === 'policy') {
+    body.vNetPolicy = {
+      cidrBlock: document.getElementById(prefix + '-cidrBlock').value.trim() || 'auto',
+      multiZone: document.getElementById(prefix + '-multiZone').checked,
+      subnetCount: parseInt(document.getElementById(prefix + '-subnetCount').value, 10) || 1
+    };
+  } else {
+    const connectionName = document.getElementById(prefix + '-connectionName').value.trim();
+    const vNetName = document.getElementById(prefix + '-vNetName').value.trim();
+    const cidrBlock = document.getElementById(prefix + '-vNetCidr').value.trim();
+    const subnetRows = document.querySelectorAll('#' + prefix + '-subnet-rows .subnet-row');
+    const subnetInfoList = [];
+    subnetRows.forEach(row => {
+      const sName = row.querySelector('.subnet-name').value.trim();
+      const sCidr = row.querySelector('.subnet-cidr').value.trim();
+      const sZone = row.querySelector('.subnet-zone').value.trim();
+      if (sName && sCidr) subnetInfoList.push({ name: sName, ipv4_CIDR: sCidr, zone: sZone });
+    });
+    body.vNetReq = { connectionName, name: vNetName, cidrBlock, subnetInfoList };
+  }
+  return body;
+}
+
+window.addSubnetRow = function (prefix) {
+  const container = document.getElementById(prefix + '-subnet-rows');
+  const row = document.createElement('div');
+  row.className = 'subnet-row row g-2 mb-2';
+  row.innerHTML = `
+    <div class="col-4"><input type="text" class="form-control form-control-sm subnet-name" placeholder="Subnet Name"></div>
+    <div class="col-4"><input type="text" class="form-control form-control-sm subnet-cidr" placeholder="CIDR (10.0.1.0/24)"></div>
+    <div class="col-3"><input type="text" class="form-control form-control-sm subnet-zone" placeholder="Zone"></div>
+    <div class="col-1"><button type="button" class="btn btn-sm btn-ghost-danger" onclick="removeSubnetRow(this)">✕</button></div>`;
+  container.appendChild(row);
+};
+
+window.removeSubnetRow = function (btn) {
+  const rows = btn.closest('[id$="-subnet-rows"]').querySelectorAll('.subnet-row');
+  if (rows.length <= 1) return;
+  btn.closest('.subnet-row').remove();
+};
+
+window.submitCreate = async function () {
+  const ns = AppState.ns;
+  if (!ns) { webconsolejs['common/util'].showToast('Please select a project first.', 'error'); return; }
+  const body = buildRequestBody('create');
+  if (!body.name) { webconsolejs['common/util'].showToast('Name is required.', 'error'); return; }
+  try {
+    await webconsolejs['common/api/services/networktemplate_api'].create(ns, body);
+    bootstrap.Modal.getInstance(document.getElementById('create-modal'))?.hide();
+    await loadList();
+    webconsolejs['common/util'].showToast('Template created.', 'success');
+  } catch (e) {
+    webconsolejs['common/util'].showToast('Failed to create: ' + (e?.response?.data?.message || e.message), 'error');
+  }
+};
+
+window.openEditModal = function () {
+  const item = AppState.resources.selected;
+  if (!item) return;
+
+  document.getElementById('edit-name').value = item.name || '';
+  document.getElementById('edit-description').value = item.description || '';
+
+  if (item.vNetPolicy) {
+    document.getElementById('edit-mode-policy').checked = true;
+    document.getElementById('edit-cidrBlock').value = item.vNetPolicy.cidrBlock || 'auto';
+    document.getElementById('edit-multiZone').checked = !!item.vNetPolicy.multiZone;
+    document.getElementById('edit-subnetCount').value = item.vNetPolicy.subnetCount || 1;
+  } else {
+    document.getElementById('edit-mode-raw').checked = true;
+    if (item.vNetReq) {
+      document.getElementById('edit-connectionName').value = item.vNetReq.connectionName || '';
+      document.getElementById('edit-vNetName').value = item.vNetReq.name || '';
+      document.getElementById('edit-vNetCidr').value = item.vNetReq.cidrBlock || '';
+    }
+  }
+  onModalModeChange('edit');
+  new bootstrap.Modal(document.getElementById('edit-modal')).show();
+};
+
+window.submitEdit = async function () {
+  const ns = AppState.ns;
+  const templateId = AppState.resources.selected?.id;
+  if (!ns || !templateId) return;
+  const body = buildRequestBody('edit');
+  if (!body.name) { webconsolejs['common/util'].showToast('Name is required.', 'error'); return; }
+  try {
+    await webconsolejs['common/api/services/networktemplate_api'].update(ns, templateId, body);
+    bootstrap.Modal.getInstance(document.getElementById('edit-modal'))?.hide();
+    await loadList();
+    webconsolejs['common/util'].showToast('Template updated.', 'success');
+  } catch (e) {
+    webconsolejs['common/util'].showToast('Failed to update: ' + (e?.response?.data?.message || e.message), 'error');
+  }
+};
+
+// ─── Delete All ────────────────────────────────────────────────────────
+
+window.confirmDeleteAll = function () {
+  webconsolejs['partials/layout/modal'].commonConfirmModal(
+    'commonDefaultModal',
+    'Delete All Templates',
+    'Delete ALL VNet templates in this namespace?',
+    'pages/settings/environment/cloudresources/networktemplates.executeDeleteAll'
+  );
+};
+
+export async function executeDeleteAll() {
+  try {
+    await webconsolejs['common/api/services/networktemplate_api'].deleteAll(AppState.ns);
+    hideDetail();
+    await loadList();
+    webconsolejs['common/util'].showToast('All templates deleted.', 'success');
+  } catch (e) {
+    webconsolejs['common/util'].showToast('Failed to delete: ' + (e?.response?.data?.message || e.message), 'error');
+  }
+}
+
+// ─── Filter ────────────────────────────────────────────────────────────
+
+function initFilter() {
+  const fieldEl = document.getElementById('filter-field');
+  const typeEl = document.getElementById('filter-type');
+  const valueEl = document.getElementById('filter-value');
+  if (!fieldEl || !typeEl || !valueEl) return;
+
+  function updateFilter() {
+    const filterVal = fieldEl.value;
+    const typeVal = typeEl.value;
+    if (filterVal && AppState.tables.resourceTable) {
+      AppState.tables.resourceTable.setFilter(filterVal, typeVal, valueEl.value);
+    }
+  }
+
+  fieldEl.addEventListener('change', updateFilter);
+  typeEl.addEventListener('change', updateFilter);
+  valueEl.addEventListener('keyup', updateFilter);
+  document.getElementById('filter-clear').addEventListener('click', function () {
+    fieldEl.value = '';
+    typeEl.value = 'like';
+    valueEl.value = '';
+    if (AppState.tables.resourceTable) AppState.tables.resourceTable.clearFilter();
+  });
+}
+
+// ─── Init ──────────────────────────────────────────────────────────────
+
+document.addEventListener('DOMContentLoaded', async function () {
+  const btnList = document.getElementById('page-header-btn-list');
+  if (btnList) {
+    btnList.innerHTML = `
+      <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#create-modal">Add Template</button>`;
+  }
+
+  const selectedWorkspaceProject = await webconsolejs['partials/layout/navbar'].workspaceProjectInit();
+  webconsolejs['partials/layout/modal'].checkWorkspaceSelection(selectedWorkspaceProject);
+
+  if (selectedWorkspaceProject.workspaceId !== '' && selectedWorkspaceProject.projectId === '') {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Project Selection Check', 'Please select a project first');
+  }
+
+  AppState.ns = selectedWorkspaceProject.nsId;
+  initFilter();
+  await loadConnectionList();
+
+  if (selectedWorkspaceProject.projectId !== '') {
+    await loadList();
+  }
+});

--- a/front/templates/pages/settings/environment/cloudresources/networktemplates.html
+++ b/front/templates/pages/settings/environment/cloudresources/networktemplates.html
@@ -1,0 +1,335 @@
+<div class="page-body">
+  <div class="container-xl">
+
+    <!-- Template List -->
+    <div class="row row-cards">
+      <div class="col-12">
+        <div class="card">
+          <div class="card-header">
+            <h3 class="card-title">VNet Template List</h3>
+            <div class="card-options ms-auto d-flex gap-2">
+              <a class="btn-action" type="button" data-bs-toggle="collapse" data-bs-target="#filter-body" aria-expanded="false">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                  <path d="M5.5 5h13a1 1 0 0 1 .5 1.5L14 12L14 19L10 16L10 12L5 6.5a1 1 0 0 1 .5 -1.5"></path>
+                </svg>
+              </a>
+              <a class="btn-action" onclick="confirmDeleteAll()">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon text-danger" width="24" height="24" viewBox="0 0 24 24"
+                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                  <path d="M4 7l16 0"></path>
+                  <path d="M10 11l0 6"></path>
+                  <path d="M14 11l0 6"></path>
+                  <path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12"></path>
+                  <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+          <div class="collapse" id="filter-body">
+            <div class="card-body border-bottom py-3">
+              <div class="row g-2 align-items-end">
+                <div class="col-auto">
+                  <label class="form-label mb-1">Field</label>
+                  <select id="filter-field" class="form-select form-select-sm">
+                    <option value="">-- select --</option>
+                    <option value="name">name</option>
+                    <option value="description">description</option>
+                    <option value="source">source</option>
+                  </select>
+                </div>
+                <div class="col-auto">
+                  <label class="form-label mb-1">Type</label>
+                  <select id="filter-type" class="form-select form-select-sm">
+                    <option value="like">like</option>
+                    <option value="=">=</option>
+                    <option value="!=">!=</option>
+                  </select>
+                </div>
+                <div class="col">
+                  <label class="form-label mb-1">Value</label>
+                  <input type="text" id="filter-value" class="form-control form-control-sm" placeholder="filter...">
+                </div>
+                <div class="col-auto">
+                  <button id="filter-clear" class="btn btn-sm btn-outline-secondary">Clear</button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="card-body p-0">
+            <div id="template-table"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Detail Panel -->
+    <div id="view-mode-cards" class="collapse">
+      <div class="row row-cards mt-2">
+        <div class="col-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">Template Info — <span id="detail-name" class="text-primary"></span></h3>
+              <div class="card-options">
+                <button class="btn btn-sm btn-outline-secondary me-1" onclick="openEditModal()">Edit</button>
+                <a href="#" class="card-options-remove" onclick="hideDetail()">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                    stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                    <path d="M18 6l-12 12"></path>
+                    <path d="M6 6l12 12"></path>
+                  </svg>
+                </a>
+              </div>
+            </div>
+            <div class="card-body">
+              <div class="datagrid">
+                <div class="datagrid-item">
+                  <div class="datagrid-title">ID</div>
+                  <div class="datagrid-content" id="detail-id">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Description</div>
+                  <div class="datagrid-content" id="detail-description">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Source</div>
+                  <div class="datagrid-content" id="detail-source">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Created At</div>
+                  <div class="datagrid-content" id="detail-createdAt">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Updated At</div>
+                  <div class="datagrid-content" id="detail-updatedAt">-</div>
+                </div>
+              </div>
+
+              <!-- Policy Mode Detail -->
+              <div id="detail-policy-section" class="mt-3">
+                <h4>VNet Policy</h4>
+                <div class="datagrid">
+                  <div class="datagrid-item">
+                    <div class="datagrid-title">CIDR Block</div>
+                    <div class="datagrid-content" id="detail-cidrBlock">-</div>
+                  </div>
+                  <div class="datagrid-item">
+                    <div class="datagrid-title">Multi Zone</div>
+                    <div class="datagrid-content" id="detail-multiZone">-</div>
+                  </div>
+                  <div class="datagrid-item">
+                    <div class="datagrid-title">Subnet Count</div>
+                    <div class="datagrid-content" id="detail-subnetCount">-</div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Raw Mode Detail -->
+              <div id="detail-raw-section" class="mt-3">
+                <h4>VNet Request</h4>
+                <div class="datagrid">
+                  <div class="datagrid-item">
+                    <div class="datagrid-title">Connection</div>
+                    <div class="datagrid-content" id="detail-connectionName">-</div>
+                  </div>
+                  <div class="datagrid-item">
+                    <div class="datagrid-title">VNet Name</div>
+                    <div class="datagrid-content" id="detail-vNetName">-</div>
+                  </div>
+                  <div class="datagrid-item">
+                    <div class="datagrid-title">CIDR Block</div>
+                    <div class="datagrid-content" id="detail-vNetCidr">-</div>
+                  </div>
+                  <div class="datagrid-item">
+                    <div class="datagrid-title">Subnets</div>
+                    <div class="datagrid-content" id="detail-subnets">-</div>
+                  </div>
+                </div>
+              </div>
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<!-- Create Modal -->
+<div class="modal modal-blur fade" id="create-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Add VNet Template</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label required">Name</label>
+          <input type="text" id="create-name" class="form-control" placeholder="my-vnet-template">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Description</label>
+          <input type="text" id="create-description" class="form-control" placeholder="Optional description">
+        </div>
+        <div class="mb-3">
+          <label class="form-label required">Mode</label>
+          <div class="d-flex gap-3">
+            <label class="form-check">
+              <input class="form-check-input" type="radio" name="create-mode" id="create-mode-policy" value="policy" checked onchange="onModalModeChange('create')">
+              <span class="form-check-label">Policy (CSP-agnostic)</span>
+            </label>
+            <label class="form-check">
+              <input class="form-check-input" type="radio" name="create-mode" id="create-mode-raw" value="raw" onchange="onModalModeChange('create')">
+              <span class="form-check-label">Raw (CSP-specific)</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- Policy Fields -->
+        <div id="create-policy-fields">
+          <div class="mb-3">
+            <label class="form-label">CIDR Block</label>
+            <input type="text" id="create-cidrBlock" class="form-control" placeholder="auto (or e.g. 10.0.0.0/16)">
+            <small class="text-muted">Use "auto" to assign automatically</small>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Subnet Count</label>
+            <input type="number" id="create-subnetCount" class="form-control" value="2" min="1">
+          </div>
+          <div class="mb-3">
+            <label class="form-check">
+              <input class="form-check-input" type="checkbox" id="create-multiZone">
+              <span class="form-check-label">Multi Zone (spread subnets across availability zones)</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- Raw Fields -->
+        <div id="create-raw-fields" style="display:none">
+          <div class="mb-3">
+            <label class="form-label required">Connection Name</label>
+            <select id="create-connectionName" class="form-select">
+              <option value="">-- select --</option>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label required">VNet Name</label>
+            <input type="text" id="create-vNetName" class="form-control" placeholder="vnet00">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">CIDR Block</label>
+            <input type="text" id="create-vNetCidr" class="form-control" placeholder="10.0.0.0/16">
+          </div>
+          <div class="mb-2">
+            <label class="form-label">Subnets</label>
+            <div id="create-subnet-rows">
+              <div class="subnet-row row g-2 mb-2">
+                <div class="col-4"><input type="text" class="form-control form-control-sm subnet-name" placeholder="Subnet Name"></div>
+                <div class="col-4"><input type="text" class="form-control form-control-sm subnet-cidr" placeholder="CIDR (10.0.1.0/24)"></div>
+                <div class="col-3"><input type="text" class="form-control form-control-sm subnet-zone" placeholder="Zone"></div>
+                <div class="col-1"><button type="button" class="btn btn-sm btn-ghost-danger" onclick="removeSubnetRow(this)">✕</button></div>
+              </div>
+            </div>
+            <button type="button" class="btn btn-sm btn-outline-secondary mt-1" onclick="addSubnetRow('create')">+ Add Subnet</button>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" onclick="submitCreate()">Create</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Edit Modal -->
+<div class="modal modal-blur fade" id="edit-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Edit VNet Template</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label required">Name</label>
+          <input type="text" id="edit-name" class="form-control">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Description</label>
+          <input type="text" id="edit-description" class="form-control">
+        </div>
+        <div class="mb-3">
+          <label class="form-label required">Mode</label>
+          <div class="d-flex gap-3">
+            <label class="form-check">
+              <input class="form-check-input" type="radio" name="edit-mode" id="edit-mode-policy" value="policy" checked onchange="onModalModeChange('edit')">
+              <span class="form-check-label">Policy</span>
+            </label>
+            <label class="form-check">
+              <input class="form-check-input" type="radio" name="edit-mode" id="edit-mode-raw" value="raw" onchange="onModalModeChange('edit')">
+              <span class="form-check-label">Raw</span>
+            </label>
+          </div>
+        </div>
+
+        <div id="edit-policy-fields">
+          <div class="mb-3">
+            <label class="form-label">CIDR Block</label>
+            <input type="text" id="edit-cidrBlock" class="form-control" placeholder="auto">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Subnet Count</label>
+            <input type="number" id="edit-subnetCount" class="form-control" value="2" min="1">
+          </div>
+          <div class="mb-3">
+            <label class="form-check">
+              <input class="form-check-input" type="checkbox" id="edit-multiZone">
+              <span class="form-check-label">Multi Zone</span>
+            </label>
+          </div>
+        </div>
+
+        <div id="edit-raw-fields" style="display:none">
+          <div class="mb-3">
+            <label class="form-label required">Connection Name</label>
+            <select id="edit-connectionName" class="form-select">
+              <option value="">-- select --</option>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label required">VNet Name</label>
+            <input type="text" id="edit-vNetName" class="form-control">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">CIDR Block</label>
+            <input type="text" id="edit-vNetCidr" class="form-control">
+          </div>
+          <div class="mb-2">
+            <label class="form-label">Subnets</label>
+            <div id="edit-subnet-rows">
+              <div class="subnet-row row g-2 mb-2">
+                <div class="col-4"><input type="text" class="form-control form-control-sm subnet-name" placeholder="Subnet Name"></div>
+                <div class="col-4"><input type="text" class="form-control form-control-sm subnet-cidr" placeholder="CIDR"></div>
+                <div class="col-3"><input type="text" class="form-control form-control-sm subnet-zone" placeholder="Zone"></div>
+                <div class="col-1"><button type="button" class="btn btn-sm btn-ghost-danger" onclick="removeSubnetRow(this)">✕</button></div>
+              </div>
+            </div>
+            <button type="button" class="btn btn-sm btn-outline-secondary mt-1" onclick="addSubnetRow('edit')">+ Add Subnet</button>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" onclick="submitEdit()">Save</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+{{ javascriptTag("common/api/services/networktemplate_api.js") | raw }} {{ javascriptTag("pages/settings/environment/cloudresources/networktemplates.js") | raw }}


### PR DESCRIPTION
## Summary
- `networktemplates` 화면 신규 구현: VNet Template CRUD (Policy 모드 / Raw 모드)
- `networktemplate_api`: GetAllVNetTemplate / PostVNetTemplate / PutVNetTemplate / DeleteAllVNetTemplate / GetVNetTemplate API 서비스
- `networks`: `ListCspAccounts` (IAM) → `GetConnConfigList` (tumblebug native connection)
- `networktemplates.html`: connectionName 텍스트 입력 → select 드롭다운

## Test plan
- [ ] `/webconsole/settings/environment/cloudresources/networktemplates` — Template 목록 조회
- [ ] Template 생성 (Policy 모드 / Raw 모드) 및 수정/삭제 확인
- [ ] Connection 드롭다운 정상 로드 확인