### PR TITLE
feat(cloud-admin-003): SecurityGroup 관리 화면 개선

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -4807,10 +4807,6 @@ serviceActions:
       method: delete
       resourcePath: /ns/{nsId}/resources/spec/{specId}
       description: "Delete spec"
-    GetProviderList:
-      method: get
-      resourcePath: /provider
-      description: "List all registered cloud providers (aws, azure, gcp, ...)"
     SetBastionNodesWithMci:
       method: put
       resourcePath: /ns/{nsId}/mci/{mciId}/vm/{targetVmId}/bastion/{bastionMciId}/{bastionVmId}

--- a/front/assets/js/common/api/services/vpc_api.js
+++ b/front/assets/js/common/api/services/vpc_api.js
@@ -11,13 +11,12 @@ export async function getAllVNet(nsId, query = {}) {
   const filterKey = Array.isArray(query.filterKey) ? query.filterKey.map(String) : [];
   const filterVal = Array.isArray(query.filterVal) ? query.filterVal.map(String) : [];
 
-  const queryParams = {
-    filterKey,
-    filterVal
-  };
-  if (option !== undefined) {
-    queryParams.option = option;
-  }
+  // QueryParams는 map[string]string — 배열을 직접 넣으면 Go Bind 실패로 pathParams까지 소실됨
+  // filterKey/filterVal이 비어있으면 queryParams에 포함하지 않음
+  const queryParams = {};
+  if (option !== undefined) queryParams.option = option;
+  if (filterKey.length > 0) queryParams.filterKey = filterKey.join(',');
+  if (filterVal.length > 0) queryParams.filterVal = filterVal.join(',');
 
   const controller = '/api/mc-infra-manager/GetAllVNet';
   const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {

--- a/front/assets/js/common/api/services/vpc_api.js
+++ b/front/assets/js/common/api/services/vpc_api.js
@@ -50,3 +50,20 @@ export async function del(nsId, name) {
   });
   return response?.data;
 }
+
+export async function createSubnet(nsId, vnetId, body) {
+  const controller = '/api/mc-infra-manager/PostSubnet';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId, vNetId: vnetId },
+    request: body
+  });
+  return response?.data;
+}
+
+export async function delSubnet(nsId, vnetId, subnetId) {
+  const controller = '/api/mc-infra-manager/DelSubnet';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId, vNetId: vnetId, subnetId }
+  });
+  return response?.data;
+}

--- a/front/assets/js/pages/settings/environment/cloudresources/networks.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/networks.js
@@ -95,22 +95,23 @@ function initTable(vNets) {
               hozAlign: 'center', width: 100 },
             { title: 'CSP Resource ID', field: 'cspResourceId', widthGrow: 2 },
         ],
-        rowClick: async function (e, row) {
-            const data = row.getData();
-            AppState.resources.selected = data;
-            renderDetail(data);
-            showDetail();
-            // GetVNet으로 subnet 등 상세 정보 추가 로드
-            try {
-                const detail = await vpcApi().get(AppState.ns, data.name);
-                if (detail) {
-                    AppState.resources.selected = detail;
-                    renderDetail(detail);
-                }
-            } catch (err) {
-                console.error('VNet 상세 조회 실패:', err);
+    });
+
+    AppState.tables.vnetTable.on('rowClick', async function (e, row) {
+        const data = row.getData();
+        AppState.resources.selected = data;
+        renderDetail(data);
+        showDetail();
+        // GetVNet으로 subnet 등 상세 정보 추가 로드
+        try {
+            const detail = await vpcApi().get(AppState.ns, data.name);
+            if (detail) {
+                AppState.resources.selected = detail;
+                renderDetail(detail);
             }
-        },
+        } catch (err) {
+            console.error('VNet 상세 조회 실패:', err);
+        }
     });
 }
 

--- a/front/assets/js/pages/settings/environment/cloudresources/networks.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/networks.js
@@ -4,26 +4,34 @@
 import { TabulatorFull as Tabulator } from "tabulator-tables";
 import { showToast, TOAST_TYPES } from "../../../../common/utils/toast.js";
 
-const vpcApi  = () => webconsolejs["common/api/services/vpc_api"];
+const vpcApi    = () => webconsolejs["common/api/services/vpc_api"];
 const importApi = () => webconsolejs["common/api/services/import_api"];
 
 // ─── 상태 ─────────────────────────────────────────────────────────────────
-let _currentNsId = null;
-let _allVNets    = [];   // 전체 목록 캐시 (필터 적용 전)
-let _table       = null; // Tabulator 인스턴스
+const AppState = {
+    ns: '',
+    tables: { vnetTable: null },
+};
+
 let _unmanagedVNets = [];
 
 // ─── 페이지 초기화 ────────────────────────────────────────────────────────
 
