### PR TITLE
feat(fr-007): add JSON/YAML export and import to menu management

### DIFF
--- a/front/assets/js/pages/settings/accountnaccess/organizations/menus.js
+++ b/front/assets/js/pages/settings/accountnaccess/organizations/menus.js
@@ -1,4 +1,5 @@
 import 'jstree';
+import jsyaml from 'js-yaml';
 
 // webconsolejs 네임스페이스 초기화
 if (typeof webconsolejs === 'undefined') {
@@ -356,11 +357,160 @@ window.confirmDeleteMenu = async function () {
     await MenuManager.delete(menu.id);
 };
 
+// parentId 의존성 기준으로 메뉴 정렬 (위상 정렬: root → children 순서)
+function sortMenusByDependency(menus) {
+    const result = [];
+    const visited = new Set();
+    const map = new Map(menus.map(m => [m.id, m]));
+
+    function visit(menu) {
+        if (visited.has(menu.id)) return;
+        if (menu.parentId && map.has(menu.parentId) && !visited.has(menu.parentId)) {
+            visit(map.get(menu.parentId));
+        }
+        visited.add(menu.id);
+        result.push(menu);
+    }
+
+    menus.forEach(m => visit(m));
+    return result;
+}
+
+// Export: 포맷(json/yaml)과 파일명을 받아 다운로드
+window.exportMenus = async function(format, filename) {
+    try {
+        const menus = await webconsolejs["common/api/services/menus_api"].listMenusTree();
+        const payload = {
+            version: "1.0",
+            exported_at: new Date().toISOString(),
+            menus: menus || []
+        };
+        let content, mimeType;
+        if (format === "yaml") {
+            content = jsyaml.dump(payload);
+            mimeType = "application/x-yaml";
+        } else {
+            content = JSON.stringify(payload, null, 2);
+            mimeType = "application/json";
+        }
+        const blob = new Blob([content], { type: mimeType });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+    } catch (err) {
+        console.error("Export failed:", err);
+        alert("메뉴 Export에 실패했습니다.");
+    }
+};
+
+// Export 모달 저장 버튼 핸들러
+window.doExportMenus = async function() {
+    const format = document.querySelector('input[name="export-format"]:checked').value;
+    const filename = (document.getElementById('export-menus-filename').value || `menu-export.${format}`).trim();
+    bootstrap.Modal.getInstance(document.getElementById('export-menus-modal')).hide();
+    await exportMenus(format, filename);
+};
+
+// 포맷 선택 변경 시 파일명 확장자 자동 갱신
+window.updateExportFilename = function() {
+    const format = document.querySelector('input[name="export-format"]:checked').value;
+    const input = document.getElementById('export-menus-filename');
+    input.value = input.value.replace(/\.(json|yaml|yml)$/i, '') + '.' + format;
+};
+
+// Import: JSON 또는 YAML 파일 파싱 후 메뉴 upsert 적용
+window.importMenus = async function(input) {
+    const file = input.files[0];
+    if (!file) return;
+    input.value = '';
+
+    let data;
+    try {
+        const text = await file.text();
+        if (file.name.match(/\.(yaml|yml)$/i)) {
+            data = jsyaml.load(text);
+        } else {
+            data = JSON.parse(text);
+        }
+    } catch (e) {
+        alert("유효하지 않은 파일입니다. JSON 또는 YAML 형식을 확인하세요.");
+        return;
+    }
+
+    const menus = data.menus || (Array.isArray(data) ? data : null);
+    if (!menus || !Array.isArray(menus)) {
+        alert("메뉴 데이터를 찾을 수 없습니다. (menus 배열 필드가 필요합니다)");
+        return;
+    }
+
+    if (!confirm(`총 ${menus.length}개의 메뉴를 Import합니다.\n현재 메뉴 구성이 교체될 수 있습니다. 계속하시겠습니까?`)) return;
+
+    const existing = await webconsolejs["common/api/services/menus_api"].listMenusTree();
+    const existingIds = new Set((existing || []).map(m => m.id));
+    const sorted = sortMenusByDependency(menus);
+
+    let created = 0, updated = 0, failed = 0;
+    for (const menu of sorted) {
+        try {
+            if (existingIds.has(menu.id)) {
+                await webconsolejs["common/api/services/menus_api"].updateMenu(menu.id, menu);
+                updated++;
+            } else {
+                await webconsolejs["common/api/services/menus_api"].createMenu(menu);
+                created++;
+            }
+        } catch (e) {
+            console.error("Import item failed:", menu.id, e);
+            failed++;
+        }
+    }
+
+    const body = document.getElementById('import-menus-result-body');
+    if (body) {
+        body.innerHTML = `
+            <p>Import가 완료되었습니다.</p>
+            ${created > 0 ? `<p><strong>${created}</strong>개 메뉴 생성됨</p>` : ''}
+            ${updated > 0 ? `<p><strong>${updated}</strong>개 메뉴 업데이트됨</p>` : ''}
+            ${failed > 0 ? `<p class="text-danger"><strong>${failed}</strong>개 실패</p>` : ''}`;
+    }
+    bootstrap.Modal.getOrCreateInstance(document.getElementById('import-menus-result-modal')).show();
+
+    await MenuManager.loadTree();
+};
+
 // 페이지 초기화
 document.addEventListener("DOMContentLoaded", async function () {
     const btnList = document.getElementById('page-header-btn-list');
     if (btnList) {
         btnList.innerHTML = `
+            <label class="btn btn-outline-secondary mb-0" style="cursor:pointer;">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
+                  viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
+                  stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                  <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2"></path>
+                  <path d="M7 9l5 -5l5 5"></path>
+                  <path d="M12 4l0 12"></path>
+                </svg>
+                Import
+                <input type="file" id="import-menus-file" accept=".json,.yaml,.yml"
+                       style="display:none;" onchange="importMenus(this)" />
+            </label>
+            <button type="button" class="btn btn-outline-secondary"
+                    data-bs-toggle="modal" data-bs-target="#export-menus-modal">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
+                  viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
+                  stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                  <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2"></path>
+                  <path d="M7 11l5 5l5 -5"></path>
+                  <path d="M12 4l0 12"></path>
+                </svg>
+                Export
+            </button>
             <button type="button" class="btn btn-primary" onclick="openCreateRootMenuModal()">
                 <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
                   viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
@@ -371,6 +521,16 @@ document.addEventListener("DOMContentLoaded", async function () {
                 </svg>
                 Add Root Menu
             </button>`;
+    }
+
+    // Export 모달 열릴 때 파일명 초기화
+    const exportModal = document.getElementById('export-menus-modal');
+    if (exportModal) {
+        exportModal.addEventListener('show.bs.modal', () => {
+            const date = new Date().toISOString().slice(0, 10);
+            document.getElementById('export-menus-filename').value = `menu-${date}.json`;
+            document.getElementById('export-format-json').checked = true;
+        });
     }
 
     await Promise.all([

--- a/front/package.json
+++ b/front/package.json
@@ -25,6 +25,7 @@
     "gridstack": "^7.3.0",
     "jquery": "^3.6.0",
     "jquery-ujs": "^1.2.2",
+    "js-yaml": "^4.1.1",
     "jstree": "^3.3.17",
     "jsvectormap": "^1.5.3",
     "list.js": "^2.3.1",

--- a/front/templates/pages/settings/accountnaccess/organizations/menus.html
+++ b/front/templates/pages/settings/accountnaccess/organizations/menus.html
@@ -239,6 +239,61 @@
   </div>
 </div>
 
+<!-- Export Menu Modal -->
+<div class="modal modal-blur fade" id="export-menus-modal" tabindex="-1" style="display: none" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">메뉴 Export</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">포맷</label>
+          <div>
+            <div class="form-check form-check-inline">
+              <input class="form-check-input" type="radio" name="export-format"
+                     id="export-format-json" value="json" checked
+                     onchange="updateExportFilename()">
+              <label class="form-check-label" for="export-format-json">JSON</label>
+            </div>
+            <div class="form-check form-check-inline">
+              <input class="form-check-input" type="radio" name="export-format"
+                     id="export-format-yaml" value="yaml"
+                     onchange="updateExportFilename()">
+              <label class="form-check-label" for="export-format-yaml">YAML</label>
+            </div>
+          </div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">파일명</label>
+          <input type="text" class="form-control" id="export-menus-filename" value="menu.json">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-primary" onclick="doExportMenus()">저장</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Import Menu Result Modal -->
+<div class="modal modal-blur fade" id="import-menus-result-modal" tabindex="-1" style="display: none" aria-hidden="true">
+  <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Import 결과</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" id="import-menus-result-body"></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">확인</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- pageloader -->
 {{ partial("partials/layout/pageloader.html") | raw }}
 


### PR DESCRIPTION
## Summary

- Export 버튼: JSON/YAML 포맷 선택 모달 + 편집 가능한 파일명으로 메뉴 구성 다운로드
- Import 버튼: .json/.yaml/.yml 파일 업로드 → 파싱 → 확인 대화상자 → API upsert (생성/수정)
- js-yaml 의존성 추가 (브라우저 YAML 직렬화/역직렬화)
- topological sort로 부모-자식 순서를 보장하여 import 시 의존성 오류 방지
- Import 결과 모달: 생성/수정/실패 건수 표시

## Changes

- `front/assets/js/pages/settings/accountnaccess/organizations/menus.js`: exportMenus, importMenus, doExportMenus, updateExportFilename 함수 추가, 헤더 버튼 업데이트
- `front/templates/pages/settings/accountnaccess/organizations/menus.html`: Export 모달, Import 결과 모달 추가
- `front/package.json`: js-yaml 의존성 추가

## Test plan

- [ ] 메뉴 관리 화면 헤더에 [Import] [Export] [+ Add Root Menu] 버튼 표시 확인
- [ ] Export → JSON 포맷 선택 → 파일명 확인 → 저장 → menu-YYYY-MM-DD.json 다운로드 확인
- [ ] Export → YAML 포맷 선택 → 파일명 자동변경 → 저장 → menu-YYYY-MM-DD.yaml 다운로드 확인
- [ ] Import → JSON 파일 선택 → 확인 → 결과 모달 표시
- [ ] Import → YAML 파일 선택 → 확인 → 결과 모달 표시
- [ ] 잘못된 형식 파일 import 시 오류 메시지 확인