### PR TITLE
fix(onboarding): MCI workload lifecycle action 버튼 수정

### DIFF
--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -97,6 +97,9 @@ func main() {
 	authProtected.POST("/logout", handler.Logout)
 	authProtected.GET("/userinfo", handler.UserInfo)
 
+	// 단일 세그먼트 내부 핸들러
+	api.POST("/disklookup", handler.DiskLookup)
+
 	// 서브시스템 프록시 라우트 (Buffalo SubsystemAnyController 호환)
 	// POST /api/:subsystemName/:operationId → conf/api.yaml 기반으로 백엔드 서비스에 프록시
 	api.Any("/:subsystemName/:operationId", handler.SubsystemAnyController)

--- a/api/internal/config/api_spec.go
+++ b/api/internal/config/api_spec.go
@@ -29,9 +29,10 @@ type AuthConfig struct {
 
 // ActionSpec API 액션 스펙
 type ActionSpec struct {
-	Method       string `mapstructure:"method"`
-	ResourcePath string `mapstructure:"resourcePath"`
-	Description  string `mapstructure:"description"`
+	Method        string            `mapstructure:"method"`
+	ResourcePath  string            `mapstructure:"resourcePath"`
+	Description   string            `mapstructure:"description"`
+	RequestCoerce map[string]string `mapstructure:"requestCoerce"` // "fieldName" → "int"|"float"|"bool"
 }
 
 // LoadApiSpec conf/api.yaml 파일 로드

--- a/api/internal/handler/disk.go
+++ b/api/internal/handler/disk.go
@@ -1,0 +1,86 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"mc_web_console_api/internal/model"
+)
+
+type diskLookupReq struct {
+	QueryParams struct {
+		Provider       string `json:"provider"`
+		ConnectionName string `json:"connectionName"`
+	} `json:"queryParams"`
+}
+
+type diskTypeInfo struct {
+	ProviderID   string   `json:"providerId"`
+	RootDiskType []string `json:"rootdisktype"`
+	DiskSize     []string `json:"disksize"`
+}
+
+var diskTypeTable = []diskTypeInfo{
+	{
+		ProviderID:   "AWS",
+		RootDiskType: []string{"standard", "gp2", "gp3"},
+		DiskSize:     []string{"standard|1|1024|GB", "gp2|1|16384|GB", "gp3|1|16384|GB", "io1|4|16384|GB", "io2|4|16384|GB", "st1|125|16384|GB", "sc1|125|16384|GB"},
+	},
+	{
+		ProviderID:   "GCP",
+		RootDiskType: []string{"pd-standard", "pd-balanced", "pd-ssd", "pd-extreme"},
+		DiskSize:     []string{"pd-standard|10|65536|GB", "pd-balanced|10|65536|GB", "pd-ssd|10|65536|GB", "pd-extreme|500|65536|GB"},
+	},
+	{
+		ProviderID:   "ALIBABA",
+		RootDiskType: []string{"cloud_essd", "cloud_efficiency", "cloud", "cloud_ssd"},
+		DiskSize:     []string{"cloud|5|2000|GB", "cloud_efficiency|20|32768|GB", "cloud_ssd|20|32768|GB", "cloud_essd_PL0|40|32768|GB", "cloud_essd_PL1|20|32768|GB"},
+	},
+	{
+		ProviderID:   "AZURE",
+		RootDiskType: []string{"Standard_LRS", "StandardSSD_LRS", "Premium_LRS", "UltraSSD_LRS"},
+		DiskSize:     []string{"Standard_LRS|1|32767|GB", "StandardSSD_LRS|1|32767|GB", "Premium_LRS|4|32767|GB", "UltraSSD_LRS|4|65536|GB"},
+	},
+	{
+		ProviderID:   "TENCENT",
+		RootDiskType: []string{"CLOUD_PREMIUM", "CLOUD_SSD"},
+		DiskSize:     []string{"CLOUD_PREMIUM|10|32000|GB", "CLOUD_SSD|20|32000|GB", "CLOUD_HSSD|20|32000|GB"},
+	},
+	{
+		ProviderID:   "NCP",
+		RootDiskType: []string{"HDD", "SSD"},
+		DiskSize:     []string{"HDD|10|2000|GB", "SSD|10|2000|GB"},
+	},
+	{
+		ProviderID:   "NHN",
+		RootDiskType: []string{"General HDD", "General SSD"},
+		DiskSize:     []string{"General HDD|20|2048|GB", "General SSD|20|2048|GB"},
+	},
+	{
+		ProviderID:   "IBM",
+		RootDiskType: []string{"BLOCK_STORAGE"},
+		DiskSize:     []string{"BLOCK_STORAGE|10|2000|GB"},
+	},
+}
+
+func DiskLookup(c echo.Context) error {
+	var req diskLookupReq
+	if err := c.Bind(&req); err != nil {
+		return err
+	}
+
+	provider := strings.TrimSpace(req.QueryParams.Provider)
+	if provider == "" {
+		return c.JSON(http.StatusOK, model.CommonResponseStatusOK(diskTypeTable))
+	}
+
+	upper := strings.ToUpper(provider)
+	for _, info := range diskTypeTable {
+		if info.ProviderID == upper {
+			return c.JSON(http.StatusOK, model.CommonResponseStatusOK([]diskTypeInfo{info}))
+		}
+	}
+
+	return c.JSON(http.StatusOK, model.CommonResponseStatusOK([]diskTypeInfo{}))
+}

--- a/api/internal/handler/proxy.go
+++ b/api/internal/handler/proxy.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"mc_web_console_api/internal/config"
@@ -85,6 +86,9 @@ func SubsystemAnyController(c echo.Context) error {
 	// 요청 바디
 	var bodyBytes []byte
 	if commonRequest.Request != nil {
+		if len(effectiveActionSpec.RequestCoerce) > 0 {
+			coerceRequestFields(commonRequest.Request, effectiveActionSpec.RequestCoerce)
+		}
 		bodyBytes, _ = json.Marshal(commonRequest.Request)
 	}
 
@@ -163,4 +167,33 @@ func buildAuthHeader(c echo.Context, service *config.Service) string {
 		}
 	}
 	return ""
+}
+
+// coerceRequestFields whitelist 방식으로 요청 바디의 특정 필드 타입을 변환한다.
+// coerceMap: 필드명 → "int"|"float"|"bool". 선언되지 않은 필드는 건드리지 않는다.
+func coerceRequestFields(req map[string]interface{}, coerceMap map[string]string) {
+	for key, targetType := range coerceMap {
+		val, ok := req[key]
+		if !ok {
+			continue
+		}
+		strVal, ok := val.(string)
+		if !ok {
+			continue
+		}
+		switch targetType {
+		case "int":
+			if n, err := strconv.Atoi(strVal); err == nil {
+				req[key] = n
+			}
+		case "float":
+			if f, err := strconv.ParseFloat(strVal, 64); err == nil {
+				req[key] = f
+			}
+		case "bool":
+			if b, err := strconv.ParseBool(strVal); err == nil {
+				req[key] = b
+			}
+		}
+	}
 }

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -4554,6 +4554,8 @@ serviceActions:
 
         Get available options by /recommendSpecOptions for filtering and prioritizing
         specs in RecommendSpec API'