-document.addEventListener("DOMContentLoaded", async function () {
-    _currentNsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
+// 프로젝트 변경 시 재조회
+$('#select-current-project').on('change', async function () {
+    if (this.value === '') return;
+    const project = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
+    AppState.ns = project?.NsId || '';
+    if (AppState.ns) await loadVNetList();
+});
 
+document.addEventListener('DOMContentLoaded', async function () {
     // page-header: + Create VPC 버튼
     const btnList = document.getElementById('page-header-btn-list');
     if (btnList) {
         btnList.innerHTML = `
-            <button type="button" class="btn btn-primary" id="create-vpc-btn"
-              onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].openCreateVNetModal()">
+            <button type="button" class="btn btn-primary"
+              data-bs-toggle="modal" data-bs-target="#create-vpc-modal">
               <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
                 viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
                 stroke-linecap="round" stroke-linejoin="round">
@@ -34,118 +42,97 @@ document.addEventListener("DOMContentLoaded", async function () {
             </button>`;
     }
 
-    // 테이블 toolbar 버튼 상태 초기화
-    _syncToolbarState();
+    const selectedWorkspaceProject = await webconsolejs['partials/layout/navbar'].workspaceProjectInit();
+    webconsolejs['partials/layout/modal'].checkWorkspaceSelection(selectedWorkspaceProject);
 
-    // VNet 목록 로드
-    if (_currentNsId) {
+    AppState.ns = selectedWorkspaceProject.nsId || '';
+    initFilter();
+
+    if (selectedWorkspaceProject.projectId !== '') {
         await loadVNetList();
     }
-
-    // 프로젝트 변경 시 재조회
-    document.getElementById('select-current-project')?.addEventListener('change', async () => {
-        _currentNsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
-        _syncToolbarState();
-        if (_currentNsId) await loadVNetList();
-    });
 });
-
-function _syncToolbarState() {
-    const importBtn = document.getElementById('import-vnet-btn');
-    const createBtn = document.getElementById('create-vpc-btn');
-    if (importBtn) {
-        importBtn.disabled = !_currentNsId;
-        importBtn.title = _currentNsId ? 'CSP 미관리 VNet 임포트' : '프로젝트를 먼저 선택하세요';
-    }
-    if (createBtn) {
-        createBtn.disabled = !_currentNsId;
-    }
-}
 
 // ─── VNet 목록 로드 ──────────────────────────────────────────────────────
 
 export async function loadVNetList() {
-    _currentNsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
-    if (!_currentNsId) return;
+    if (!AppState.ns) return;
     try {
-        const data = await vpcApi().getAllVNet(_currentNsId);
-        _allVNets = data?.vNet || (Array.isArray(data) ? data : []);
-        renderFilterConnections(_allVNets);
-        renderVNetTable(_allVNets);
+        const data = await vpcApi().getAllVNet(AppState.ns);
+        const vNets = data?.vNet || (Array.isArray(data) ? data : []);
+        if (AppState.tables.vnetTable) {
+            AppState.tables.vnetTable.replaceData(vNets);
+        } else {
+            initTable(vNets);
+        }
     } catch (err) {
         console.error('VNet 목록 조회 실패:', err);
         showToast(TOAST_TYPES.ERROR, 'VNet 목록 조회에 실패했습니다.');
     }
 }
 
-// ─── 테이블 Filter ────────────────────────────────────────────────────────
+// ─── Tabulator 테이블 ─────────────────────────────────────────────────────
 
-function renderFilterConnections(vNets) {
-    const sel = document.getElementById('filter-connection');
-    if (!sel) return;
-    const current = sel.value;
-    const connections = [...new Set(vNets.map(v => v.connectionName).filter(Boolean))].sort();
-    sel.innerHTML = '<option value="">전체</option>' +
-        connections.map(c => `<option value="${c}"${c === current ? ' selected' : ''}>${c}</option>`).join('');
-}
-
-export function applyFilter() {
-    const connFilter = document.getElementById('filter-connection')?.value || '';
-    const nameFilter = (document.getElementById('filter-name')?.value || '').toLowerCase();
-    const filtered = _allVNets.filter(v => {
-        const matchConn = !connFilter || v.connectionName === connFilter;
-        const matchName = !nameFilter || (v.name || '').toLowerCase().includes(nameFilter);
-        return matchConn && matchName;
-    });
-    _table?.setData(filtered);
-}
-
-// ─── Tabulator 테이블 렌더링 ──────────────────────────────────────────────
-
-function renderVNetTable(vNets) {
-    if (_table) {
-        _table.setData(vNets);
-        return;
-    }
-    _table = new Tabulator("#vnet-list-table", {
+function initTable(vNets) {
+    AppState.tables.vnetTable = new Tabulator('#vnet-list-table', {
         data: vNets,
-        layout: "fitColumns",
-        placeholder: "등록된 VNet이 없습니다.",
-        pagination: true,
+        layout: 'fitColumns',
+        placeholder: '등록된 VNet이 없습니다.',
+        pagination: 'local',
         paginationSize: 10,
         paginationSizeSelector: [10, 20, 50],
+        paginationCounter: 'rows',
+        movableColumns: true,
+        initialSort: [{ column: 'name', dir: 'asc' }],
         columns: [
-            { title: "이름",           field: "name",           widthGrow: 2, sorter: "string" },
-            { title: "Connection",     field: "connectionName", widthGrow: 1, sorter: "string" },
-            { title: "CIDR",           field: "cidrBlock",      widthGrow: 1 },
-            { title: "Subnet 수",      field: "subnetInfoList",
+            { title: '이름',           field: 'name',           widthGrow: 2, sorter: 'string' },
+            { title: 'Connection',     field: 'connectionName', widthGrow: 1, sorter: 'string' },
+            { title: 'CIDR',           field: 'cidrBlock',      widthGrow: 1 },
+            { title: 'Subnet 수',      field: 'subnetInfoList',
               formatter: (cell) => `${(cell.getValue() || []).length}개`,
-              hozAlign: "center", width: 100 },
-            { title: "CSP Resource ID", field: "cspResourceId", widthGrow: 2 },
+              hozAlign: 'center', width: 100 },
+            { title: 'CSP Resource ID', field: 'cspResourceId', widthGrow: 2 },
         ],
+    });
+}
+
+// ─── Filter (Tabulator 내장 setFilter) ───────────────────────────────────
+
+function initFilter() {
+    const fieldEl = document.getElementById('filter-field');
+    const typeEl  = document.getElementById('filter-type');
+    const valueEl = document.getElementById('filter-value');
+    if (!fieldEl || !typeEl || !valueEl) return;
+
+    function updateFilter() {
+        const field = fieldEl.value;
+        const type  = typeEl.value;
+        if (field && AppState.tables.vnetTable) {
+            AppState.tables.vnetTable.setFilter(field, type, valueEl.value);
+        }
+    }
+
+    fieldEl.addEventListener('change', updateFilter);
+    typeEl.addEventListener('change', updateFilter);
+    valueEl.addEventListener('keyup', updateFilter);
+
+    document.getElementById('filter-clear').addEventListener('click', function () {
+        fieldEl.value = '';
+        typeEl.value  = 'like';
+        valueEl.value = '';
+        if (AppState.tables.vnetTable) AppState.tables.vnetTable.clearFilter();
     });
 }
 
 // ─── Create VPC 모달 ─────────────────────────────────────────────────────
 
-export async function openCreateVNetModal() {
-    _currentNsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
-    if (!_currentNsId) {
-        showToast(TOAST_TYPES.WARNING, '프로젝트를 먼저 선택하세요.');
-        return;
-    }
-
-    // 폼 초기화
+document.getElementById('create-vpc-modal')?.addEventListener('show.bs.modal', async function () {
     document.getElementById('create-vpc-name').value = '';
     document.getElementById('create-vpc-cidr').value = '';
     document.getElementById('create-vpc-subnet-list').innerHTML = '';
-
     await _loadConnectionOptions('create-vpc-connection');
-    // 기본 subnet row 1개 추가
     addSubnetRow();
-
-    new bootstrap.Modal(document.getElementById('create-vpc-modal')).show();
-}
+});
 
 export function addSubnetRow() {
     const list = document.getElementById('create-vpc-subnet-list');
@@ -170,31 +157,28 @@ export function addSubnetRow() {
 
 export async function executeCreateVNet() {
     const connectionName = document.getElementById('create-vpc-connection').value;
-    const name = document.getElementById('create-vpc-name').value.trim();
-    const cidrBlock = document.getElementById('create-vpc-cidr').value.trim();
+    const name           = document.getElementById('create-vpc-name').value.trim();
+    const cidrBlock      = document.getElementById('create-vpc-cidr').value.trim();
 
     if (!connectionName || !name || !cidrBlock) {
         showToast(TOAST_TYPES.WARNING, 'Connection, VPC 이름, CIDR은 필수입니다.');
         return;
     }
 
-    // Subnet 목록 수집
     const subnetInfoList = [];
     document.querySelectorAll('#create-vpc-subnet-list .subnet-row').forEach(row => {
         const subName = row.querySelector('.subnet-name')?.value.trim();
         const subCidr = row.querySelector('.subnet-cidr')?.value.trim();
-        if (subName && subCidr) {
-            subnetInfoList.push({ name: subName, ipv4_cidr: subCidr });
-        }
+        if (subName && subCidr) subnetInfoList.push({ name: subName, ipv4_cidr: subCidr });
     });
 
     const spinner = document.getElementById('create-vpc-spinner');
-    const btn = document.getElementById('create-vpc-execute-btn');
+    const btn     = document.getElementById('create-vpc-execute-btn');
     spinner.classList.remove('d-none');
     btn.disabled = true;
 
     try {
-        await vpcApi().create(_currentNsId, { connectionName, name, cidrBlock, subnetInfoList });
+        await vpcApi().create(AppState.ns, { connectionName, name, cidrBlock, subnetInfoList });
         showToast(TOAST_TYPES.SUCCESS, `VPC "${name}" 생성 완료`);
         bootstrap.Modal.getInstance(document.getElementById('create-vpc-modal'))?.hide();
         await loadVNetList();
@@ -210,20 +194,20 @@ export async function executeCreateVNet() {
 // ─── Import VNet 모달 ─────────────────────────────────────────────────────
 
 export async function openImportVNetModal() {
-    _currentNsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
-    if (!_currentNsId) {
+    const project = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
+    AppState.ns = project?.NsId || '';
+    if (!AppState.ns) {
         showToast(TOAST_TYPES.WARNING, '프로젝트를 먼저 선택하세요.');
         return;
     }
 
-    document.getElementById('import-vnet-project').value = _currentNsId;
+    document.getElementById('import-vnet-project').value = AppState.ns;
     document.getElementById('import-vnet-list-area').classList.add('d-none');
     document.getElementById('import-vnet-empty').classList.add('d-none');
     document.getElementById('import-vnet-tbody').innerHTML = '';
     _unmanagedVNets = [];
 
     await _loadConnectionOptions('import-vnet-connection');
-
     new bootstrap.Modal(document.getElementById('import-vnet-modal')).show();
 }
 
@@ -231,8 +215,8 @@ async function _loadConnectionOptions(selectId) {
     const select = document.getElementById(selectId);
     select.innerHTML = '<option value="">선택하세요</option>';
     try {
-        const result = await webconsolejs["common/api/http"].commonAPIPost(
-            "/api/mc-infra-manager/GetConnConfigList", {}
+        const result = await webconsolejs['common/api/http'].commonAPIPost(
+            '/api/mc-infra-manager/GetConnConfigList', {}
         );
         const list = result?.data?.responseData?.connectionconfig || [];
         for (const conn of list) {
@@ -260,15 +244,15 @@ export async function loadUnmanagedVNets() {
     try {
         const [cspVNets, registeredVNets] = await Promise.all([
             importApi().getCspVNets(connectionName),
-            importApi().getRegisteredVNets(_currentNsId),
+            importApi().getRegisteredVNets(AppState.ns),
         ]);
 
         const registeredIds = new Set(registeredVNets.map(v => v.cspResourceId));
         const unmanaged = cspVNets.filter(v => !registeredIds.has(v.id || v.cspResourceId));
-        const alreadyManaged = cspVNets.filter(v => registeredIds.has(v.id || v.cspResourceId));
+        const managed   = cspVNets.filter(v =>  registeredIds.has(v.id || v.cspResourceId));
 
         _unmanagedVNets = unmanaged;
-        _renderUnmanagedVNetTable(unmanaged, alreadyManaged);
+        _renderUnmanagedVNetTable(unmanaged, managed);
     } catch (err) {
         console.error('미관리 VNet 조회 실패:', err);
         showToast(TOAST_TYPES.ERROR, '미관리 VNet 조회에 실패했습니다: ' + (err.message || ''));
@@ -297,7 +281,6 @@ function _renderUnmanagedVNetTable(unmanaged, managed) {
             <td><span class="badge bg-warning-lt">● 미관리</span></td>`;
         tbody.appendChild(tr);
     }
-
     for (const v of managed) {
         const tr = document.createElement('tr');
         tr.className = 'text-muted';
@@ -311,7 +294,6 @@ function _renderUnmanagedVNetTable(unmanaged, managed) {
     }
 
     document.getElementById('import-vnet-list-area').classList.remove('d-none');
-
     document.getElementById('import-vnet-select-all').onchange = function () {
         document.querySelectorAll('.import-vnet-check').forEach(cb => cb.checked = this.checked);
     };
@@ -327,25 +309,18 @@ export async function executeImportVNets() {
     }
 
     const spinner = document.getElementById('import-vnet-spinner');
-    const btn = document.getElementById('import-vnet-execute-btn');
+    const btn     = document.getElementById('import-vnet-execute-btn');
     spinner.classList.remove('d-none');
     btn.disabled = true;
 
     let successCount = 0, skipCount = 0, failCount = 0;
-
     for (const cb of checked) {
-        const cspResourceId = cb.dataset.id;
-        const name = cb.dataset.name;
         try {
-            await importApi().registerCspVNet(_currentNsId, connectionName, cspResourceId, name);
+            await importApi().registerCspVNet(AppState.ns, connectionName, cb.dataset.id, cb.dataset.name);
             successCount++;
         } catch (err) {
-            if (err.response?.status === 409) {
-                skipCount++;
-            } else {
-                failCount++;
-                console.error(`VNet ${name} 등록 실패:`, err);
-            }
+            err.response?.status === 409 ? skipCount++ : failCount++;
+            if (err.response?.status !== 409) console.error(`VNet ${cb.dataset.name} 등록 실패:`, err);
         }
     }
 
@@ -355,21 +330,19 @@ export async function executeImportVNets() {
     let msg = `VNet ${successCount}개 등록 완료`;
     if (skipCount > 0) msg += `, ${skipCount}개 이미 등록됨`;
     if (failCount > 0) msg += `, ${failCount}개 실패`;
-
     showToast(failCount > 0 ? TOAST_TYPES.WARNING : TOAST_TYPES.SUCCESS, msg);
+
     bootstrap.Modal.getInstance(document.getElementById('import-vnet-modal'))?.hide();
     await loadVNetList();
 }
 
 // ─── webconsolejs 등록 ────────────────────────────────────────────────────
-if (typeof webconsolejs === "undefined") { window.webconsolejs = {}; }
-webconsolejs["pages/settings/environment/cloudresources/networks"] = {
+if (typeof webconsolejs === 'undefined') { window.webconsolejs = {}; }
+webconsolejs['pages/settings/environment/cloudresources/networks'] = {
     loadVNetList,
-    applyFilter,
-    openCreateVNetModal,
-    addSubnetRow,
-    executeCreateVNet,
     openImportVNetModal,
     loadUnmanagedVNets,
     executeImportVNets,
+    addSubnetRow,
+    executeCreateVNet,
 };

--- a/front/assets/js/pages/settings/environment/cloudresources/networks.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/networks.js
@@ -11,6 +11,8 @@ const importApi = () => webconsolejs["common/api/services/import_api"];
 const AppState = {
     ns: '',
     tables: { vnetTable: null },
+    resources: { selected: null },
+    ui: { viewMode: false },
 };
 
 let _unmanagedVNets = [];
@@ -93,7 +95,84 @@ function initTable(vNets) {
               hozAlign: 'center', width: 100 },
             { title: 'CSP Resource ID', field: 'cspResourceId', widthGrow: 2 },
         ],
+        rowClick: async function (e, row) {
+            const data = row.getData();
+            AppState.resources.selected = data;
+            renderDetail(data);
+            showDetail();
+            // GetVNet으로 subnet 등 상세 정보 추가 로드
+            try {
+                const detail = await vpcApi().get(AppState.ns, data.name);
+                if (detail) {
+                    AppState.resources.selected = detail;
+                    renderDetail(detail);
+                }
+            } catch (err) {
+                console.error('VNet 상세 조회 실패:', err);
+            }
+        },
     });
+}
+
+// ─── Detail Panel ─────────────────────────────────────────────────────────
+
+function renderDetail(data) {
+    document.getElementById('detail-name').textContent      = data.name || '-';
+    document.getElementById('detail-vnet-name').textContent = data.name || '-';
+    document.getElementById('detail-vnet-connection').textContent = data.connectionName || '-';
+    document.getElementById('detail-vnet-cidr').textContent = data.cidrBlock || '-';
+    document.getElementById('detail-vnet-csp-id').textContent = data.cspResourceId || '-';
+
+    const subnets = data.subnetInfoList || [];
+    const tbody = document.getElementById('detail-subnet-tbody');
+    const emptyEl = document.getElementById('detail-subnet-empty');
+    const tableWrap = document.getElementById('detail-subnet-table-wrap');
+
+    tbody.innerHTML = '';
+    if (subnets.length === 0) {
+        emptyEl.classList.remove('d-none');
+        tableWrap.classList.add('d-none');
+    } else {
+        emptyEl.classList.add('d-none');
+        tableWrap.classList.remove('d-none');
+        for (const s of subnets) {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>${s.name || '-'}</td>
+                <td>${s.ipv4_cidr || s.ipv4CIDR || s.cidr || '-'}</td>
+                <td>${s.zone || '-'}</td>
+                <td><code>${s.cspResourceId || '-'}</code></td>`;
+            tbody.appendChild(tr);
+        }
+    }
+}
+
+function showDetail() {
+    const el = document.getElementById('view-mode-cards');
+    if (el) el.classList.add('show');
+    AppState.ui.viewMode = true;
+}
+
+export function hideDetail() {
+    const el = document.getElementById('view-mode-cards');
+    if (el) el.classList.remove('show');
+    AppState.ui.viewMode = false;
+    AppState.resources.selected = null;
+}
+
+export async function confirmDeleteVNet() {
+    const selected = AppState.resources.selected;
+    if (!selected) return;
+    if (!confirm(`VPC "${selected.name}"을 삭제하시겠습니까?`)) return;
+    try {
+        await vpcApi().del(AppState.ns, selected.name);
+        showToast(TOAST_TYPES.SUCCESS, `VPC "${selected.name}" 삭제 완료`);
+        hideDetail();
+        await loadVNetList();
+    } catch (err) {
+        console.error('VPC 삭제 실패:', err);
+        showToast(TOAST_TYPES.ERROR, 'VPC 삭제에 실패했습니다: ' + (err.message || ''));
+    }
 }
 
 // ─── Filter (Tabulator 내장 setFilter) ───────────────────────────────────
@@ -345,4 +424,6 @@ webconsolejs['pages/settings/environment/cloudresources/networks'] = {
     executeImportVNets,
     addSubnetRow,
     executeCreateVNet,
+    hideDetail,
+    confirmDeleteVNet,
 };

--- a/front/assets/js/pages/settings/environment/cloudresources/networks.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/networks.js
@@ -155,10 +155,159 @@ function showDetail() {
 }
 
 export function hideDetail() {
-    const el = document.getElementById('view-mode-cards');
-    if (el) el.classList.remove('show');
+    document.getElementById('view-mode-cards')?.classList.remove('show');
+    document.getElementById('edit-mode-cards')?.classList.remove('show');
     AppState.ui.viewMode = false;
+    AppState.ui.editMode = false;
     AppState.resources.selected = null;
+}
+
+// ─── Edit Mode ────────────────────────────────────────────────────────────
+
+export function showEditMode() {
+    const selected = AppState.resources.selected;
+    if (!selected) return;
+
+    // read-only 필드 채우기
+    document.getElementById('edit-name').textContent       = selected.name || '';
+    document.getElementById('edit-vnet-name').value        = selected.name || '';
+    document.getElementById('edit-vnet-connection').value  = selected.connectionName || '';
+    document.getElementById('edit-vnet-cidr').value        = selected.cidrBlock || '';
+
+    // 기존 Subnet 행 렌더링
+    _renderEditSubnetTable(selected.subnetInfoList || []);
+    document.getElementById('edit-new-subnet-list').innerHTML = '';
+
+    // 모드 전환
+    document.getElementById('view-mode-cards')?.classList.remove('show');
+    document.getElementById('edit-mode-cards')?.classList.add('show');
+    AppState.ui.viewMode = false;
+    AppState.ui.editMode = true;
+}
+
+export function cancelEditMode() {
+    document.getElementById('edit-mode-cards')?.classList.remove('show');
+    document.getElementById('view-mode-cards')?.classList.add('show');
+    AppState.ui.editMode = false;
+    AppState.ui.viewMode = true;
+}
+
+function _renderEditSubnetTable(subnets) {
+    const tbody = document.getElementById('edit-subnet-tbody');
+    tbody.innerHTML = '';
+    for (const s of subnets) {
+        const tr = document.createElement('tr');
+        tr.dataset.subnetId = s.name;
+        tr.innerHTML = `
+            <td>${s.name || '-'}</td>
+            <td>${s.ipv4_cidr || s.ipv4CIDR || s.cidr || '-'}</td>
+            <td>${s.zone || '-'}</td>
+            <td><code>${s.cspResourceId || '-'}</code></td>
+            <td>
+              <button type="button" class="btn btn-sm btn-outline-danger"
+                onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].deleteSubnet('${s.name}')">
+                삭제
+              </button>
+            </td>`;
+        tbody.appendChild(tr);
+    }
+}
+
+export function addEditSubnetRow() {
+    const list = document.getElementById('edit-new-subnet-list');
+    const idx = list.children.length;
+    const row = document.createElement('div');
+    row.className = 'row g-2 mb-2 align-items-center new-subnet-row';
+    row.innerHTML = `
+        <div class="col-md-4">
+          <input type="text" class="form-control form-control-sm new-subnet-name"
+            placeholder="Subnet 이름 (예: subnet-${idx + 1})">
+        </div>
+        <div class="col-md-4">
+          <input type="text" class="form-control form-control-sm new-subnet-cidr"
+            placeholder="CIDR (예: 10.0.${idx}.0/24)">
+        </div>
+        <div class="col-md-3">
+          <input type="text" class="form-control form-control-sm new-subnet-zone"
+            placeholder="Zone (선택)">
+        </div>
+        <div class="col-md-1">
+          <button type="button" class="btn btn-sm btn-outline-danger w-100"
+            onclick="this.closest('.new-subnet-row').remove()">✕</button>
+        </div>`;
+    list.appendChild(row);
+}
+
+export async function deleteSubnet(subnetId) {
+    const vnetName = AppState.resources.selected?.name;
+    if (!vnetName || !subnetId) return;
+    if (!confirm(`Subnet "${subnetId}"을 삭제하시겠습니까?`)) return;
+    try {
+        await vpcApi().delSubnet(AppState.ns, vnetName, subnetId);
+        showToast(TOAST_TYPES.SUCCESS, `Subnet "${subnetId}" 삭제 완료`);
+        // 상태 업데이트 및 UI 갱신
+        const detail = await vpcApi().get(AppState.ns, vnetName);
+        if (detail) {
+            AppState.resources.selected = detail;
+            _renderEditSubnetTable(detail.subnetInfoList || []);
+        }
+    } catch (err) {
+        console.error('Subnet 삭제 실패:', err);
+        showToast(TOAST_TYPES.ERROR, 'Subnet 삭제에 실패했습니다: ' + (err.message || ''));
+    }
+}
+
+export async function saveVNet() {
+    const vnetName = AppState.resources.selected?.name;
+    if (!vnetName) return;
+
+    const newRows = Array.from(document.querySelectorAll('#edit-new-subnet-list .new-subnet-row'));
+    const toAdd = newRows
+        .map(row => ({
+            name:      row.querySelector('.new-subnet-name')?.value.trim(),
+            ipv4_cidr: row.querySelector('.new-subnet-cidr')?.value.trim(),
+            zone:      row.querySelector('.new-subnet-zone')?.value.trim() || undefined,
+        }))
+        .filter(s => s.name && s.ipv4_cidr);
+
+    if (toAdd.length === 0) {
+        showToast(TOAST_TYPES.WARNING, '추가할 Subnet이 없습니다.');
+        return;
+    }
+
+    const spinner = document.getElementById('edit-save-spinner');
+    const btn = document.querySelector('#edit-mode-cards .btn-primary');
+    spinner?.classList.remove('d-none');
+    if (btn) btn.disabled = true;
+
+    let successCount = 0, failCount = 0;
+    for (const subnet of toAdd) {
+        try {
+            await vpcApi().createSubnet(AppState.ns, vnetName, subnet);
+            successCount++;
+        } catch (err) {
+            failCount++;
+            console.error(`Subnet ${subnet.name} 추가 실패:`, err);
+        }
+    }
+
+    spinner?.classList.add('d-none');
+    if (btn) btn.disabled = false;
+
+    if (failCount > 0) {
+        showToast(TOAST_TYPES.WARNING, `${successCount}개 추가 완료, ${failCount}개 실패`);
+    } else {
+        showToast(TOAST_TYPES.SUCCESS, `Subnet ${successCount}개 추가 완료`);
+    }
+
+    // 상세 갱신 후 view 모드로 복귀
+    const detail = await vpcApi().get(AppState.ns, vnetName);
+    if (detail) {
+        AppState.resources.selected = detail;
+        renderDetail(detail);
+    }
+    cancelEditMode();
+    await loadVNetList();
 }
 
 export async function confirmDeleteVNet() {
@@ -427,4 +576,9 @@ webconsolejs['pages/settings/environment/cloudresources/networks'] = {
     executeCreateVNet,
     hideDetail,
     confirmDeleteVNet,
+    showEditMode,
+    cancelEditMode,
+    addEditSubnetRow,
+    deleteSubnet,
+    saveVNet,
 };

--- a/front/assets/js/pages/settings/environment/cloudresources/networks.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/networks.js
@@ -1,70 +1,218 @@
-// VNet(VPC) 관리 페이지 — Import 기능 포함
-// RQ-CLOUD-ADMIN-007 / UC-IMPORT-002
+// VNet(VPC) 관리 페이지 — Create / Import / Filter 기능
+// FR-CLOUD-ADMIN-003-01 / RQ-CLOUD-ADMIN-007
 
 import { TabulatorFull as Tabulator } from "tabulator-tables";
 import { showToast, TOAST_TYPES } from "../../../../common/utils/toast.js";
 
+const vpcApi  = () => webconsolejs["common/api/services/vpc_api"];
 const importApi = () => webconsolejs["common/api/services/import_api"];
 
-// 상태
-let _unmanagedVNets = [];  // 조회된 미관리 VNet 목록
+// ─── 상태 ─────────────────────────────────────────────────────────────────
 let _currentNsId = null;
+let _allVNets    = [];   // 전체 목록 캐시 (필터 적용 전)
+let _table       = null; // Tabulator 인스턴스
+let _unmanagedVNets = [];
 
-// ─── 페이지 초기화 ────────────────────────────────────────────────────
+// ─── 페이지 초기화 ────────────────────────────────────────────────────────
 
 document.addEventListener("DOMContentLoaded", async function () {
     _currentNsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
 
-    // Import VNet 버튼 삽입
+    // page-header: + Create VPC 버튼
     const btnList = document.getElementById('page-header-btn-list');
     if (btnList) {
-        const importBtn = document.createElement('button');
-        importBtn.className = 'btn btn-secondary';
-        importBtn.id = 'import-vnet-btn';
-        importBtn.textContent = 'Import VNet';
-        importBtn.disabled = !_currentNsId;
-        importBtn.title = _currentNsId ? 'CSP 미관리 VNet 임포트' : '프로젝트를 먼저 선택하세요';
-        importBtn.onclick = () => openImportVNetModal();
-        btnList.appendChild(importBtn);
+        btnList.innerHTML = `
+            <button type="button" class="btn btn-primary" id="create-vpc-btn"
+              onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].openCreateVNetModal()">
+              <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
+                viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
+                stroke-linecap="round" stroke-linejoin="round">
+                <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                <path d="M12 5l0 14"/><path d="M5 12l14 0"/>
+              </svg>
+              Create VPC
+            </button>`;
     }
+
+    // 테이블 toolbar 버튼 상태 초기화
+    _syncToolbarState();
 
     // VNet 목록 로드
     if (_currentNsId) {
-        await loadVNetList(_currentNsId);
+        await loadVNetList();
     }
+
+    // 프로젝트 변경 시 재조회
+    document.getElementById('select-current-project')?.addEventListener('change', async () => {
+        _currentNsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
+        _syncToolbarState();
+        if (_currentNsId) await loadVNetList();
+    });
 });
 
-async function loadVNetList(nsId) {
-    try {
-        const vNets = await importApi().getRegisteredVNets(nsId);
-        renderVNetTable(vNets);
-    } catch (err) {
-        console.error('VNet 목록 조회 실패:', err);
+function _syncToolbarState() {
+    const importBtn = document.getElementById('import-vnet-btn');
+    const createBtn = document.getElementById('create-vpc-btn');
+    if (importBtn) {
+        importBtn.disabled = !_currentNsId;
+        importBtn.title = _currentNsId ? 'CSP 미관리 VNet 임포트' : '프로젝트를 먼저 선택하세요';
+    }
+    if (createBtn) {
+        createBtn.disabled = !_currentNsId;
     }
 }
 
+// ─── VNet 목록 로드 ──────────────────────────────────────────────────────
+
+export async function loadVNetList() {
+    _currentNsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
+    if (!_currentNsId) return;
+    try {
+        const data = await vpcApi().getAllVNet(_currentNsId);
+        _allVNets = data?.vNet || (Array.isArray(data) ? data : []);
+        renderFilterConnections(_allVNets);
+        renderVNetTable(_allVNets);
+    } catch (err) {
+        console.error('VNet 목록 조회 실패:', err);
+        showToast(TOAST_TYPES.ERROR, 'VNet 목록 조회에 실패했습니다.');
+    }
+}
+
+// ─── 테이블 Filter ────────────────────────────────────────────────────────
+
+function renderFilterConnections(vNets) {
+    const sel = document.getElementById('filter-connection');
+    if (!sel) return;
+    const current = sel.value;
+    const connections = [...new Set(vNets.map(v => v.connectionName).filter(Boolean))].sort();
+    sel.innerHTML = '<option value="">전체</option>' +
+        connections.map(c => `<option value="${c}"${c === current ? ' selected' : ''}>${c}</option>`).join('');
+}
+
+export function applyFilter() {
+    const connFilter = document.getElementById('filter-connection')?.value || '';
+    const nameFilter = (document.getElementById('filter-name')?.value || '').toLowerCase();
+    const filtered = _allVNets.filter(v => {
+        const matchConn = !connFilter || v.connectionName === connFilter;
+        const matchName = !nameFilter || (v.name || '').toLowerCase().includes(nameFilter);
+        return matchConn && matchName;
+    });
+    _table?.setData(filtered);
+}
+
+// ─── Tabulator 테이블 렌더링 ──────────────────────────────────────────────
+
 function renderVNetTable(vNets) {
-    new Tabulator("#vnet-list-table", {
+    if (_table) {
+        _table.setData(vNets);
+        return;
+    }
+    _table = new Tabulator("#vnet-list-table", {
         data: vNets,
         layout: "fitColumns",
         placeholder: "등록된 VNet이 없습니다.",
+        pagination: true,
+        paginationSize: 10,
+        paginationSizeSelector: [10, 20, 50],
         columns: [
-            { title: "이름", field: "name", widthGrow: 2 },
+            { title: "이름",           field: "name",           widthGrow: 2, sorter: "string" },
+            { title: "Connection",     field: "connectionName", widthGrow: 1, sorter: "string" },
+            { title: "CIDR",           field: "cidrBlock",      widthGrow: 1 },
+            { title: "Subnet 수",      field: "subnetInfoList",
+              formatter: (cell) => `${(cell.getValue() || []).length}개`,
+              hozAlign: "center", width: 100 },
             { title: "CSP Resource ID", field: "cspResourceId", widthGrow: 2 },
-            { title: "Connection", field: "connectionName", widthGrow: 1 },
-            { title: "CIDR", field: "cidrBlock", widthGrow: 1 },
-            { title: "Subnet 수", field: "subnetInfoList",
-              formatter: (cell) => (cell.getValue() || []).length + "개" },
         ],
     });
 }
 
-// ─── Import VNet 모달 ─────────────────────────────────────────────────
+// ─── Create VPC 모달 ─────────────────────────────────────────────────────
+
+export async function openCreateVNetModal() {
+    _currentNsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
+    if (!_currentNsId) {
+        showToast(TOAST_TYPES.WARNING, '프로젝트를 먼저 선택하세요.');
+        return;
+    }
+
+    // 폼 초기화
+    document.getElementById('create-vpc-name').value = '';
+    document.getElementById('create-vpc-cidr').value = '';
+    document.getElementById('create-vpc-subnet-list').innerHTML = '';
+
+    await _loadConnectionOptions('create-vpc-connection');
+    // 기본 subnet row 1개 추가
+    addSubnetRow();
+
+    new bootstrap.Modal(document.getElementById('create-vpc-modal')).show();
+}
+
+export function addSubnetRow() {
+    const list = document.getElementById('create-vpc-subnet-list');
+    const idx = list.children.length;
+    const row = document.createElement('div');
+    row.className = 'row g-2 mb-2 align-items-center subnet-row';
+    row.innerHTML = `
+        <div class="col-md-5">
+          <input type="text" class="form-control form-control-sm subnet-name"
+            placeholder="Subnet 이름 (예: subnet-${idx + 1})">
+        </div>
+        <div class="col-md-5">
+          <input type="text" class="form-control form-control-sm subnet-cidr"
+            placeholder="CIDR (예: 10.0.${idx}.0/24)">
+        </div>
+        <div class="col-md-2">
+          <button type="button" class="btn btn-sm btn-outline-danger w-100"
+            onclick="this.closest('.subnet-row').remove()">삭제</button>
+        </div>`;
+    list.appendChild(row);
+}
+
+export async function executeCreateVNet() {
+    const connectionName = document.getElementById('create-vpc-connection').value;
+    const name = document.getElementById('create-vpc-name').value.trim();
+    const cidrBlock = document.getElementById('create-vpc-cidr').value.trim();
+
+    if (!connectionName || !name || !cidrBlock) {
+        showToast(TOAST_TYPES.WARNING, 'Connection, VPC 이름, CIDR은 필수입니다.');
+        return;
+    }
+
+    // Subnet 목록 수집
+    const subnetInfoList = [];
+    document.querySelectorAll('#create-vpc-subnet-list .subnet-row').forEach(row => {
+        const subName = row.querySelector('.subnet-name')?.value.trim();
+        const subCidr = row.querySelector('.subnet-cidr')?.value.trim();
+        if (subName && subCidr) {
+            subnetInfoList.push({ name: subName, ipv4_cidr: subCidr });
+        }
+    });
+
+    const spinner = document.getElementById('create-vpc-spinner');
+    const btn = document.getElementById('create-vpc-execute-btn');
+    spinner.classList.remove('d-none');
+    btn.disabled = true;
+
+    try {
+        await vpcApi().create(_currentNsId, { connectionName, name, cidrBlock, subnetInfoList });
+        showToast(TOAST_TYPES.SUCCESS, `VPC "${name}" 생성 완료`);
+        bootstrap.Modal.getInstance(document.getElementById('create-vpc-modal'))?.hide();
+        await loadVNetList();
+    } catch (err) {
+        console.error('VPC 생성 실패:', err);
+        showToast(TOAST_TYPES.ERROR, 'VPC 생성에 실패했습니다: ' + (err.message || ''));
+    } finally {
+        spinner.classList.add('d-none');
+        btn.disabled = false;
+    }
+}
+
+// ─── Import VNet 모달 ─────────────────────────────────────────────────────
 
 export async function openImportVNetModal() {
     _currentNsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
     if (!_currentNsId) {
-        alert('프로젝트를 먼저 선택하세요.');
+        showToast(TOAST_TYPES.WARNING, '프로젝트를 먼저 선택하세요.');
         return;
     }
 
@@ -74,13 +222,12 @@ export async function openImportVNetModal() {
     document.getElementById('import-vnet-tbody').innerHTML = '';
     _unmanagedVNets = [];
 
-    // Connection 목록 로드 (CSP 계정에서)
-    await loadConnectionOptions('import-vnet-connection');
+    await _loadConnectionOptions('import-vnet-connection');
 
     new bootstrap.Modal(document.getElementById('import-vnet-modal')).show();
 }
 
-async function loadConnectionOptions(selectId) {
+async function _loadConnectionOptions(selectId) {
     const select = document.getElementById(selectId);
     select.innerHTML = '<option value="">선택하세요</option>';
     try {
@@ -99,14 +246,10 @@ async function loadConnectionOptions(selectId) {
     }
 }
 
-/**
- * 미관리 VNet 조회
- * CSP 전체 VNet - 등록된 VNet = 미관리 VNet
- */
 export async function loadUnmanagedVNets() {
     const connectionName = document.getElementById('import-vnet-connection').value;
     if (!connectionName) {
-        alert('Connection을 선택하세요.');
+        showToast(TOAST_TYPES.WARNING, 'Connection을 선택하세요.');
         return;
     }
 
@@ -125,7 +268,7 @@ export async function loadUnmanagedVNets() {
         const alreadyManaged = cspVNets.filter(v => registeredIds.has(v.id || v.cspResourceId));
 
         _unmanagedVNets = unmanaged;
-        renderUnmanagedVNetTable(unmanaged, alreadyManaged);
+        _renderUnmanagedVNetTable(unmanaged, alreadyManaged);
     } catch (err) {
         console.error('미관리 VNet 조회 실패:', err);
         showToast(TOAST_TYPES.ERROR, '미관리 VNet 조회에 실패했습니다: ' + (err.message || ''));
@@ -134,7 +277,7 @@ export async function loadUnmanagedVNets() {
     }
 }
 
-function renderUnmanagedVNetTable(unmanaged, managed) {
+function _renderUnmanagedVNetTable(unmanaged, managed) {
     const tbody = document.getElementById('import-vnet-tbody');
     tbody.innerHTML = '';
 
@@ -143,20 +286,18 @@ function renderUnmanagedVNetTable(unmanaged, managed) {
         return;
     }
 
-    // 미관리 항목 (선택 가능)
     for (const v of unmanaged) {
         const tr = document.createElement('tr');
         tr.innerHTML = `
-            <td><input type="checkbox" class="form-check-input import-vnet-check" data-id="${v.id || v.cspResourceId}" data-name="${v.name || v.id}" data-cidr="${v.cidrBlock || ''}"></td>
+            <td><input type="checkbox" class="form-check-input import-vnet-check"
+              data-id="${v.id || v.cspResourceId}" data-name="${v.name || v.id}" data-cidr="${v.cidrBlock || ''}"></td>
             <td>${v.name || v.id}</td>
             <td>${v.cidrBlock || '-'}</td>
             <td><code>${v.id || '-'}</code></td>
-            <td><span class="badge bg-warning-lt">● 미관리</span></td>
-        `;
+            <td><span class="badge bg-warning-lt">● 미관리</span></td>`;
         tbody.appendChild(tr);
     }
 
-    // 이미 등록된 항목 (비활성화)
     for (const v of managed) {
         const tr = document.createElement('tr');
         tr.className = 'text-muted';
@@ -165,28 +306,23 @@ function renderUnmanagedVNetTable(unmanaged, managed) {
             <td>${v.name || v.id}</td>
             <td>${v.cidrBlock || '-'}</td>
             <td><code>${v.id || '-'}</code></td>
-            <td><span class="badge bg-success-lt">✓ 등록됨</span></td>
-        `;
+            <td><span class="badge bg-success-lt">✓ 등록됨</span></td>`;
         tbody.appendChild(tr);
     }
 
     document.getElementById('import-vnet-list-area').classList.remove('d-none');
 
-    // 전체 선택 체크박스
     document.getElementById('import-vnet-select-all').onchange = function () {
         document.querySelectorAll('.import-vnet-check').forEach(cb => cb.checked = this.checked);
     };
 }
 
-/**
- * 선택된 VNet Import 실행
- */
 export async function executeImportVNets() {
     const connectionName = document.getElementById('import-vnet-connection').value;
     const checked = Array.from(document.querySelectorAll('.import-vnet-check:checked'));
 
     if (checked.length === 0) {
-        alert('Import할 VNet을 선택하세요.');
+        showToast(TOAST_TYPES.WARNING, 'Import할 VNet을 선택하세요.');
         return;
     }
 
@@ -195,9 +331,7 @@ export async function executeImportVNets() {
     spinner.classList.remove('d-none');
     btn.disabled = true;
 
-    let successCount = 0;
-    let skipCount = 0;
-    let failCount = 0;
+    let successCount = 0, skipCount = 0, failCount = 0;
 
     for (const cb of checked) {
         const cspResourceId = cb.dataset.id;
@@ -222,16 +356,19 @@ export async function executeImportVNets() {
     if (skipCount > 0) msg += `, ${skipCount}개 이미 등록됨`;
     if (failCount > 0) msg += `, ${failCount}개 실패`;
 
-    const toastType = failCount > 0 ? TOAST_TYPES.WARNING : TOAST_TYPES.SUCCESS;
-    showToast(toastType, msg);
-
+    showToast(failCount > 0 ? TOAST_TYPES.WARNING : TOAST_TYPES.SUCCESS, msg);
     bootstrap.Modal.getInstance(document.getElementById('import-vnet-modal'))?.hide();
-    await loadVNetList(_currentNsId);
+    await loadVNetList();
 }
 
-// webconsolejs 등록
+// ─── webconsolejs 등록 ────────────────────────────────────────────────────
 if (typeof webconsolejs === "undefined") { window.webconsolejs = {}; }
 webconsolejs["pages/settings/environment/cloudresources/networks"] = {
+    loadVNetList,
+    applyFilter,
+    openCreateVNetModal,
+    addSubnetRow,
+    executeCreateVNet,
     openImportVNetModal,
     loadUnmanagedVNets,
     executeImportVNets,

--- a/front/assets/js/pages/settings/environment/cloudresources/securitygroups.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/securitygroups.js
@@ -6,6 +6,7 @@ import { showToast, TOAST_TYPES } from "../../../../common/utils/toast.js";
 
 const sgApi     = () => webconsolejs["common/api/services/securitygroup_api"];
 const importApi = () => webconsolejs["common/api/services/import_api"];
+const vpcApi    = () => webconsolejs["common/api/services/vpc_api"];
 
 // ─── 상태 ─────────────────────────────────────────────────────────────────
 const AppState = {
@@ -211,9 +212,9 @@ function initFilter() {
 
 document.getElementById('create-sg-modal')?.addEventListener('show.bs.modal', async function () {
     document.getElementById('create-sg-name').value = '';
-    document.getElementById('create-sg-vnet').value = '';
+    document.getElementById('create-sg-connection-display').value = '';
     document.getElementById('create-sg-rule-list').innerHTML = '';
-    await _loadConnectionOptions('create-sg-connection');
+    await _loadVNetOptions('create-sg-vnet-select', AppState.ns);
     addFirewallRuleRow();
 });
 
@@ -256,12 +257,13 @@ export function addFirewallRuleRow() {
 }
 
 export async function executeCreateSG() {
-    const connectionName = document.getElementById('create-sg-connection').value;
+    const vNetEl         = document.getElementById('create-sg-vnet-select');
+    const vNetId         = vNetEl?.value || '';
+    const connectionName = document.getElementById('create-sg-connection-display').value.trim();
     const name           = document.getElementById('create-sg-name').value.trim();
-    const vNetId         = document.getElementById('create-sg-vnet').value.trim();
 
-    if (!connectionName || !name || !vNetId) {
-        showToast(TOAST_TYPES.WARNING, 'Connection, SG 이름, VPC 이름은 필수입니다.');
+    if (!vNetId || !connectionName || !name) {
+        showToast(TOAST_TYPES.WARNING, 'VPC 선택과 SG 이름은 필수입니다.');
         return;
     }
 
@@ -333,6 +335,37 @@ export async function executeImportSG() {
         showToast(TOAST_TYPES.ERROR, 'SecurityGroup Import 실패: ' + (err.message || ''));
     } finally {
         spinner.classList.add('d-none');
+    }
+}
+
+async function _loadVNetOptions(selectId, ns) {
+    const select = document.getElementById(selectId);
+    select.innerHTML = '<option value="">-- VPC 선택 --</option>';
+    if (!ns) return;
+    try {
+        const data  = await vpcApi().getAllVNet(ns);
+        const vNets = data?.vNet || (Array.isArray(data) ? data : []);
+        if (vNets.length === 0) {
+            const opt = document.createElement('option');
+            opt.disabled = true;
+            opt.textContent = '등록된 VPC가 없습니다.';
+            select.appendChild(opt);
+            return;
+        }
+        for (const v of vNets) {
+            const opt = document.createElement('option');
+            opt.value = v.name;
+            opt.dataset.connection = v.connectionName || '';
+            opt.textContent = `${v.name} (${v.connectionName || '-'})`;
+            select.appendChild(opt);
+        }
+        select.onchange = function () {
+            const chosen = this.options[this.selectedIndex];
+            document.getElementById('create-sg-connection-display').value =
+                chosen?.dataset?.connection || '';
+        };
+    } catch (err) {
+        console.error('VPC 목록 로드 실패:', err);
     }
 }
 

--- a/front/assets/js/pages/settings/environment/cloudresources/securitygroups.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/securitygroups.js
@@ -1,50 +1,334 @@
-// SecurityGroup 관리 페이지 — Import 기능 (Connection 단위)
-// RQ-CLOUD-ADMIN-007 / UC-IMPORT-003
+// SecurityGroup 관리 페이지 — CRUD + Import
+// FR-CLOUD-ADMIN-003-02 / RQ-CLOUD-ADMIN-007
 
+import { TabulatorFull as Tabulator } from "tabulator-tables";
 import { showToast, TOAST_TYPES } from "../../../../common/utils/toast.js";
 
+const sgApi     = () => webconsolejs["common/api/services/securitygroup_api"];
 const importApi = () => webconsolejs["common/api/services/import_api"];
 
-let _nsId = null;
+// ─── 상태 ─────────────────────────────────────────────────────────────────
+const AppState = {
+    ns: '',
+    tables: { sgTable: null },
+    resources: { selected: null },
+    ui: { viewMode: false },
+};
 
-document.addEventListener("DOMContentLoaded", async function () {
-    _nsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
+// ─── 페이지 초기화 ────────────────────────────────────────────────────────
 
+$('#select-current-project').on('change', async function () {
+    if (this.value === '') return;
+    const project = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
+    AppState.ns = project?.NsId || '';
+    if (AppState.ns) await loadSGList();
+});
+
+document.addEventListener('DOMContentLoaded', async function () {
     const btnList = document.getElementById('page-header-btn-list');
     if (btnList) {
-        const btn = document.createElement('button');
-        btn.className = 'btn btn-secondary';
-        btn.textContent = 'Import SecurityGroup';
-        btn.disabled = !_nsId;
-        btn.title = _nsId ? 'CSP 미관리 SecurityGroup 임포트' : '프로젝트를 먼저 선택하세요';
-        btn.onclick = () => openImportSGModal();
-        btnList.appendChild(btn);
+        btnList.innerHTML = `
+            <button type="button" class="btn btn-primary"
+              data-bs-toggle="modal" data-bs-target="#create-sg-modal">
+              <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
+                viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
+                stroke-linecap="round" stroke-linejoin="round">
+                <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                <path d="M12 5l0 14"/><path d="M5 12l14 0"/>
+              </svg>
+              Create SG
+            </button>`;
+    }
+
+    const selectedWorkspaceProject = await webconsolejs['partials/layout/navbar'].workspaceProjectInit();
+    webconsolejs['partials/layout/modal'].checkWorkspaceSelection(selectedWorkspaceProject);
+
+    AppState.ns = selectedWorkspaceProject.nsId || '';
+    initFilter();
+
+    if (selectedWorkspaceProject.projectId !== '') {
+        await loadSGList();
     }
 });
 
-export async function openImportSGModal() {
-    _nsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
-    if (!_nsId) { alert('프로젝트를 먼저 선택하세요.'); return; }
+// ─── SG 목록 로드 ─────────────────────────────────────────────────────────
 
-    document.getElementById('import-sg-project').value = _nsId;
-    await loadConnectionSelect('import-sg-connection');
+export async function loadSGList() {
+    if (!AppState.ns) return;
+    try {
+        const data = await sgApi().list(AppState.ns);
+        const items = data?.securityGroup || (Array.isArray(data) ? data : []);
+        if (AppState.tables.sgTable) {
+            AppState.tables.sgTable.replaceData(items);
+        } else {
+            initTable(items);
+        }
+    } catch (err) {
+        console.error('SecurityGroup 목록 조회 실패:', err);
+        showToast(TOAST_TYPES.ERROR, 'SecurityGroup 목록 조회에 실패했습니다.');
+    }
+}
+
+// ─── Tabulator 테이블 ─────────────────────────────────────────────────────
+
+function initTable(items) {
+    AppState.tables.sgTable = new Tabulator('#sg-list-table', {
+        data: items,
+        layout: 'fitColumns',
+        placeholder: '등록된 SecurityGroup이 없습니다.',
+        pagination: 'local',
+        paginationSize: 10,
+        paginationSizeSelector: [10, 20, 50],
+        paginationCounter: 'rows',
+        movableColumns: true,
+        initialSort: [{ column: 'name', dir: 'asc' }],
+        columns: [
+            { title: '이름',         field: 'name',           widthGrow: 2, sorter: 'string' },
+            { title: 'Connection',   field: 'connectionName', widthGrow: 1, sorter: 'string' },
+            { title: 'VPC',          field: 'vNetId',         widthGrow: 1 },
+            { title: '규칙 수',       field: 'firewallRules',
+              formatter: (cell) => {
+                  const rules = cell.getValue() || [];
+                  return `${rules.length}개`;
+              },
+              hozAlign: 'center', width: 90 },
+            { title: 'CSP Resource ID', field: 'cspResourceId', widthGrow: 2 },
+        ],
+    });
+
+    AppState.tables.sgTable.on('rowClick', async function (e, row) {
+        const data = row.getData();
+        AppState.resources.selected = data;
+        renderDetail(data);
+        showDetail();
+        try {
+            const detail = await sgApi().get(AppState.ns, data.name);
+            if (detail) {
+                AppState.resources.selected = detail;
+                renderDetail(detail);
+            }
+        } catch (err) {
+            console.error('SG 상세 조회 실패:', err);
+        }
+    });
+}
+
+// ─── Detail Panel ─────────────────────────────────────────────────────────
+
+function renderDetail(data) {
+    document.getElementById('detail-name').textContent         = data.name || '-';
+    document.getElementById('detail-sg-name').textContent      = data.name || '-';
+    document.getElementById('detail-sg-connection').textContent = data.connectionName || '-';
+    document.getElementById('detail-sg-vnet').textContent      = data.vNetId || '-';
+    document.getElementById('detail-sg-csp-id').textContent    = data.cspResourceId || '-';
+
+    const rules = data.firewallRules || data.securityRuleList || [];
+    const tbody    = document.getElementById('detail-rule-tbody');
+    const emptyEl  = document.getElementById('detail-rule-empty');
+    const tableWrap = document.getElementById('detail-rule-table-wrap');
+
+    tbody.innerHTML = '';
+    if (rules.length === 0) {
+        emptyEl.classList.remove('d-none');
+        tableWrap.classList.add('d-none');
+    } else {
+        emptyEl.classList.add('d-none');
+        tableWrap.classList.remove('d-none');
+        for (const r of rules) {
+            const dirBadge = r.direction === 'inbound'
+                ? '<span class="badge bg-blue-lt">inbound</span>'
+                : '<span class="badge bg-orange-lt">outbound</span>';
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>${dirBadge}</td>
+                <td>${r.ipProtocol || r.IPProtocol || '-'}</td>
+                <td>${r.fromPort || '-'}</td>
+                <td>${r.toPort || '-'}</td>
+                <td><code>${r.cidr || '-'}</code></td>`;
+            tbody.appendChild(tr);
+        }
+    }
+}
+
+function showDetail() {
+    const el = document.getElementById('view-mode-cards');
+    if (el) el.classList.add('show');
+    AppState.ui.viewMode = true;
+}
+
+export function hideDetail() {
+    document.getElementById('view-mode-cards')?.classList.remove('show');
+    AppState.ui.viewMode = false;
+    AppState.resources.selected = null;
+}
+
+// ─── Delete ───────────────────────────────────────────────────────────────
+
+export async function confirmDeleteSG() {
+    const selected = AppState.resources.selected;
+    if (!selected) return;
+    if (!confirm(`SecurityGroup "${selected.name}"을 삭제하시겠습니까?`)) return;
+    try {
+        await sgApi().del(AppState.ns, selected.name);
+        showToast(TOAST_TYPES.SUCCESS, `SecurityGroup "${selected.name}" 삭제 완료`);
+        hideDetail();
+        await loadSGList();
+    } catch (err) {
+        console.error('SG 삭제 실패:', err);
+        showToast(TOAST_TYPES.ERROR, 'SecurityGroup 삭제에 실패했습니다: ' + (err.message || ''));
+    }
+}
+
+// ─── Filter ───────────────────────────────────────────────────────────────
+
+function initFilter() {
+    const fieldEl = document.getElementById('filter-field');
+    const typeEl  = document.getElementById('filter-type');
+    const valueEl = document.getElementById('filter-value');
+    if (!fieldEl || !typeEl || !valueEl) return;
+
+    function updateFilter() {
+        const field = fieldEl.value;
+        const type  = typeEl.value;
+        if (field && AppState.tables.sgTable) {
+            AppState.tables.sgTable.setFilter(field, type, valueEl.value);
+        }
+    }
+
+    fieldEl.addEventListener('change', updateFilter);
+    typeEl.addEventListener('change', updateFilter);
+    valueEl.addEventListener('keyup', updateFilter);
+
+    document.getElementById('filter-clear').addEventListener('click', function () {
+        fieldEl.value = '';
+        typeEl.value  = 'like';
+        valueEl.value = '';
+        if (AppState.tables.sgTable) AppState.tables.sgTable.clearFilter();
+    });
+}
+
+// ─── Create SG 모달 ───────────────────────────────────────────────────────
+
+document.getElementById('create-sg-modal')?.addEventListener('show.bs.modal', async function () {
+    document.getElementById('create-sg-name').value = '';
+    document.getElementById('create-sg-vnet').value = '';
+    document.getElementById('create-sg-rule-list').innerHTML = '';
+    await _loadConnectionOptions('create-sg-connection');
+    addFirewallRuleRow();
+});
+
+export function addFirewallRuleRow() {
+    const list = document.getElementById('create-sg-rule-list');
+    const row = document.createElement('div');
+    row.className = 'row g-2 mb-2 align-items-center sg-rule-row';
+    row.innerHTML = `
+        <div class="col-md-2">
+          <select class="form-select form-select-sm rule-direction">
+            <option value="inbound">inbound</option>
+            <option value="outbound">outbound</option>
+          </select>
+        </div>
+        <div class="col-md-2">
+          <select class="form-select form-select-sm rule-protocol">
+            <option value="tcp">TCP</option>
+            <option value="udp">UDP</option>
+            <option value="icmp">ICMP</option>
+            <option value="all">ALL</option>
+          </select>
+        </div>
+        <div class="col-md-2">
+          <input type="text" class="form-control form-control-sm rule-from-port"
+            placeholder="From Port">
+        </div>
+        <div class="col-md-2">
+          <input type="text" class="form-control form-control-sm rule-to-port"
+            placeholder="To Port">
+        </div>
+        <div class="col-md-3">
+          <input type="text" class="form-control form-control-sm rule-cidr"
+            placeholder="CIDR (예: 0.0.0.0/0)">
+        </div>
+        <div class="col-md-1">
+          <button type="button" class="btn btn-sm btn-outline-danger w-100"
+            onclick="this.closest('.sg-rule-row').remove()">✕</button>
+        </div>`;
+    list.appendChild(row);
+}
+
+export async function executeCreateSG() {
+    const connectionName = document.getElementById('create-sg-connection').value;
+    const name           = document.getElementById('create-sg-name').value.trim();
+    const vNetId         = document.getElementById('create-sg-vnet').value.trim();
+
+    if (!connectionName || !name || !vNetId) {
+        showToast(TOAST_TYPES.WARNING, 'Connection, SG 이름, VPC 이름은 필수입니다.');
+        return;
+    }
+
+    const firewallRules = [];
+    document.querySelectorAll('#create-sg-rule-list .sg-rule-row').forEach(row => {
+        const direction  = row.querySelector('.rule-direction')?.value;
+        const ipProtocol = row.querySelector('.rule-protocol')?.value;
+        const fromPort   = row.querySelector('.rule-from-port')?.value.trim();
+        const toPort     = row.querySelector('.rule-to-port')?.value.trim();
+        const cidr       = row.querySelector('.rule-cidr')?.value.trim();
+        if (ipProtocol && cidr) {
+            firewallRules.push({ direction, ipProtocol, fromPort, toPort, cidr });
+        }
+    });
+
+    const spinner = document.getElementById('create-sg-spinner');
+    const btn     = document.getElementById('create-sg-execute-btn');
+    spinner.classList.remove('d-none');
+    btn.disabled = true;
+
+    try {
+        await sgApi().create(AppState.ns, { connectionName, name, vNetId, firewallRules });
+        showToast(TOAST_TYPES.SUCCESS, `SecurityGroup "${name}" 생성 완료`);
+        bootstrap.Modal.getInstance(document.getElementById('create-sg-modal'))?.hide();
+        await loadSGList();
+    } catch (err) {
+        console.error('SG 생성 실패:', err);
+        showToast(TOAST_TYPES.ERROR, 'SecurityGroup 생성에 실패했습니다: ' + (err.message || ''));
+    } finally {
+        spinner.classList.add('d-none');
+        btn.disabled = false;
+    }
+}
+
+// ─── Import SG 모달 ───────────────────────────────────────────────────────
+
+export async function openImportSGModal() {
+    AppState.ns = webconsolejs['common/api/services/workspace_api'].getCurrentProject()?.NsId || '';
+    if (!AppState.ns) {
+        showToast(TOAST_TYPES.WARNING, '프로젝트를 먼저 선택하세요.');
+        return;
+    }
+    document.getElementById('import-sg-project').value = AppState.ns;
+    await _loadConnectionOptions('import-sg-connection');
     new bootstrap.Modal(document.getElementById('import-sg-modal')).show();
 }
 
 export async function executeImportSG() {
     const connectionName = document.getElementById('import-sg-connection').value;
-    if (!connectionName) { alert('Connection을 선택하세요.'); return; }
+    if (!connectionName) {
+        showToast(TOAST_TYPES.WARNING, 'Connection을 선택하세요.');
+        return;
+    }
 
     const spinner = document.getElementById('import-sg-spinner');
     spinner.classList.remove('d-none');
 
     try {
-        const result = await importApi().registerCspResources(['securityGroup'], connectionName, _nsId);
-        const count = result?.registerationOverview?.securityGroup || 0;
+        const result = await importApi().registerCspResources(['securityGroup'], connectionName, AppState.ns);
+        const count  = result?.registerationOverview?.securityGroup || 0;
         const failed = result?.registerationOverview?.failed || 0;
-        showToast(failed > 0 ? TOAST_TYPES.WARNING : TOAST_TYPES.SUCCESS,
-            `SecurityGroup ${count}개 등록 완료${failed > 0 ? `, ${failed}개 실패` : ''}`);
+        showToast(
+            failed > 0 ? TOAST_TYPES.WARNING : TOAST_TYPES.SUCCESS,
+            `SecurityGroup ${count}개 등록 완료${failed > 0 ? `, ${failed}개 실패` : ''}`
+        );
         bootstrap.Modal.getInstance(document.getElementById('import-sg-modal'))?.hide();
+        await loadSGList();
     } catch (err) {
         showToast(TOAST_TYPES.ERROR, 'SecurityGroup Import 실패: ' + (err.message || ''));
     } finally {
@@ -52,22 +336,33 @@ export async function executeImportSG() {
     }
 }
 
-async function loadConnectionSelect(selectId) {
+async function _loadConnectionOptions(selectId) {
     const select = document.getElementById(selectId);
     select.innerHTML = '<option value="">선택하세요</option>';
     try {
-        const result = await webconsolejs["common/api/http"].commonAPIPost("/api/mc-iam-manager/ListCspAccounts", {});
-        const accounts = result?.data?.responseData?.items || [];
-        accounts.forEach(acc => {
+        const result = await webconsolejs['common/api/http'].commonAPIPost(
+            '/api/mc-infra-manager/GetConnConfigList', {}
+        );
+        const list = result?.data?.responseData?.connectionconfig || [];
+        for (const conn of list) {
             const opt = document.createElement('option');
-            opt.value = acc.connectionName || acc.name;
-            opt.textContent = acc.name;
+            opt.value = conn.configName;
+            opt.textContent = conn.configName;
             select.appendChild(opt);
-        });
-    } catch (err) { console.error(err); }
+        }
+    } catch (err) {
+        console.error('Connection 목록 로드 실패:', err);
+    }
 }
 
-if (typeof webconsolejs === "undefined") { window.webconsolejs = {}; }
-webconsolejs["pages/settings/environment/cloudresources/securitygroups"] = {
-    openImportSGModal, executeImportSG,
+// ─── webconsolejs 등록 ────────────────────────────────────────────────────
+if (typeof webconsolejs === 'undefined') { window.webconsolejs = {}; }
+webconsolejs['pages/settings/environment/cloudresources/securitygroups'] = {
+    loadSGList,
+    hideDetail,
+    confirmDeleteSG,
+    addFirewallRuleRow,
+    executeCreateSG,
+    openImportSGModal,
+    executeImportSG,
 };

--- a/front/assets/js/pages/settings/environment/cloudresources/securitygroups.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/securitygroups.js
@@ -66,7 +66,7 @@ export async function loadSGList() {
         }
     } catch (err) {
         console.error('SecurityGroup 목록 조회 실패:', err);
-        showToast(TOAST_TYPES.ERROR, 'SecurityGroup 목록 조회에 실패했습니다.');
+        showToast(TOAST_TYPES.ERROR, 'Failed to load SecurityGroup list.');
     }
 }
 
@@ -76,7 +76,7 @@ function initTable(items) {
     AppState.tables.sgTable = new Tabulator('#sg-list-table', {
         data: items,
         layout: 'fitColumns',
-        placeholder: '등록된 SecurityGroup이 없습니다.',
+        placeholder: 'No SecurityGroups registered.',
         pagination: 'local',
         paginationSize: 10,
         paginationSizeSelector: [10, 20, 50],
@@ -84,13 +84,13 @@ function initTable(items) {
         movableColumns: true,
         initialSort: [{ column: 'name', dir: 'asc' }],
         columns: [
-            { title: '이름',         field: 'name',           widthGrow: 2, sorter: 'string' },
+            { title: 'Name',         field: 'name',           widthGrow: 2, sorter: 'string' },
             { title: 'Connection',   field: 'connectionName', widthGrow: 1, sorter: 'string' },
             { title: 'VPC',          field: 'vNetId',         widthGrow: 1 },
-            { title: '규칙 수',       field: 'firewallRules',
+            { title: 'Rules',        field: 'firewallRules',
               formatter: (cell) => {
                   const rules = cell.getValue() || [];
-                  return `${rules.length}개`;
+                  return `${rules.length}`;
               },
               hozAlign: 'center', width: 90 },
             { title: 'CSP Resource ID', field: 'cspResourceId', widthGrow: 2 },
@@ -117,15 +117,24 @@ function initTable(items) {
 // ─── Detail Panel ─────────────────────────────────────────────────────────
 
 function renderDetail(data) {
-    document.getElementById('detail-name').textContent         = data.name || '-';
-    document.getElementById('detail-sg-name').textContent      = data.name || '-';
+    document.getElementById('detail-name').textContent          = data.name || '-';
+    document.getElementById('detail-sg-name').textContent       = data.name || '-';
     document.getElementById('detail-sg-connection').textContent = data.connectionName || '-';
-    document.getElementById('detail-sg-vnet').textContent      = data.vNetId || '-';
-    document.getElementById('detail-sg-csp-id').textContent    = data.cspResourceId || '-';
+    document.getElementById('detail-sg-vnet').textContent       = data.vNetId || '-';
+    document.getElementById('detail-sg-csp-id').textContent     = data.cspResourceId || '-';
+    document.getElementById('detail-sg-csp-name').textContent   = data.cspResourceName || '-';
+    document.getElementById('detail-sg-uid').textContent        = data.uid || '-';
+    document.getElementById('detail-sg-description').textContent = data.description || '-';
 
-    const rules = data.firewallRules || data.securityRuleList || [];
-    const tbody    = document.getElementById('detail-rule-tbody');
-    const emptyEl  = document.getElementById('detail-rule-empty');
+    const cc = data.connectionConfig;
+    document.getElementById('detail-sg-provider').textContent = cc?.providerName || '-';
+    document.getElementById('detail-sg-region').textContent   = cc?.regionZoneInfo?.assignedRegion || '-';
+    document.getElementById('detail-sg-zone').textContent     = cc?.regionZoneInfo?.assignedZone || '-';
+
+    // Firewall Rules
+    const rules     = data.firewallRules || data.securityRuleList || [];
+    const tbody     = document.getElementById('detail-rule-tbody');
+    const emptyEl   = document.getElementById('detail-rule-empty');
     const tableWrap = document.getElementById('detail-rule-table-wrap');
 
     tbody.innerHTML = '';
@@ -136,18 +145,31 @@ function renderDetail(data) {
         emptyEl.classList.add('d-none');
         tableWrap.classList.remove('d-none');
         for (const r of rules) {
-            const dirBadge = r.direction === 'inbound'
+            const dir      = (r.Direction || r.direction || '').toLowerCase();
+            const dirBadge = dir === 'inbound'
                 ? '<span class="badge bg-blue-lt">inbound</span>'
                 : '<span class="badge bg-orange-lt">outbound</span>';
+            const protocol = r.Protocol || r.ipProtocol || r.IPProtocol || '-';
+            const port     = (r.Port !== undefined ? r.Port : (r.fromPort !== undefined ? r.fromPort : null));
+            const portText = port === null ? '-' : (port === '' ? 'ALL' : port);
+            const cidr     = r.CIDR || r.cidr || '-';
             const tr = document.createElement('tr');
             tr.innerHTML = `
                 <td>${dirBadge}</td>
-                <td>${r.ipProtocol || r.IPProtocol || '-'}</td>
-                <td>${r.fromPort || '-'}</td>
-                <td>${r.toPort || '-'}</td>
-                <td><code>${r.cidr || '-'}</code></td>`;
+                <td>${protocol}</td>
+                <td>${portText}</td>
+                <td><code>${cidr}</code></td>`;
             tbody.appendChild(tr);
         }
+    }
+
+    // keyValueList
+    const kvTbody = document.getElementById('detail-kv-tbody');
+    kvTbody.innerHTML = '';
+    for (const kv of (data.keyValueList || [])) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td class="text-muted" style="width:40%">${kv.key}</td><td>${kv.value || '-'}</td>`;
+        kvTbody.appendChild(tr);
     }
 }
 
@@ -168,15 +190,15 @@ export function hideDetail() {
 export async function confirmDeleteSG() {
     const selected = AppState.resources.selected;
     if (!selected) return;
-    if (!confirm(`SecurityGroup "${selected.name}"을 삭제하시겠습니까?`)) return;
+    if (!confirm(`Delete SecurityGroup "${selected.name}"?`)) return;
     try {
         await sgApi().del(AppState.ns, selected.name);
-        showToast(TOAST_TYPES.SUCCESS, `SecurityGroup "${selected.name}" 삭제 완료`);
+        showToast(TOAST_TYPES.SUCCESS, `SecurityGroup "${selected.name}" deleted.`);
         hideDetail();
         await loadSGList();
     } catch (err) {
-        console.error('SG 삭제 실패:', err);
-        showToast(TOAST_TYPES.ERROR, 'SecurityGroup 삭제에 실패했습니다: ' + (err.message || ''));
+        console.error('Delete SG failed:', err);
+        showToast(TOAST_TYPES.ERROR, 'Failed to delete SecurityGroup: ' + (err.message || ''));
     }
 }
 
@@ -210,10 +232,13 @@ function initFilter() {
 
 // ─── Create SG 모달 ───────────────────────────────────────────────────────
 
-document.getElementById('create-sg-modal')?.addEventListener('show.bs.modal', async function () {
+document.getElementById('create-sg-modal')?.addEventListener('hidden.bs.modal', function () {
     document.getElementById('create-sg-name').value = '';
     document.getElementById('create-sg-connection-display').value = '';
     document.getElementById('create-sg-rule-list').innerHTML = '';
+});
+
+document.getElementById('create-sg-modal')?.addEventListener('show.bs.modal', async function () {
     await _loadVNetOptions('create-sg-vnet-select', AppState.ns);
     addFirewallRuleRow();
 });
@@ -239,15 +264,15 @@ export function addFirewallRuleRow() {
         </div>
         <div class="col-md-2">
           <input type="text" class="form-control form-control-sm rule-from-port"
-            placeholder="From Port">
+            placeholder="e.g. 0">
         </div>
         <div class="col-md-2">
           <input type="text" class="form-control form-control-sm rule-to-port"
-            placeholder="To Port">
+            placeholder="e.g. 65535">
         </div>
         <div class="col-md-3">
           <input type="text" class="form-control form-control-sm rule-cidr"
-            placeholder="CIDR (예: 0.0.0.0/0)">
+            placeholder="CIDR (e.g. 0.0.0.0/0)">
         </div>
         <div class="col-md-1">
           <button type="button" class="btn btn-sm btn-outline-danger w-100"
@@ -263,21 +288,32 @@ export async function executeCreateSG() {
     const name           = document.getElementById('create-sg-name').value.trim();
 
     if (!vNetId || !connectionName || !name) {
-        showToast(TOAST_TYPES.WARNING, 'VPC 선택과 SG 이름은 필수입니다.');
+        showToast(TOAST_TYPES.WARNING, 'VPC and SG name are required.');
         return;
     }
 
     const firewallRules = [];
+    let ruleError = false;
     document.querySelectorAll('#create-sg-rule-list .sg-rule-row').forEach(row => {
         const direction  = row.querySelector('.rule-direction')?.value;
-        const ipProtocol = row.querySelector('.rule-protocol')?.value;
+        const protocol   = row.querySelector('.rule-protocol')?.value.toUpperCase();
         const fromPort   = row.querySelector('.rule-from-port')?.value.trim();
         const toPort     = row.querySelector('.rule-to-port')?.value.trim();
         const cidr       = row.querySelector('.rule-cidr')?.value.trim();
-        if (ipProtocol && cidr) {
-            firewallRules.push({ direction, ipProtocol, fromPort, toPort, cidr });
-        }
+        if (!protocol && !cidr) return;
+        const needsPort = protocol !== 'ICMP' && protocol !== 'ALL';
+        if (needsPort && (!fromPort || !toPort)) { ruleError = true; return; }
+        if (!cidr) { ruleError = true; return; }
+        const ports = needsPort
+            ? (fromPort === toPort ? fromPort : `${fromPort}-${toPort}`)
+            : '';
+        firewallRules.push({ Direction: direction, Protocol: protocol, Ports: ports, CIDR: cidr });
     });
+
+    if (ruleError) {
+        showToast(TOAST_TYPES.WARNING, 'TCP/UDP rules require From Port, To Port, and CIDR.');
+        return;
+    }
 
     const spinner = document.getElementById('create-sg-spinner');
     const btn     = document.getElementById('create-sg-execute-btn');
@@ -286,12 +322,12 @@ export async function executeCreateSG() {
 
     try {
         await sgApi().create(AppState.ns, { connectionName, name, vNetId, firewallRules });
-        showToast(TOAST_TYPES.SUCCESS, `SecurityGroup "${name}" 생성 완료`);
-        bootstrap.Modal.getInstance(document.getElementById('create-sg-modal'))?.hide();
+        showToast(TOAST_TYPES.SUCCESS, `SecurityGroup "${name}" created.`);
+        document.querySelector('#create-sg-modal .btn-close')?.click();
         await loadSGList();
     } catch (err) {
-        console.error('SG 생성 실패:', err);
-        showToast(TOAST_TYPES.ERROR, 'SecurityGroup 생성에 실패했습니다: ' + (err.message || ''));
+        console.error('Create SG failed:', err);
+        showToast(TOAST_TYPES.ERROR, 'Failed to create SecurityGroup: ' + (err.message || ''));
     } finally {
         spinner.classList.add('d-none');
         btn.disabled = false;
@@ -303,7 +339,7 @@ export async function executeCreateSG() {
 export async function openImportSGModal() {
     AppState.ns = webconsolejs['common/api/services/workspace_api'].getCurrentProject()?.NsId || '';
     if (!AppState.ns) {
-        showToast(TOAST_TYPES.WARNING, '프로젝트를 먼저 선택하세요.');
+        showToast(TOAST_TYPES.WARNING, 'Please select a project first.');
         return;
     }
     document.getElementById('import-sg-project').value = AppState.ns;
@@ -314,7 +350,7 @@ export async function openImportSGModal() {
 export async function executeImportSG() {
     const connectionName = document.getElementById('import-sg-connection').value;
     if (!connectionName) {
-        showToast(TOAST_TYPES.WARNING, 'Connection을 선택하세요.');
+        showToast(TOAST_TYPES.WARNING, 'Please select a Connection.');
         return;
     }
 
@@ -327,12 +363,12 @@ export async function executeImportSG() {
         const failed = result?.registerationOverview?.failed || 0;
         showToast(
             failed > 0 ? TOAST_TYPES.WARNING : TOAST_TYPES.SUCCESS,
-            `SecurityGroup ${count}개 등록 완료${failed > 0 ? `, ${failed}개 실패` : ''}`
+            `${count} SecurityGroup(s) imported${failed > 0 ? `, ${failed} failed` : ''}`
         );
         bootstrap.Modal.getInstance(document.getElementById('import-sg-modal'))?.hide();
         await loadSGList();
     } catch (err) {
-        showToast(TOAST_TYPES.ERROR, 'SecurityGroup Import 실패: ' + (err.message || ''));
+        showToast(TOAST_TYPES.ERROR, 'Failed to import SecurityGroups: ' + (err.message || ''));
     } finally {
         spinner.classList.add('d-none');
     }
@@ -340,15 +376,18 @@ export async function executeImportSG() {
 
 async function _loadVNetOptions(selectId, ns) {
     const select = document.getElementById(selectId);
-    select.innerHTML = '<option value="">-- VPC 선택 --</option>';
-    if (!ns) return;
+    if (!ns) {
+        select.innerHTML = '<option value="">-- Select VPC --</option>';
+        return;
+    }
     try {
         const data  = await vpcApi().getAllVNet(ns);
+        select.innerHTML = '<option value="">-- Select VPC --</option>';
         const vNets = data?.vNet || (Array.isArray(data) ? data : []);
         if (vNets.length === 0) {
             const opt = document.createElement('option');
             opt.disabled = true;
-            opt.textContent = '등록된 VPC가 없습니다.';
+            opt.textContent = 'No VPCs registered.';
             select.appendChild(opt);
             return;
         }
@@ -371,7 +410,7 @@ async function _loadVNetOptions(selectId, ns) {
 
 async function _loadConnectionOptions(selectId) {
     const select = document.getElementById(selectId);
-    select.innerHTML = '<option value="">선택하세요</option>';
+    select.innerHTML = '<option value="">-- Select --</option>';
     try {
         const result = await webconsolejs['common/api/http'].commonAPIPost(
             '/api/mc-infra-manager/GetConnConfigList', {}

--- a/front/assets/js/pages/settings/environment/cloudresources/sshkeys.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/sshkeys.js
@@ -1,49 +1,294 @@
-// SSH Key 관리 페이지 — Import 기능 (Connection 단위)
-// RQ-CLOUD-ADMIN-007 / UC-IMPORT-004
+// SSH Key 관리 페이지 — CRUD + Import
+// FR-CLOUD-ADMIN-003-03 / RQ-CLOUD-ADMIN-007
 
+import { TabulatorFull as Tabulator } from "tabulator-tables";
 import { showToast, TOAST_TYPES } from "../../../../common/utils/toast.js";
 
+const sshKeyApi = () => webconsolejs["common/api/services/sshkey_api"];
 const importApi = () => webconsolejs["common/api/services/import_api"];
-let _nsId = null;
 
-document.addEventListener("DOMContentLoaded", async function () {
-    _nsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
+// ─── 상태 ─────────────────────────────────────────────────────────────────
+const AppState = {
+    ns: '',
+    tables: { keyTable: null },
+    resources: { selected: null },
+    ui: { viewMode: false, privKeyVisible: false },
+    _lastCreatedPrivKey: null,
+};
 
+// ─── 페이지 초기화 ────────────────────────────────────────────────────────
+
+$('#select-current-project').on('change', async function () {
+    if (this.value === '') return;
+    const project = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
+    AppState.ns = project?.NsId || '';
+    if (AppState.ns) await loadKeyList();
+});
+
+document.addEventListener('DOMContentLoaded', async function () {
     const btnList = document.getElementById('page-header-btn-list');
     if (btnList) {
-        const btn = document.createElement('button');
-        btn.className = 'btn btn-secondary';
-        btn.textContent = 'Import SSH Key';
-        btn.disabled = !_nsId;
-        btn.title = _nsId ? 'CSP 미관리 SSH Key 임포트' : '프로젝트를 먼저 선택하세요';
-        btn.onclick = () => openImportSshKeyModal();
-        btnList.appendChild(btn);
+        btnList.innerHTML = `
+            <button type="button" class="btn btn-primary"
+              data-bs-toggle="modal" data-bs-target="#create-sshkey-modal">
+              <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
+                viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
+                stroke-linecap="round" stroke-linejoin="round">
+                <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                <path d="M12 5l0 14"/><path d="M5 12l14 0"/>
+              </svg>
+              Create SSH Key
+            </button>`;
+    }
+
+    const selectedWorkspaceProject = await webconsolejs['partials/layout/navbar'].workspaceProjectInit();
+    webconsolejs['partials/layout/modal'].checkWorkspaceSelection(selectedWorkspaceProject);
+
+    AppState.ns = selectedWorkspaceProject.nsId || '';
+    initFilter();
+
+    if (selectedWorkspaceProject.projectId !== '') {
+        await loadKeyList();
     }
 });
 
-export async function openImportSshKeyModal() {
-    _nsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject()?.NsId;
-    if (!_nsId) { alert('프로젝트를 먼저 선택하세요.'); return; }
+// ─── SSH Key 목록 로드 ────────────────────────────────────────────────────
 
-    document.getElementById('import-sshkey-project').value = _nsId;
-    await loadConnectionSelect('import-sshkey-connection');
+export async function loadKeyList() {
+    if (!AppState.ns) return;
+    try {
+        const data = await sshKeyApi().list(AppState.ns);
+        const items = data?.sshKey || (Array.isArray(data) ? data : []);
+        if (AppState.tables.keyTable) {
+            AppState.tables.keyTable.replaceData(items);
+        } else {
+            initTable(items);
+        }
+    } catch (err) {
+        console.error('SSH Key 목록 조회 실패:', err);
+        showToast(TOAST_TYPES.ERROR, 'SSH Key 목록 조회에 실패했습니다.');
+    }
+}
+
+// ─── Tabulator 테이블 ─────────────────────────────────────────────────────
+
+function initTable(items) {
+    AppState.tables.keyTable = new Tabulator('#sshkey-list-table', {
+        data: items,
+        layout: 'fitColumns',
+        placeholder: '등록된 SSH Key가 없습니다.',
+        pagination: 'local',
+        paginationSize: 10,
+        paginationSizeSelector: [10, 20, 50],
+        paginationCounter: 'rows',
+        movableColumns: true,
+        initialSort: [{ column: 'name', dir: 'asc' }],
+        columns: [
+            { title: '이름',        field: 'name',           widthGrow: 2, sorter: 'string' },
+            { title: 'Connection',  field: 'connectionName', widthGrow: 1, sorter: 'string' },
+            { title: 'Fingerprint', field: 'fingerprint',    widthGrow: 2 },
+            { title: 'CSP Resource ID', field: 'cspResourceId', widthGrow: 2 },
+        ],
+    });
+
+    AppState.tables.keyTable.on('rowClick', async function (e, row) {
+        const data = row.getData();
+        // 행 클릭 시 private key 초기화 (생성 직후가 아닌 경우)
+        AppState._lastCreatedPrivKey = null;
+        AppState.resources.selected = data;
+        renderDetail(data, null);
+        showDetail();
+        try {
+            const detail = await sshKeyApi().get(AppState.ns, data.name);
+            if (detail) {
+                AppState.resources.selected = detail;
+                renderDetail(detail, null);
+            }
+        } catch (err) {
+            console.error('SSH Key 상세 조회 실패:', err);
+        }
+    });
+}
+
+// ─── Detail Panel ─────────────────────────────────────────────────────────
+
+function renderDetail(data, privateKey) {
+    document.getElementById('detail-name').textContent            = data.name || '-';
+    document.getElementById('detail-key-name').textContent        = data.name || '-';
+    document.getElementById('detail-key-connection').textContent  = data.connectionName || '-';
+    document.getElementById('detail-key-fingerprint').textContent = data.fingerprint || '-';
+    document.getElementById('detail-key-csp-id').textContent      = data.cspResourceId || '-';
+
+    const pubKey = data.publicKey || data.publicKeyMaterial || '';
+    const pubKeyEl    = document.getElementById('detail-pubkey');
+    const pubEmptyEl  = document.getElementById('detail-pubkey-empty');
+    if (pubKey) {
+        pubKeyEl.textContent = pubKey;
+        pubKeyEl.style.display = '';
+        pubEmptyEl.classList.add('d-none');
+    } else {
+        pubKeyEl.style.display = 'none';
+        pubEmptyEl.classList.remove('d-none');
+    }
+
+    const privSection = document.getElementById('detail-privkey-section');
+    if (privateKey) {
+        privSection.style.display = '';
+        document.getElementById('detail-privkey').textContent = privateKey;
+        document.getElementById('detail-privkey').style.filter = 'blur(4px)';
+        document.getElementById('toggle-privkey-btn').textContent = '보기';
+        AppState.ui.privKeyVisible = false;
+    } else {
+        privSection.style.display = 'none';
+    }
+}
+
+function showDetail() {
+    const el = document.getElementById('view-mode-cards');
+    if (el) el.classList.add('show');
+    AppState.ui.viewMode = true;
+}
+
+export function hideDetail() {
+    document.getElementById('view-mode-cards')?.classList.remove('show');
+    AppState.ui.viewMode = false;
+    AppState.resources.selected = null;
+    AppState._lastCreatedPrivKey = null;
+}
+
+export function togglePrivateKey() {
+    const preEl  = document.getElementById('detail-privkey');
+    const btnEl  = document.getElementById('toggle-privkey-btn');
+    AppState.ui.privKeyVisible = !AppState.ui.privKeyVisible;
+    preEl.style.filter    = AppState.ui.privKeyVisible ? 'none' : 'blur(4px)';
+    preEl.style.userSelect = AppState.ui.privKeyVisible ? 'text' : 'none';
+    btnEl.textContent = AppState.ui.privKeyVisible ? '숨기기' : '보기';
+}
+
+// ─── Delete ───────────────────────────────────────────────────────────────
+
+export async function confirmDeleteSshKey() {
+    const selected = AppState.resources.selected;
+    if (!selected) return;
+    if (!confirm(`SSH Key "${selected.name}"을 삭제하시겠습니까?`)) return;
+    try {
+        await sshKeyApi().del(AppState.ns, selected.name);
+        showToast(TOAST_TYPES.SUCCESS, `SSH Key "${selected.name}" 삭제 완료`);
+        hideDetail();
+        await loadKeyList();
+    } catch (err) {
+        console.error('SSH Key 삭제 실패:', err);
+        showToast(TOAST_TYPES.ERROR, 'SSH Key 삭제에 실패했습니다: ' + (err.message || ''));
+    }
+}
+
+// ─── Filter ───────────────────────────────────────────────────────────────
+
+function initFilter() {
+    const fieldEl = document.getElementById('filter-field');
+    const typeEl  = document.getElementById('filter-type');
+    const valueEl = document.getElementById('filter-value');
+    if (!fieldEl || !typeEl || !valueEl) return;
+
+    function updateFilter() {
+        const field = fieldEl.value;
+        const type  = typeEl.value;
+        if (field && AppState.tables.keyTable) {
+            AppState.tables.keyTable.setFilter(field, type, valueEl.value);
+        }
+    }
+
+    fieldEl.addEventListener('change', updateFilter);
+    typeEl.addEventListener('change', updateFilter);
+    valueEl.addEventListener('keyup', updateFilter);
+
+    document.getElementById('filter-clear').addEventListener('click', function () {
+        fieldEl.value = '';
+        typeEl.value  = 'like';
+        valueEl.value = '';
+        if (AppState.tables.keyTable) AppState.tables.keyTable.clearFilter();
+    });
+}
+
+// ─── Create SSH Key 모달 ──────────────────────────────────────────────────
+
+document.getElementById('create-sshkey-modal')?.addEventListener('show.bs.modal', async function () {
+    document.getElementById('create-sshkey-name').value = '';
+    await _loadConnectionOptions('create-sshkey-connection');
+});
+
+export async function executeCreateSshKey() {
+    const connectionName = document.getElementById('create-sshkey-connection').value;
+    const name           = document.getElementById('create-sshkey-name').value.trim();
+
+    if (!connectionName || !name) {
+        showToast(TOAST_TYPES.WARNING, 'Connection과 Key 이름은 필수입니다.');
+        return;
+    }
+
+    const spinner = document.getElementById('create-sshkey-spinner');
+    const btn     = document.getElementById('create-sshkey-execute-btn');
+    spinner.classList.remove('d-none');
+    btn.disabled = true;
+
+    try {
+        const result = await sshKeyApi().create(AppState.ns, { connectionName, name });
+        const created = result?.responseData || result;
+        showToast(TOAST_TYPES.SUCCESS, `SSH Key "${name}" 생성 완료`);
+        bootstrap.Modal.getInstance(document.getElementById('create-sshkey-modal'))?.hide();
+
+        // Private Key는 생성 응답에만 포함 — 즉시 상세 패널에 표시
+        const privateKey = created?.privateKey || created?.privateKeyMaterial || null;
+        AppState._lastCreatedPrivKey = privateKey;
+
+        await loadKeyList();
+
+        // 생성된 항목 선택 후 상세 패널 표시
+        AppState.resources.selected = created;
+        renderDetail(created, privateKey);
+        showDetail();
+    } catch (err) {
+        console.error('SSH Key 생성 실패:', err);
+        showToast(TOAST_TYPES.ERROR, 'SSH Key 생성에 실패했습니다: ' + (err.message || ''));
+    } finally {
+        spinner.classList.add('d-none');
+        btn.disabled = false;
+    }
+}
+
+// ─── Import SSH Key 모달 ──────────────────────────────────────────────────
+
+export async function openImportSshKeyModal() {
+    AppState.ns = webconsolejs['common/api/services/workspace_api'].getCurrentProject()?.NsId || '';
+    if (!AppState.ns) {
+        showToast(TOAST_TYPES.WARNING, '프로젝트를 먼저 선택하세요.');
+        return;
+    }
+    document.getElementById('import-sshkey-project').value = AppState.ns;
+    await _loadConnectionOptions('import-sshkey-connection');
     new bootstrap.Modal(document.getElementById('import-sshkey-modal')).show();
 }
 
 export async function executeImportSshKey() {
     const connectionName = document.getElementById('import-sshkey-connection').value;
-    if (!connectionName) { alert('Connection을 선택하세요.'); return; }
+    if (!connectionName) {
+        showToast(TOAST_TYPES.WARNING, 'Connection을 선택하세요.');
+        return;
+    }
 
     const spinner = document.getElementById('import-sshkey-spinner');
     spinner.classList.remove('d-none');
 
     try {
-        const result = await importApi().registerCspResources(['sshKey'], connectionName, _nsId);
-        const count = result?.registerationOverview?.sshKey || 0;
+        const result = await importApi().registerCspResources(['sshKey'], connectionName, AppState.ns);
+        const count  = result?.registerationOverview?.sshKey || 0;
         const failed = result?.registerationOverview?.failed || 0;
-        showToast(failed > 0 ? TOAST_TYPES.WARNING : TOAST_TYPES.SUCCESS,
-            `SSH Key ${count}개 등록 완료${failed > 0 ? `, ${failed}개 실패` : ''}`);
+        showToast(
+            failed > 0 ? TOAST_TYPES.WARNING : TOAST_TYPES.SUCCESS,
+            `SSH Key ${count}개 등록 완료${failed > 0 ? `, ${failed}개 실패` : ''}`
+        );
         bootstrap.Modal.getInstance(document.getElementById('import-sshkey-modal'))?.hide();
+        await loadKeyList();
     } catch (err) {
         showToast(TOAST_TYPES.ERROR, 'SSH Key Import 실패: ' + (err.message || ''));
     } finally {
@@ -51,22 +296,33 @@ export async function executeImportSshKey() {
     }
 }
 
-async function loadConnectionSelect(selectId) {
+async function _loadConnectionOptions(selectId) {
     const select = document.getElementById(selectId);
     select.innerHTML = '<option value="">선택하세요</option>';
     try {
-        const result = await webconsolejs["common/api/http"].commonAPIPost("/api/mc-iam-manager/ListCspAccounts", {});
-        const accounts = result?.data?.responseData?.items || [];
-        accounts.forEach(acc => {
+        const result = await webconsolejs['common/api/http'].commonAPIPost(
+            '/api/mc-infra-manager/GetConnConfigList', {}
+        );
+        const list = result?.data?.responseData?.connectionconfig || [];
+        for (const conn of list) {
             const opt = document.createElement('option');
-            opt.value = acc.connectionName || acc.name;
-            opt.textContent = acc.name;
+            opt.value = conn.configName;
+            opt.textContent = conn.configName;
             select.appendChild(opt);
-        });
-    } catch (err) { console.error(err); }
+        }
+    } catch (err) {
+        console.error('Connection 목록 로드 실패:', err);
+    }
 }
 
-if (typeof webconsolejs === "undefined") { window.webconsolejs = {}; }
-webconsolejs["pages/settings/environment/cloudresources/sshkeys"] = {
-    openImportSshKeyModal, executeImportSshKey,
+// ─── webconsolejs 등록 ────────────────────────────────────────────────────
+if (typeof webconsolejs === 'undefined') { window.webconsolejs = {}; }
+webconsolejs['pages/settings/environment/cloudresources/sshkeys'] = {
+    loadKeyList,
+    hideDetail,
+    togglePrivateKey,
+    confirmDeleteSshKey,
+    executeCreateSshKey,
+    openImportSshKeyModal,
+    executeImportSshKey,
 };

--- a/front/templates/pages/settings/environment/cloudresources/networks.html
+++ b/front/templates/pages/settings/environment/cloudresources/networks.html
@@ -75,6 +75,7 @@
             <div class="card-header">
               <h3 class="card-title">VPC 상세 — <span id="detail-name" class="text-primary"></span></h3>
               <div class="card-options">
+                <button class="btn btn-sm btn-outline-secondary me-1" onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].showEditMode()">Edit</button>
                 <button class="btn btn-sm btn-outline-danger me-1" onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].confirmDeleteVNet()">Delete</button>
                 <a href="#" class="card-options-remove" onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].hideDetail()">
                   <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
@@ -122,6 +123,68 @@
                     <tbody id="detail-subnet-tbody"></tbody>
                   </table>
                 </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    <!-- Edit Mode Panel -->
+    <div id="edit-mode-cards" class="collapse">
+      <div class="row row-cards mt-2">
+        <div class="col-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">VPC 편집 — <span id="edit-name" class="text-primary"></span></h3>
+              <div class="card-options">
+                <button class="btn btn-sm btn-secondary me-1" onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].cancelEditMode()">Cancel</button>
+                <button class="btn btn-sm btn-primary" onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].saveVNet()">
+                  <span id="edit-save-spinner" class="spinner-border spinner-border-sm d-none me-1" role="status"></span>
+                  Save
+                </button>
+              </div>
+            </div>
+            <div class="card-body">
+              <!-- Read-only 정보 -->
+              <div class="row g-3 mb-4">
+                <div class="col-md-4">
+                  <label class="form-label text-muted">Name <span class="badge bg-secondary-lt ms-1">read-only</span></label>
+                  <input type="text" class="form-control form-control-sm bg-light" id="edit-vnet-name" readonly>
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label text-muted">Connection <span class="badge bg-secondary-lt ms-1">read-only</span></label>
+                  <input type="text" class="form-control form-control-sm bg-light" id="edit-vnet-connection" readonly>
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label text-muted">CIDR Block <span class="badge bg-secondary-lt ms-1">read-only</span></label>
+                  <input type="text" class="form-control form-control-sm bg-light" id="edit-vnet-cidr" readonly>
+                </div>
+              </div>
+
+              <!-- Subnet 편집 -->
+              <div class="mt-2">
+                <div class="d-flex align-items-center justify-content-between mb-2">
+                  <h4 class="mb-0">Subnet 목록</h4>
+                  <button type="button" class="btn btn-sm btn-outline-primary"
+                    onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].addEditSubnetRow()">
+                    + Add Subnet
+                  </button>
+                </div>
+                <div class="table-responsive">
+                  <table class="table table-sm table-vcenter">
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>CIDR</th>
+                        <th>Zone</th>
+                        <th>CSP ID</th>
+                        <th style="width:60px"></th>
+                      </tr>
+                    </thead>
+                    <tbody id="edit-subnet-tbody"></tbody>
+                  </table>
+                </div>
+                <!-- 새 Subnet 추가 행 -->
+                <div id="edit-new-subnet-list"></div>
               </div>
             </div>
           </div>

--- a/front/templates/pages/settings/environment/cloudresources/networks.html
+++ b/front/templates/pages/settings/environment/cloudresources/networks.html
@@ -7,12 +7,85 @@
           <div class="card">
             <div class="card-header">
               <h3 class="card-title">네트워크 (VPC) 목록</h3>
+              <div class="card-options ms-auto d-flex gap-2">
+                <button id="import-vnet-btn" class="btn btn-sm btn-secondary"
+                  onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].openImportVNetModal()">
+                  Import VNet
+                </button>
+                <button class="btn btn-sm btn-outline-secondary"
+                  onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].loadVNetList()">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-sm me-1" width="16" height="16" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                    <path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"/>
+                    <path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4"/>
+                  </svg>
+                  Refresh
+                </button>
+              </div>
             </div>
-            <div class="card-body p-0">
+            <div class="card-body">
+              <!-- Filter 영역 -->
+              <div class="row g-2 mb-3 align-items-end" id="vnet-filter-area">
+                <div class="col-md-4">
+                  <label class="form-label mb-1">Connection</label>
+                  <select id="filter-connection" class="form-select form-select-sm"
+                    onchange="webconsolejs['pages/settings/environment/cloudresources/networks'].applyFilter()">
+                    <option value="">전체</option>
+                  </select>
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label mb-1">이름 검색</label>
+                  <input id="filter-name" type="text" class="form-control form-control-sm"
+                    placeholder="VPC 이름 검색..."
+                    oninput="webconsolejs['pages/settings/environment/cloudresources/networks'].applyFilter()">
+                </div>
+              </div>
               <div id="vnet-list-table"></div>
             </div>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Create VPC 모달 -->
+<div class="modal modal-blur fade" id="create-vpc-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">VPC 생성</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label required">Connection</label>
+          <select class="form-select" id="create-vpc-connection"></select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label required">VPC 이름</label>
+          <input type="text" class="form-control" id="create-vpc-name" placeholder="예: my-vpc">
+        </div>
+        <div class="mb-3">
+          <label class="form-label required">IPv4 CIDR</label>
+          <input type="text" class="form-control" id="create-vpc-cidr" placeholder="예: 10.0.0.0/16">
+        </div>
+        <div class="mb-2">
+          <label class="form-label">Subnet 목록</label>
+          <div id="create-vpc-subnet-list"></div>
+          <button type="button" class="btn btn-sm btn-outline-secondary mt-2"
+            onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].addSubnetRow()">
+            + Add Subnet
+          </button>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-primary" id="create-vpc-execute-btn"
+          onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].executeCreateVNet()">
+          <span id="create-vpc-spinner" class="spinner-border spinner-border-sm d-none me-1" role="status"></span>
+          생성
+        </button>
       </div>
     </div>
   </div>
@@ -75,5 +148,6 @@
   </div>
 </div>
 
+{{ javascriptTag("common/api/services/vpc_api.js") | raw }}
 {{ javascriptTag("common/api/services/import_api.js") | raw }}
 {{ javascriptTag("pages/settings/environment/cloudresources/networks.js") | raw }}

--- a/front/templates/pages/settings/environment/cloudresources/networks.html
+++ b/front/templates/pages/settings/environment/cloudresources/networks.html
@@ -66,6 +66,69 @@
         </div>
       </div>
     </div>
+
+    <!-- Detail Panel -->
+    <div id="view-mode-cards" class="collapse">
+      <div class="row row-cards mt-2">
+        <div class="col-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">VPC 상세 — <span id="detail-name" class="text-primary"></span></h3>
+              <div class="card-options">
+                <button class="btn btn-sm btn-outline-danger me-1" onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].confirmDeleteVNet()">Delete</button>
+                <a href="#" class="card-options-remove" onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].hideDetail()">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                    stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                    <path d="M18 6l-12 12"/><path d="M6 6l12 12"/>
+                  </svg>
+                </a>
+              </div>
+            </div>
+            <div class="card-body">
+              <div class="datagrid">
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Name</div>
+                  <div class="datagrid-content" id="detail-vnet-name">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Connection</div>
+                  <div class="datagrid-content" id="detail-vnet-connection">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">CIDR Block</div>
+                  <div class="datagrid-content" id="detail-vnet-cidr">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">CSP Resource ID</div>
+                  <div class="datagrid-content"><code id="detail-vnet-csp-id">-</code></div>
+                </div>
+              </div>
+
+              <!-- Subnet 목록 -->
+              <div class="mt-3">
+                <h4 class="mb-2">Subnet 목록</h4>
+                <div id="detail-subnet-empty" class="text-muted small d-none">등록된 Subnet이 없습니다.</div>
+                <div class="table-responsive" id="detail-subnet-table-wrap">
+                  <table class="table table-sm table-vcenter">
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>CIDR</th>
+                        <th>Zone</th>
+                        <th>CSP ID</th>
+                      </tr>
+                    </thead>
+                    <tbody id="detail-subnet-tbody"></tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
 </div>
 

--- a/front/templates/pages/settings/environment/cloudresources/networks.html
+++ b/front/templates/pages/settings/environment/cloudresources/networks.html
@@ -1,47 +1,67 @@
 <div class="page-body">
   <div class="container-xl">
-    <!-- VNet LIST SECTION -->
-    <div id="index" class="section">
-      <div class="row row-cards">
-        <div class="col-12">
-          <div class="card">
-            <div class="card-header">
-              <h3 class="card-title">네트워크 (VPC) 목록</h3>
-              <div class="card-options ms-auto d-flex gap-2">
-                <button id="import-vnet-btn" class="btn btn-sm btn-secondary"
-                  onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].openImportVNetModal()">
-                  Import VNet
-                </button>
-                <button class="btn btn-sm btn-outline-secondary"
-                  onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].loadVNetList()">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-sm me-1" width="16" height="16" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-                    <path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"/>
-                    <path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4"/>
-                  </svg>
-                  Refresh
-                </button>
-              </div>
+    <div class="row row-cards">
+      <div class="col-12">
+        <div class="card">
+          <div class="card-header">
+            <h3 class="card-title">네트워크 (VPC) 목록</h3>
+            <div class="card-options ms-auto d-flex gap-2">
+              <!-- Import VNet -->
+              <a class="btn-action" type="button" title="CSP 미관리 VNet 임포트"
+                onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].openImportVNetModal()">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                  <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2"/>
+                  <path d="M7 11l5 5l5 -5"/>
+                  <path d="M12 4l0 12"/>
+                </svg>
+              </a>
+              <!-- Filter toggle -->
+              <a class="btn-action" type="button" data-bs-toggle="collapse" data-bs-target="#filter-body" aria-expanded="false">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                  <path d="M5.5 5h13a1 1 0 0 1 .5 1.5L14 12L14 19L10 16L10 12L5 6.5a1 1 0 0 1 .5 -1.5"/>
+                </svg>
+              </a>
             </div>
-            <div class="card-body">
-              <!-- Filter 영역 -->
-              <div class="row g-2 mb-3 align-items-end" id="vnet-filter-area">
-                <div class="col-md-4">
-                  <label class="form-label mb-1">Connection</label>
-                  <select id="filter-connection" class="form-select form-select-sm"
-                    onchange="webconsolejs['pages/settings/environment/cloudresources/networks'].applyFilter()">
-                    <option value="">전체</option>
+          </div>
+
+          <!-- Filter Panel -->
+          <div class="collapse" id="filter-body">
+            <div class="card-body border-bottom py-3">
+              <div class="row g-2 align-items-end">
+                <div class="col-auto">
+                  <label class="form-label mb-1">Field</label>
+                  <select id="filter-field" class="form-select form-select-sm">
+                    <option value="">-- select --</option>
+                    <option value="name">Name</option>
+                    <option value="connectionName">Connection</option>
+                    <option value="cidrBlock">CIDR</option>
                   </select>
                 </div>
-                <div class="col-md-4">
-                  <label class="form-label mb-1">이름 검색</label>
-                  <input id="filter-name" type="text" class="form-control form-control-sm"
-                    placeholder="VPC 이름 검색..."
-                    oninput="webconsolejs['pages/settings/environment/cloudresources/networks'].applyFilter()">
+                <div class="col-auto">
+                  <label class="form-label mb-1">Type</label>
+                  <select id="filter-type" class="form-select form-select-sm">
+                    <option value="like">like</option>
+                    <option value="=">=</option>
+                    <option value="!=">!=</option>
+                  </select>
+                </div>
+                <div class="col">
+                  <label class="form-label mb-1">Value</label>
+                  <input type="text" id="filter-value" class="form-control form-control-sm" placeholder="filter...">
+                </div>
+                <div class="col-auto">
+                  <button id="filter-clear" class="btn btn-sm btn-outline-secondary">Clear</button>
                 </div>
               </div>
-              <div id="vnet-list-table"></div>
             </div>
+          </div>
+
+          <div class="card-body p-0">
+            <div id="vnet-list-table"></div>
           </div>
         </div>
       </div>
@@ -114,7 +134,6 @@
           <label class="form-label">대상 프로젝트</label>
           <input type="text" class="form-control" id="import-vnet-project" readonly>
         </div>
-        <!-- 목록 테이블 -->
         <div id="import-vnet-list-area" class="d-none">
           <div class="table-responsive">
             <table class="table table-vcenter">

--- a/front/templates/pages/settings/environment/cloudresources/networks.html
+++ b/front/templates/pages/settings/environment/cloudresources/networks.html
@@ -128,6 +128,8 @@
           </div>
         </div>
       </div>
+    </div>
+
     <!-- Edit Mode Panel -->
     <div id="edit-mode-cards" class="collapse">
       <div class="row row-cards mt-2">

--- a/front/templates/pages/settings/environment/cloudresources/securitygroups.html
+++ b/front/templates/pages/settings/environment/cloudresources/securitygroups.html
@@ -1,17 +1,177 @@
 <div class="page-body">
   <div class="container-xl">
-    <div id="index" class="section">
-      <div class="row row-cards">
+    <div class="row row-cards">
+      <div class="col-12">
+        <div class="card">
+          <div class="card-header">
+            <h3 class="card-title">SecurityGroup 목록</h3>
+            <div class="card-options ms-auto d-flex gap-2">
+              <!-- Import SG -->
+              <a class="btn-action" type="button" title="CSP 미관리 SecurityGroup 임포트"
+                onclick="webconsolejs['pages/settings/environment/cloudresources/securitygroups'].openImportSGModal()">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                  <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2"/>
+                  <path d="M7 11l5 5l5 -5"/>
+                  <path d="M12 4l0 12"/>
+                </svg>
+              </a>
+              <!-- Filter toggle -->
+              <a class="btn-action" type="button" data-bs-toggle="collapse" data-bs-target="#filter-body" aria-expanded="false">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                  <path d="M5.5 5h13a1 1 0 0 1 .5 1.5L14 12L14 19L10 16L10 12L5 6.5a1 1 0 0 1 .5 -1.5"/>
+                </svg>
+              </a>
+            </div>
+          </div>
+
+          <!-- Filter Panel -->
+          <div class="collapse" id="filter-body">
+            <div class="card-body border-bottom py-3">
+              <div class="row g-2 align-items-end">
+                <div class="col-auto">
+                  <label class="form-label mb-1">Field</label>
+                  <select id="filter-field" class="form-select form-select-sm">
+                    <option value="">-- select --</option>
+                    <option value="name">Name</option>
+                    <option value="connectionName">Connection</option>
+                    <option value="vNetId">VPC</option>
+                  </select>
+                </div>
+                <div class="col-auto">
+                  <label class="form-label mb-1">Type</label>
+                  <select id="filter-type" class="form-select form-select-sm">
+                    <option value="like">like</option>
+                    <option value="=">=</option>
+                    <option value="!=">!=</option>
+                  </select>
+                </div>
+                <div class="col">
+                  <label class="form-label mb-1">Value</label>
+                  <input type="text" id="filter-value" class="form-control form-control-sm" placeholder="filter...">
+                </div>
+                <div class="col-auto">
+                  <button id="filter-clear" class="btn btn-sm btn-outline-secondary">Clear</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card-body p-0">
+            <div id="sg-list-table"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Detail Panel -->
+    <div id="view-mode-cards" class="collapse">
+      <div class="row row-cards mt-2">
         <div class="col-12">
           <div class="card">
             <div class="card-header">
-              <h3 class="card-title">SecurityGroup 목록</h3>
+              <h3 class="card-title">SecurityGroup 상세 — <span id="detail-name" class="text-primary"></span></h3>
+              <div class="card-options">
+                <button class="btn btn-sm btn-outline-danger me-1"
+                  onclick="webconsolejs['pages/settings/environment/cloudresources/securitygroups'].confirmDeleteSG()">Delete</button>
+                <a href="#" class="card-options-remove"
+                  onclick="webconsolejs['pages/settings/environment/cloudresources/securitygroups'].hideDetail()">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                    stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                    <path d="M18 6l-12 12"/><path d="M6 6l12 12"/>
+                  </svg>
+                </a>
+              </div>
             </div>
-            <div class="card-body p-0">
-              <div id="sg-list-table"></div>
+            <div class="card-body">
+              <div class="datagrid">
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Name</div>
+                  <div class="datagrid-content" id="detail-sg-name">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Connection</div>
+                  <div class="datagrid-content" id="detail-sg-connection">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">VPC</div>
+                  <div class="datagrid-content" id="detail-sg-vnet">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">CSP Resource ID</div>
+                  <div class="datagrid-content"><code id="detail-sg-csp-id">-</code></div>
+                </div>
+              </div>
+
+              <!-- Firewall Rules -->
+              <div class="mt-3">
+                <h4 class="mb-2">방화벽 규칙</h4>
+                <div id="detail-rule-empty" class="text-muted small d-none">등록된 규칙이 없습니다.</div>
+                <div class="table-responsive" id="detail-rule-table-wrap">
+                  <table class="table table-sm table-vcenter">
+                    <thead>
+                      <tr>
+                        <th>Direction</th>
+                        <th>Protocol</th>
+                        <th>From Port</th>
+                        <th>To Port</th>
+                        <th>CIDR</th>
+                      </tr>
+                    </thead>
+                    <tbody id="detail-rule-tbody"></tbody>
+                  </table>
+                </div>
+              </div>
             </div>
           </div>
         </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<!-- Create SecurityGroup 모달 -->
+<div class="modal modal-blur fade" id="create-sg-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">SecurityGroup 생성</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label required">Connection</label>
+          <select class="form-select" id="create-sg-connection"></select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label required">SG 이름</label>
+          <input type="text" class="form-control" id="create-sg-name" placeholder="예: my-sg">
+        </div>
+        <div class="mb-3">
+          <label class="form-label required">VPC 이름</label>
+          <input type="text" class="form-control" id="create-sg-vnet" placeholder="예: my-vpc">
+        </div>
+        <div class="mb-2">
+          <label class="form-label">방화벽 규칙</label>
+          <div id="create-sg-rule-list"></div>
+          <button type="button" class="btn btn-sm btn-outline-secondary mt-2"
+            onclick="webconsolejs['pages/settings/environment/cloudresources/securitygroups'].addFirewallRuleRow()">
+            + Add Rule
+          </button>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-primary" id="create-sg-execute-btn"
+          onclick="webconsolejs['pages/settings/environment/cloudresources/securitygroups'].executeCreateSG()">
+          <span id="create-sg-spinner" class="spinner-border spinner-border-sm d-none me-1" role="status"></span>
+          생성
+        </button>
       </div>
     </div>
   </div>
@@ -50,5 +210,6 @@
   </div>
 </div>
 
+{{ javascriptTag("common/api/services/securitygroup_api.js") | raw }}
 {{ javascriptTag("common/api/services/import_api.js") | raw }}
 {{ javascriptTag("pages/settings/environment/cloudresources/securitygroups.js") | raw }}

--- a/front/templates/pages/settings/environment/cloudresources/securitygroups.html
+++ b/front/templates/pages/settings/environment/cloudresources/securitygroups.html
@@ -145,16 +145,17 @@
       </div>
       <div class="modal-body">
         <div class="mb-3">
-          <label class="form-label required">Connection</label>
-          <select class="form-select" id="create-sg-connection"></select>
+          <label class="form-label required">VPC</label>
+          <select class="form-select" id="create-sg-vnet-select"></select>
+          <div class="form-text text-muted">VPC를 선택하면 Connection이 자동 설정됩니다.</div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label text-muted">Connection <span class="badge bg-secondary-lt ms-1">자동</span></label>
+          <input type="text" class="form-control bg-light" id="create-sg-connection-display" readonly placeholder="VPC 선택 시 자동 채움">
         </div>
         <div class="mb-3">
           <label class="form-label required">SG 이름</label>
           <input type="text" class="form-control" id="create-sg-name" placeholder="예: my-sg">
-        </div>
-        <div class="mb-3">
-          <label class="form-label required">VPC 이름</label>
-          <input type="text" class="form-control" id="create-sg-vnet" placeholder="예: my-vpc">
         </div>
         <div class="mb-2">
           <label class="form-label">방화벽 규칙</label>
@@ -210,6 +211,7 @@
   </div>
 </div>
 
+{{ javascriptTag("common/api/services/vpc_api.js") | raw }}
 {{ javascriptTag("common/api/services/securitygroup_api.js") | raw }}
 {{ javascriptTag("common/api/services/import_api.js") | raw }}
 {{ javascriptTag("pages/settings/environment/cloudresources/securitygroups.js") | raw }}

--- a/front/templates/pages/settings/environment/cloudresources/securitygroups.html
+++ b/front/templates/pages/settings/environment/cloudresources/securitygroups.html
@@ -4,10 +4,11 @@
       <div class="col-12">
         <div class="card">
           <div class="card-header">
-            <h3 class="card-title">SecurityGroup 목록</h3>
+            <h3 class="card-title">SecurityGroup List</h3>
             <div class="card-options ms-auto d-flex gap-2">
               <!-- Import SG -->
               <a class="btn-action" type="button" title="CSP 미관리 SecurityGroup 임포트"
+                title="Import unregistered SecurityGroups from CSP"
                 onclick="webconsolejs['pages/settings/environment/cloudresources/securitygroups'].openImportSGModal()">
                 <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
                   stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
@@ -73,7 +74,7 @@
         <div class="col-12">
           <div class="card">
             <div class="card-header">
-              <h3 class="card-title">SecurityGroup 상세 — <span id="detail-name" class="text-primary"></span></h3>
+              <h3 class="card-title">SecurityGroup Detail — <span id="detail-name" class="text-primary"></span></h3>
               <div class="card-options">
                 <button class="btn btn-sm btn-outline-danger me-1"
                   onclick="webconsolejs['pages/settings/environment/cloudresources/securitygroups'].confirmDeleteSG()">Delete</button>
@@ -88,6 +89,7 @@
               </div>
             </div>
             <div class="card-body">
+              <!-- Basic Info -->
               <div class="datagrid">
                 <div class="datagrid-item">
                   <div class="datagrid-title">Name</div>
@@ -102,28 +104,69 @@
                   <div class="datagrid-content" id="detail-sg-vnet">-</div>
                 </div>
                 <div class="datagrid-item">
+                  <div class="datagrid-title">Provider</div>
+                  <div class="datagrid-content" id="detail-sg-provider">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Region</div>
+                  <div class="datagrid-content" id="detail-sg-region">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Zone</div>
+                  <div class="datagrid-content" id="detail-sg-zone">-</div>
+                </div>
+              </div>
+              <!-- Identity Info -->
+              <div class="datagrid mt-3">
+                <div class="datagrid-item">
                   <div class="datagrid-title">CSP Resource ID</div>
                   <div class="datagrid-content"><code id="detail-sg-csp-id">-</code></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">CSP Resource Name</div>
+                  <div class="datagrid-content"><code id="detail-sg-csp-name">-</code></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">UID</div>
+                  <div class="datagrid-content"><code id="detail-sg-uid">-</code></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Description</div>
+                  <div class="datagrid-content" id="detail-sg-description">-</div>
                 </div>
               </div>
 
               <!-- Firewall Rules -->
               <div class="mt-3">
-                <h4 class="mb-2">방화벽 규칙</h4>
-                <div id="detail-rule-empty" class="text-muted small d-none">등록된 규칙이 없습니다.</div>
+                <h4 class="mb-2">Firewall Rules</h4>
+                <div id="detail-rule-empty" class="text-muted small d-none">No firewall rules registered.</div>
                 <div class="table-responsive" id="detail-rule-table-wrap">
                   <table class="table table-sm table-vcenter">
                     <thead>
                       <tr>
                         <th>Direction</th>
                         <th>Protocol</th>
-                        <th>From Port</th>
-                        <th>To Port</th>
+                        <th>Port</th>
                         <th>CIDR</th>
                       </tr>
                     </thead>
                     <tbody id="detail-rule-tbody"></tbody>
                   </table>
+                </div>
+              </div>
+
+              <!-- CSP Detail Info (keyValueList) -->
+              <div class="mt-3">
+                <button type="button" class="btn btn-link btn-sm text-muted p-0 text-decoration-none"
+                  data-bs-toggle="collapse" data-bs-target="#detail-kv-collapse">
+                  CSP Detail Info ▾
+                </button>
+                <div class="collapse" id="detail-kv-collapse">
+                  <div class="table-responsive mt-1">
+                    <table class="table table-sm table-vcenter">
+                      <tbody id="detail-kv-tbody"></tbody>
+                    </table>
+                  </div>
                 </div>
               </div>
             </div>
@@ -140,25 +183,25 @@
   <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">SecurityGroup 생성</h5>
+        <h5 class="modal-title">Create SecurityGroup</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
         <div class="mb-3">
           <label class="form-label required">VPC</label>
           <select class="form-select" id="create-sg-vnet-select"></select>
-          <div class="form-text text-muted">VPC를 선택하면 Connection이 자동 설정됩니다.</div>
+          <div class="form-text text-muted">Selecting a VPC will auto-fill the Connection.</div>
         </div>
         <div class="mb-3">
-          <label class="form-label text-muted">Connection <span class="badge bg-secondary-lt ms-1">자동</span></label>
-          <input type="text" class="form-control bg-light" id="create-sg-connection-display" readonly placeholder="VPC 선택 시 자동 채움">
+          <label class="form-label text-muted">Connection <span class="badge bg-secondary-lt ms-1">auto</span></label>
+          <input type="text" class="form-control bg-light" id="create-sg-connection-display" readonly placeholder="Auto-filled when VPC is selected">
         </div>
         <div class="mb-3">
-          <label class="form-label required">SG 이름</label>
-          <input type="text" class="form-control" id="create-sg-name" placeholder="예: my-sg">
+          <label class="form-label required">SG Name</label>
+          <input type="text" class="form-control" id="create-sg-name" placeholder="e.g. my-sg">
         </div>
         <div class="mb-2">
-          <label class="form-label">방화벽 규칙</label>
+          <label class="form-label">Firewall Rules</label>
           <div id="create-sg-rule-list"></div>
           <button type="button" class="btn btn-sm btn-outline-secondary mt-2"
             onclick="webconsolejs['pages/settings/environment/cloudresources/securitygroups'].addFirewallRuleRow()">
@@ -167,11 +210,11 @@
         </div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
         <button type="button" class="btn btn-primary" id="create-sg-execute-btn"
           onclick="webconsolejs['pages/settings/environment/cloudresources/securitygroups'].executeCreateSG()">
           <span id="create-sg-spinner" class="spinner-border spinner-border-sm d-none me-1" role="status"></span>
-          생성
+          Create
         </button>
       </div>
     </div>
@@ -183,28 +226,28 @@
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">SecurityGroup 임포트</h5>
+        <h5 class="modal-title">Import SecurityGroup</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
         <div class="alert alert-info mb-3">
-          선택된 Connection의 미등록 SecurityGroup 전체가 현재 프로젝트에 등록됩니다.
+          All unregistered SecurityGroups for the selected Connection will be imported into the current project.
         </div>
         <div class="mb-3">
           <label class="form-label">Connection</label>
           <select class="form-select" id="import-sg-connection"></select>
         </div>
         <div class="mb-2">
-          <label class="form-label">대상 프로젝트</label>
+          <label class="form-label">Target Project</label>
           <input type="text" class="form-control" id="import-sg-project" readonly>
         </div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
         <button type="button" class="btn btn-primary"
           onclick="webconsolejs['pages/settings/environment/cloudresources/securitygroups'].executeImportSG()">
           <span id="import-sg-spinner" class="spinner-border spinner-border-sm d-none me-1" role="status"></span>
-          Import 실행
+          Import
         </button>
       </div>
     </div>

--- a/front/templates/pages/settings/environment/cloudresources/sshkeys.html
+++ b/front/templates/pages/settings/environment/cloudresources/sshkeys.html
@@ -1,17 +1,168 @@
 <div class="page-body">
   <div class="container-xl">
-    <div id="index" class="section">
-      <div class="row row-cards">
+    <div class="row row-cards">
+      <div class="col-12">
+        <div class="card">
+          <div class="card-header">
+            <h3 class="card-title">SSH Key 목록</h3>
+            <div class="card-options ms-auto d-flex gap-2">
+              <!-- Import SSH Key -->
+              <a class="btn-action" type="button" title="CSP 미관리 SSH Key 임포트"
+                onclick="webconsolejs['pages/settings/environment/cloudresources/sshkeys'].openImportSshKeyModal()">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                  <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2"/>
+                  <path d="M7 11l5 5l5 -5"/>
+                  <path d="M12 4l0 12"/>
+                </svg>
+              </a>
+              <!-- Filter toggle -->
+              <a class="btn-action" type="button" data-bs-toggle="collapse" data-bs-target="#filter-body" aria-expanded="false">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                  <path d="M5.5 5h13a1 1 0 0 1 .5 1.5L14 12L14 19L10 16L10 12L5 6.5a1 1 0 0 1 .5 -1.5"/>
+                </svg>
+              </a>
+            </div>
+          </div>
+
+          <!-- Filter Panel -->
+          <div class="collapse" id="filter-body">
+            <div class="card-body border-bottom py-3">
+              <div class="row g-2 align-items-end">
+                <div class="col-auto">
+                  <label class="form-label mb-1">Field</label>
+                  <select id="filter-field" class="form-select form-select-sm">
+                    <option value="">-- select --</option>
+                    <option value="name">Name</option>
+                    <option value="connectionName">Connection</option>
+                  </select>
+                </div>
+                <div class="col-auto">
+                  <label class="form-label mb-1">Type</label>
+                  <select id="filter-type" class="form-select form-select-sm">
+                    <option value="like">like</option>
+                    <option value="=">=</option>
+                    <option value="!=">!=</option>
+                  </select>
+                </div>
+                <div class="col">
+                  <label class="form-label mb-1">Value</label>
+                  <input type="text" id="filter-value" class="form-control form-control-sm" placeholder="filter...">
+                </div>
+                <div class="col-auto">
+                  <button id="filter-clear" class="btn btn-sm btn-outline-secondary">Clear</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card-body p-0">
+            <div id="sshkey-list-table"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Detail Panel -->
+    <div id="view-mode-cards" class="collapse">
+      <div class="row row-cards mt-2">
         <div class="col-12">
           <div class="card">
             <div class="card-header">
-              <h3 class="card-title">SSH Key 목록</h3>
+              <h3 class="card-title">SSH Key 상세 — <span id="detail-name" class="text-primary"></span></h3>
+              <div class="card-options">
+                <button class="btn btn-sm btn-outline-danger me-1"
+                  onclick="webconsolejs['pages/settings/environment/cloudresources/sshkeys'].confirmDeleteSshKey()">Delete</button>
+                <a href="#" class="card-options-remove"
+                  onclick="webconsolejs['pages/settings/environment/cloudresources/sshkeys'].hideDetail()">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                    stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                    <path d="M18 6l-12 12"/><path d="M6 6l12 12"/>
+                  </svg>
+                </a>
+              </div>
             </div>
-            <div class="card-body p-0">
-              <div id="sshkey-list-table"></div>
+            <div class="card-body">
+              <div class="datagrid">
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Name</div>
+                  <div class="datagrid-content" id="detail-key-name">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Connection</div>
+                  <div class="datagrid-content" id="detail-key-connection">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Fingerprint</div>
+                  <div class="datagrid-content"><code id="detail-key-fingerprint">-</code></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">CSP Resource ID</div>
+                  <div class="datagrid-content"><code id="detail-key-csp-id">-</code></div>
+                </div>
+              </div>
+
+              <!-- Public Key -->
+              <div class="mt-3">
+                <h4 class="mb-2">Public Key</h4>
+                <div id="detail-pubkey-empty" class="text-muted small d-none">없음</div>
+                <pre id="detail-pubkey" class="pre-scrollable bg-light p-2 rounded small" style="max-height:120px;word-break:break-all;white-space:pre-wrap;"></pre>
+              </div>
+
+              <!-- Private Key (생성 직후에만 표시) -->
+              <div class="mt-3" id="detail-privkey-section" style="display:none">
+                <div class="d-flex align-items-center gap-2 mb-2">
+                  <h4 class="mb-0">Private Key</h4>
+                  <span class="badge bg-warning-lt">생성 직후에만 확인 가능</span>
+                  <button type="button" class="btn btn-sm btn-outline-secondary ms-auto" id="toggle-privkey-btn"
+                    onclick="webconsolejs['pages/settings/environment/cloudresources/sshkeys'].togglePrivateKey()">
+                    보기
+                  </button>
+                </div>
+                <pre id="detail-privkey" class="pre-scrollable bg-light p-2 rounded small"
+                  style="max-height:200px;word-break:break-all;white-space:pre-wrap;filter:blur(4px);user-select:none;"></pre>
+              </div>
             </div>
           </div>
         </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<!-- Create SSH Key 모달 -->
+<div class="modal modal-blur fade" id="create-sshkey-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">SSH Key 생성</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="alert alert-warning mb-3">
+          <strong>주의:</strong> Private Key는 생성 직후에만 확인할 수 있습니다. 반드시 복사해 두세요.
+        </div>
+        <div class="mb-3">
+          <label class="form-label required">Connection</label>
+          <select class="form-select" id="create-sshkey-connection"></select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label required">Key 이름</label>
+          <input type="text" class="form-control" id="create-sshkey-name" placeholder="예: my-ssh-key">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-primary" id="create-sshkey-execute-btn"
+          onclick="webconsolejs['pages/settings/environment/cloudresources/sshkeys'].executeCreateSshKey()">
+          <span id="create-sshkey-spinner" class="spinner-border spinner-border-sm d-none me-1" role="status"></span>
+          생성
+        </button>
       </div>
     </div>
   </div>
@@ -50,5 +201,6 @@
   </div>
 </div>
 
+{{ javascriptTag("common/api/services/sshkey_api.js") | raw }}
 {{ javascriptTag("common/api/services/import_api.js") | raw }}
 {{ javascriptTag("pages/settings/environment/cloudresources/sshkeys.js") | raw }}


### PR DESCRIPTION
## Summary

- Create 모달: VPC 텍스트 입력 → 드롭다운 (`getAllVNet`) + Connection 자동 채움
- firewallRules 필드명 수정 (`Port`/`Protocol`/`Direction`/`CIDR` 대소문자 일치)
- Detail 패널: Provider / Region / Zone / CSP Resource Name / UID / Description 6개 항목 추가
- keyValueList CSP 상세 정보 접이식 섹션 추가
- 화면 한글 문구 전체 영문화
- `conf/api.yaml` 중복 키(`GetProviderList`) 제거

## Test plan

- [ ] SecurityGroups 목록 조회 정상 동작
- [ ] Create SG: VPC 드롭다운 표시 → Connection 자동 채움 → 생성 성공
- [ ] Detail 패널: Provider/Region/Zone 등 신규 항목 표시 확인
- [ ] Firewall Rules 테이블 값 정상 표시 (이전: 모두 '-')
- [ ] CSP Detail Info 접이식 섹션 동작 확인
- [ ] Import SG 정상 동작