+      requestCoerce:
+        limit: int
     RecommendSpecOptions:
       method: get
       resourcePath: /recommendSpecOptions
@@ -4807,10 +4809,6 @@ serviceActions:
       method: delete
       resourcePath: /ns/{nsId}/resources/spec/{specId}
       description: "Delete spec"
-    GetProviderList:
-      method: get
-      resourcePath: /provider
-      description: "List all registered cloud providers (aws, azure, gcp, ...)"
     SetBastionNodesWithMci:
       method: put
       resourcePath: /ns/{nsId}/mci/{mciId}/vm/{targetVmId}/bastion/{bastionMciId}/{bastionVmId}

--- a/front/assets/js/application.js
+++ b/front/assets/js/application.js
@@ -1,5 +1,3 @@
 require("expose-loader?exposes=$,jQuery!jquery");
-const bootstrap = require("bootstrap/dist/js/bootstrap.bundle.js");
-window.bootstrap = bootstrap;
 require("@fortawesome/fontawesome-free/js/all.js");
 require("jquery-ujs/src/rails.js");

--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -225,10 +225,10 @@ export async function mciDynamicReview(mciName, mciDesc, Express_Server_Config_A
     specId: config.commonSpec,
     imageId: config.commonImage,
     name: config.name,
-    subGroupSize: config.subGroupSize,
+    subGroupSize: parseInt(config.subGroupSize) || 1,
     connectionName: config.connectionName,
     description: config.description,
-    rootDiskSize: config.rootDiskSize,
+    rootDiskSize: (config.rootDiskSize !== "" && config.rootDiskSize !== undefined) ? parseInt(config.rootDiskSize) : 0,
     rootDiskType: config.rootDiskType,
     label: config.label || {},
     vmUserPassword: config.vmUserPassword || ""
@@ -274,10 +274,10 @@ export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, ns
     specId: config.commonSpec,
     imageId: config.commonImage,
     name: config.name,
-    subGroupSize: config.subGroupSize,
+    subGroupSize: parseInt(config.subGroupSize) || 1,
     connectionName: config.connectionName,
     description: config.description,
-    rootDiskSize: config.rootDiskSize,
+    rootDiskSize: (config.rootDiskSize !== "" && config.rootDiskSize !== undefined) ? parseInt(config.rootDiskSize) : 0,
     rootDiskType: config.rootDiskType
   }));
 
@@ -365,7 +365,7 @@ export async function searchImage(nsId, searchParams) {
     request: searchParams
   };
 
-  var controller = "/api/" + "mc-infra-manager/" + "Searchimage";
+  var controller = "/api/" + "mc-infra-manager/" + "SearchImage";
   const response = await webconsolejs["common/api/http"].commonAPIPost(
     controller,
     data

--- a/front/assets/js/pages/operation/manage/mci.js
+++ b/front/assets/js/pages/operation/manage/mci.js
@@ -616,6 +616,10 @@ function executeWithToast(apiCall, successMessage, errorMessage) {
 
 // mci life cycle 변경
 export function changeMciLifeCycle(type) {
+  if (window.currentMciId == undefined || window.currentMciId == "") {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Validation', 'Please select an MCI')
+    return;
+  }
   executeWithToast(
     () => webconsolejs["common/api/services/mci_api"].mciLifeCycle(type, window.currentMciId, window.currentNsId),
     `MCI ${type} completed successfully`,

--- a/front/assets/js/partials/layout/modal.js
+++ b/front/assets/js/partials/layout/modal.js
@@ -11,6 +11,7 @@ export function commonModal(elm, title, content, func, argument) {
     document.getElementById(`${form}-content`).innerText = content
     document.getElementById(`${form}-confirm-btn`).onclick = function () {
         const executefunction = `webconsolejs["${funcArr[0]}"].${funcArr[1]}('${argument}')`;
+        modalHide(form);
         eval(executefunction);
     };
 }
@@ -57,8 +58,8 @@ export function commonShowDefaultModal(title, content) {
 // modalId = ex)'spec-search'
 export function modalHide(modalId) {
     var myModalEl = document.getElementById(modalId);
-    var modal = bootstrap.Modal.getInstance(myModalEl); // Returns a Bootstrap modal instance
-    modal.hide();
+    var modal = bootstrap.Modal.getInstance(myModalEl);
+    if (modal) modal.hide();
 }
 
 // workspace selection 여부 확인 function

--- a/front/assets/js/partials/operation/manage/serverrecommendation.js
+++ b/front/assets/js/partials/operation/manage/serverrecommendation.js
@@ -458,7 +458,7 @@ export async function getRecommendVmInfo() {
 						"val": [lat + "/" + lon]
 					}
 				],
-				"weight": "0.3"
+				"weight": 0.3
 			};
 			priorityArr.push(priorityPolicy);
 		}
@@ -466,7 +466,7 @@ export async function getRecommendVmInfo() {
 		// 비용 우선순위 (낮은 시간당 비용 우선)
 		var costPriorityPolicy = {
 			"metric": "costPerHour",
-			"weight": "1.0"
+			"weight": 1.0
 		};
 		priorityArr.push(costPriorityPolicy);
 	}
@@ -475,21 +475,25 @@ export async function getRecommendVmInfo() {
 			"filter": {
 				"policy": policyArr
 			},
-			"limit": "1000",
+			"limit": 1000,
 			"priority": {
 				"policy": priorityArr,
 			}
 		}
 	}
 	
+	$("#spec-table-loading").removeClass("d-none");
+	$("#spec-table").addClass("d-none");
 	var respData = await webconsolejs["common/api/services/mci_api"].mciRecommendVm(data);
+	$("#spec-table-loading").addClass("d-none");
+	$("#spec-table").removeClass("d-none");
 	//var specList = response.data.responseData
 	if (respData.status.code != 200) {
 		console.error(e)
 		// TODO : Error 표시
 		return
 	}
-	recommendVmSpecListObj = respData.responseData	
+	recommendVmSpecListObj = respData.responseData
 	recommendTable.setData(recommendVmSpecListObj)
 
 }

--- a/front/templates/application.html
+++ b/front/templates/application.html
@@ -55,7 +55,8 @@
   {{ javascriptTag("common/storage/sessionstorage.js") | raw }}
   {{ javascriptTag("partials/layout/navigatePages.js") | raw }}
   {{ javascriptTag("partials/layout/modal.js") | raw }}
-  
+  {{ javascriptTag("common/utils/toast.js") | raw }}
+
   </body>
 
   <script>

--- a/front/templates/partials/operation/manage/_serverrecommendation.html
+++ b/front/templates/partials/operation/manage/_serverrecommendation.html
@@ -320,6 +320,10 @@
             </select>
           </div>
         </div>
+        <div id="spec-table-loading" class="text-center py-5 d-none">
+          <div class="spinner-border text-primary" role="status"></div>
+          <div class="text-muted mt-2 small">Loading specs...</div>
+        </div>
         <div class="table-responsive" id="spec-table"></div>
       </div>
 


### PR DESCRIPTION
## Summary

- `application.js` 중복 Bootstrap 인스턴스 제거 — tabler.js가 이미 `globalThis.bootstrap`을 설정하므로, application.js에서 재로드 시 두 인스턴스가 dropdown toggle 이벤트를 이중 처리하여 dropdown이 열리지 않던 현상 해소
- `modal.js` `commonModal` confirm 핸들러에 `modalHide` 명시적 호출 추가 — confirm 클릭 후 모달이 닫히지 않던 현상 해소, `modalHide` null-safe 처리 추가
- `application.html` toast.js 전역 로드 추가 — `executeWithToast()` 호출 시 `webconsolejs["common/utils/toast"]` undefined TypeError 해소
- `mci.js` `changeMciLifeCycle` currentMciId 유효성 검사 추가
- `api/internal/handler/disk.go` 신규 — `/api/disklookup` 엔드포인트 구현 (정적 CSP별 디스크 타입 데이터 반환)
- `api/internal/handler/proxy.go` requestCoerce 기능 추가 — api.yaml 선언 기반 타입 강제 변환

## Test plan

- [ ] MCI workload 화면 action item 드롭다운 정상 열림 확인
- [ ] Resume/Terminate/Suspend/Reboot 클릭 → Confirm 클릭 → 모달 닫힘 + API 호출 확인
- [ ] 자원 추천 화면 recommendSpec 정상 호출 (200) 확인
- [ ] disklookup CSP별 디스크 타입 목록 반환 확인