### PR TITLE
[Feature] RQ-CLOUD-ADMIN-005 Resource Sync 화면 구현

### DIFF
--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -97,8 +97,6 @@ func main() {
 	authProtected.POST("/logout", handler.Logout)
 	authProtected.GET("/userinfo", handler.UserInfo)
 
-	// 서브시스템 프록시 라우트 (Buffalo SubsystemAnyController 호환)
-	// POST /api/:subsystemName/:operationId → conf/api.yaml 기반으로 백엔드 서비스에 프록시
 	api.Any("/:subsystemName/:operationId", handler.SubsystemAnyController)
 
 	// 테스트 엔드포인트들

--- a/api/internal/handler/proxy.go
+++ b/api/internal/handler/proxy.go
@@ -72,12 +72,21 @@ func SubsystemAnyController(c echo.Context) error {
 		resourcePath = strings.ReplaceAll(resourcePath, "{"+k+"}", v)
 	}
 
-	// QueryParams 추가
+	// QueryParams 추가 (string 또는 []interface{} 배열 모두 처리)
 	targetURL := effectiveBaseURL + resourcePath
 	if len(commonRequest.QueryParams) > 0 {
 		params := []string{}
 		for k, v := range commonRequest.QueryParams {
-			params = append(params, k+"="+v)
+			switch val := v.(type) {
+			case string:
+				params = append(params, k+"="+val)
+			case []interface{}:
+				for _, item := range val {
+					params = append(params, k+"="+fmt.Sprint(item))
+				}
+			default:
+				params = append(params, k+"="+fmt.Sprint(val))
+			}
 		}
 		targetURL += "?" + strings.Join(params, "&")
 	}

--- a/api/internal/model/request.go
+++ b/api/internal/model/request.go
@@ -4,7 +4,7 @@ package model
 // Buffalo의 CommonRequest와 동일한 구조 유지
 type CommonRequest struct {
 	PathParams  map[string]string      `json:"pathParams"`
-	QueryParams map[string]string      `json:"queryParams"`
+	QueryParams map[string]interface{} `json:"queryParams"`
 	Request     map[string]interface{} `json:"request"`
 }
 
@@ -12,7 +12,7 @@ type CommonRequest struct {
 func NewCommonRequest() *CommonRequest {
 	return &CommonRequest{
 		PathParams:  make(map[string]string),
-		QueryParams: make(map[string]string),
+		QueryParams: make(map[string]interface{}),
 		Request:     make(map[string]interface{}),
 	}
 }
@@ -24,7 +24,7 @@ func (r *CommonRequest) GetPathParam(key string) (string, bool) {
 }
 
 // GetQueryParam QueryParams에서 값 조회
-func (r *CommonRequest) GetQueryParam(key string) (string, bool) {
+func (r *CommonRequest) GetQueryParam(key string) (interface{}, bool) {
 	val, exists := r.QueryParams[key]
 	return val, exists
 }

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -1197,6 +1197,14 @@ serviceActions:
       method: post
       resourcePath: /api/csp-accounts/id/{accountId}/deactivate
       description: CSP 계정 비활성화
+    GetProjectSyncDiff:
+      method: get
+      resourcePath: /api/setup/projects/sync-diff
+      description: "Infra NS ↔ IAM Project 동기화 차이 조회"
+    ApplyProjectSync:
+      method: post
+      resourcePath: /api/setup/projects/sync
+      description: "nsIds + workspaceId를 받아 Project 생성 + Workspace 할당"
   mc-infra-manager:
     GetInfraReadyzInit:
       method: put

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -4807,10 +4807,6 @@ serviceActions:
       method: delete
       resourcePath: /ns/{nsId}/resources/spec/{specId}
       description: "Delete spec"
-    GetProviderList:
-      method: get
-      resourcePath: /provider
-      description: "List all registered cloud providers (aws, azure, gcp, ...)"
     SetBastionNodesWithMci:
       method: put
       resourcePath: /ns/{nsId}/mci/{mciId}/vm/{targetVmId}/bastion/{bastionMciId}/{bastionVmId}

--- a/conf/selfiammenu.yaml
+++ b/conf/selfiammenu.yaml
@@ -1,30 +1,429 @@
+version: '1.0'
+exported_at: '2026-04-27T07:48:03.033Z'
 menus:
-  - id: depth1
-    parentmenuid: ""
-    displayname: depth1
-    isaction: "false"
-    priority: "0"
-
-  - id: depth2
-    parentmenuid: depth1
-    displayname: depth2
-    isaction: "false"
-    priority: "0"
-
-  - id: depth3
-    parentmenuid: depth2
-    displayname: depth3
-    isaction: "false"
-    priority: "0"
-
-  - id: menu1
-    parentmenuid: depth3
-    displayname: menu1
-    isaction: "true"
-    priority: "0"
-
-  - id: menu2
-    parentmenuid: depth3
-    displayname: menu2
-    isaction: "true"
-    priority: "1"
+  - displayName: Networks
+    id: networks
+    isAction: true
+    menuNumber: 1510
+    parentId: cloudresources
+    priority: 1
+    resType: menu
+  - displayName: Account & Access
+    id: accountnaccess
+    isAction: false
+    menuNumber: 1201
+    parentId: settings
+    priority: 2
+    resType: menu
+  - displayName: Organizations
+    id: organizations
+    isAction: false
+    menuNumber: 1205
+    parentId: accountnaccess
+    priority: 2
+    resType: menu
+  - displayName: Company Info
+    id: companyinfo
+    isAction: false
+    menuNumber: 1212
+    parentId: organizations
+    priority: 2
+    resType: menu
+  - displayName: Users
+    id: users
+    isAction: true
+    menuNumber: 1220
+    parentId: organizations
+    priority: 2
+    resType: menu
+  - displayName: Groups
+    id: groups
+    isAction: true
+    menuNumber: 1225
+    parentId: organizations
+    priority: 2
+    resType: menu
+  - displayName: Approvals
+    id: approvals
+    isAction: true
+    menuNumber: 1230
+    parentId: organizations
+    priority: 2
+    resType: menu
+  - displayName: Access Controls
+    id: accesscontrols
+    isAction: false
+    menuNumber: 1240
+    parentId: organizations
+    priority: 2
+    resType: menu
+  - displayName: Menus
+    id: menus
+    isAction: true
+    menuNumber: 1250
+    parentId: organizations
+    priority: 2
+    resType: menu
+  - displayName: Environment
+    id: environment
+    isAction: false
+    menuNumber: 1301
+    parentId: settings
+    priority: 2
+    resType: menu
+  - displayName: Cloud SPs
+    id: cloudsps
+    isAction: false
+    menuNumber: 1305
+    parentId: environment
+    priority: 2
+    resType: menu
+  - displayName: Cloud Overview
+    id: cloudoverview
+    isAction: true
+    menuNumber: 1310
+    parentId: cloudsps
+    priority: 2
+    resType: menu
+  - displayName: Regions
+    id: regions
+    isAction: true
+    menuNumber: 1320
+    parentId: cloudsps
+    priority: 2
+    resType: menu
+  - displayName: Connections
+    id: connections
+    isAction: true
+    menuNumber: 1330
+    parentId: cloudsps
+    priority: 2
+    resType: menu
+  - displayName: Cloud Drivers
+    id: clouddrivers
+    isAction: true
+    menuNumber: 1340
+    parentId: cloudsps
+    priority: 2
+    resType: menu
+  - displayName: Credentials
+    id: credentials
+    isAction: true
+    menuNumber: 1350
+    parentId: cloudsps
+    priority: 2
+    resType: menu
+  - displayName: Cloud Resources
+    id: cloudresources
+    isAction: false
+    menuNumber: 1405
+    parentId: environment
+    priority: 2
+    resType: menu
+  - displayName: Securitys
+    id: securitygroups
+    isAction: true
+    menuNumber: 1520
+    parentId: cloudresources
+    priority: 2
+    resType: menu
+  - displayName: Cloud Res Catalogs
+    id: cloudrescatalogs
+    isAction: false
+    menuNumber: 1560
+    parentId: environment
+    priority: 2
+    resType: menu
+  - displayName: Workspaces Settings
+    id: workspacessettings
+    isAction: false
+    menuNumber: 1660
+    parentId: environment
+    priority: 2
+    resType: menu
+  - displayName: Allocated Projects
+    id: allocatedprojects
+    isAction: false
+    menuNumber: 1665
+    parentId: workspacessettings
+    priority: 2
+    resType: menu
+  - displayName: Share Members
+    id: sharemembers
+    isAction: false
+    menuNumber: 1666
+    parentId: workspacessettings
+    priority: 2
+    resType: menu
+  - displayName: Access Controls
+    id: allocaterolesws
+    isAction: false
+    menuNumber: 1667
+    parentId: workspacessettings
+    priority: 2
+    resType: menu
+  - displayName: Operations
+    id: operations
+    isAction: false
+    menuNumber: 1700
+    parentId: home
+    priority: 2
+    resType: menu
+  - displayName: Manage
+    id: manage
+    isAction: false
+    menuNumber: 1701
+    parentId: operations
+    priority: 2
+    resType: menu
+  - displayName: Workspaces
+    id: workspaces
+    isAction: true
+    menuNumber: 1710
+    parentId: manage
+    priority: 2
+    resType: menu
+  - displayName: Projects
+    id: projects
+    isAction: false
+    menuNumber: 1720
+    parentId: workspaces
+    priority: 2
+    resType: menu
+  - displayName: Project board
+    id: projectboard
+    isAction: false
+    menuNumber: 1728
+    parentId: workspaces
+    priority: 2
+    resType: menu
+  - displayName: Members
+    id: members
+    isAction: false
+    menuNumber: 1730
+    parentId: workspaces
+    priority: 2
+    resType: menu
+  - displayName: Roles
+    id: roles
+    isAction: true
+    menuNumber: 1740
+    parentId: workspaces
+    priority: 2
+    resType: menu
+  - displayName: CSP Roles
+    id: csproles
+    isAction: true
+    menuNumber: 1741
+    parentId: workspaces
+    priority: 2
+    resType: menu
+  - displayName: Workloads
+    id: workloads
+    isAction: false
+    menuNumber: 1750
+    parentId: manage
+    priority: 2
+    resType: menu
+  - displayName: MCI Workloads
+    id: mciworkloads
+    isAction: true
+    menuNumber: 1760
+    parentId: workloads
+    priority: 2
+    resType: menu
+  - displayName: PMK Workloads
+    id: pmkworkloads
+    isAction: true
+    menuNumber: 1790
+    parentId: workloads
+    priority: 2
+    resType: menu
+  - displayName: Monitorings
+    id: monitorings
+    isAction: false
+    menuNumber: 1905
+    parentId: analytics
+    priority: 2
+    resType: menu
+  - displayName: MCIs Monitoring
+    id: mcismonitoring
+    isAction: true
+    menuNumber: 1910
+    parentId: monitorings
+    priority: 2
+    resType: menu
+  - displayName: 3rd party Monitoring
+    id: 3rdpartymonitoring
+    isAction: false
+    menuNumber: 1930
+    parentId: monitorings
+    priority: 2
+    resType: menu
+  - displayName: Monitoring Config
+    id: monitoringconfig
+    isAction: true
+    menuNumber: 1940
+    parentId: monitorings
+    priority: 2
+    resType: menu
+  - displayName: Events & Traces
+    id: eventsntraces
+    isAction: false
+    menuNumber: 1950
+    parentId: analytics
+    priority: 2
+    resType: menu
+  - displayName: Alarms History
+    id: alarmshistory
+    isAction: true
+    menuNumber: 1960
+    parentId: eventsntraces
+    priority: 2
+    resType: menu
+  - displayName: Threshold Config
+    id: thresholdconfig
+    isAction: true
+    menuNumber: 1970
+    parentId: eventsntraces
+    priority: 2
+    resType: menu
+  - displayName: Log Manage
+    id: logmanage
+    isAction: true
+    menuNumber: 1980
+    parentId: eventsntraces
+    priority: 2
+    resType: menu
+  - displayName: Log Config
+    id: logconfig
+    isAction: true
+    menuNumber: 1990
+    parentId: eventsntraces
+    priority: 2
+    resType: menu
+  - displayName: Event Trace
+    id: eventtrace
+    isAction: false
+    menuNumber: 1996
+    parentId: eventsntraces
+    priority: 2
+    resType: menu
+  - displayName: Cost Analysis
+    id: costanalysis
+    isAction: true
+    menuNumber: 1998
+    parentId: analytics
+    priority: 2
+    resType: menu
+  - displayName: Data Migrations
+    id: datamigrations
+    isAction: true
+    menuNumber: 1998
+    parentId: manage
+    priority: 2
+    resType: menu
+  - displayName: SW Catalogs
+    id: swcatalogs
+    isAction: true
+    menuNumber: 1998
+    parentId: manage
+    priority: 2
+    resType: menu
+  - displayName: Workflows
+    id: workflows
+    isAction: true
+    menuNumber: 1998
+    parentId: manage
+    priority: 2
+    resType: menu
+  - displayName: Specs
+    id: serverspecs
+    isAction: true
+    menuNumber: 1410
+    parentId: cloudresources
+    priority: 3
+    resType: menu
+  - displayName: Images
+    id: serverimages
+    isAction: true
+    menuNumber: 1420
+    parentId: cloudresources
+    priority: 3
+    resType: menu
+  - displayName: Resource Sync
+    id: resourcesync
+    isAction: true
+    menuNumber: 1595
+    parentId: cloudresources
+    priority: 3
+    resType: menu
+  - displayName: Analytics
+    id: analytics
+    isAction: false
+    menuNumber: 1901
+    parentId: operations
+    priority: 3
+    resType: menu
+  - displayName: Settings
+    id: settings
+    isAction: false
+    menuNumber: 1200
+    parentId: home
+    priority: 4
+    resType: menu
+  - displayName: MyImages
+    id: myimages
+    isAction: true
+    menuNumber: 1530
+    parentId: cloudresources
+    priority: 4
+    resType: menu
+  - displayName: SSH Keys
+    id: sshkeys
+    isAction: true
+    menuNumber: 1550
+    parentId: cloudresources
+    priority: 5
+    resType: menu
+  - displayName: Disks
+    id: disks
+    isAction: true
+    menuNumber: 1540
+    parentId: cloudresources
+    priority: 6
+    resType: menu
+  - displayName: VPC Template
+    id: networktemplates
+    isAction: true
+    menuNumber: 0
+    parentId: cloudresources
+    priority: 11
+    resType: menu
+  - displayName: ST4 Root Menu
+    id: st4_root
+    isAction: false
+    menuNumber: 9000
+    priority: 90
+    resType: menu
+  - displayName: ST4 Child 1 (BUG Fixed)
+    id: st4_child1
+    isAction: true
+    menuNumber: 9001
+    parentId: st4_root
+    priority: 91
+    resType: page
+  - displayName: ST4 Child 2
+    id: st4_child2
+    isAction: false
+    menuNumber: 9002
+    parentId: st4_root
+    priority: 92
+    resType: page
+  - displayName: ST4 CRUD Child
+    id: st4_crud_child
+    isAction: true
+    menuNumber: 9501
+    parentId: st4_crud_root
+    priority: 96
+    resType: page

--- a/conf/webconsole_menu_resources.yaml
+++ b/conf/webconsole_menu_resources.yaml
@@ -200,6 +200,14 @@ menus:
     priority: 2
     menunumber: 1590
 
+  - id: resourcesync
+    parentid: cloudresources
+    displayname: Resource Sync
+    restype: menu
+    isaction: true
+    priority: 3
+    menunumber: 1595
+
   - id: cloudrescatalogs
     parentid: environment
     displayname: Cloud Res Catalogs

--- a/front/assets/js/common/api/services/cspimport_api.js
+++ b/front/assets/js/common/api/services/cspimport_api.js
@@ -161,3 +161,31 @@ export async function resumeSchedule(jobId) {
 export async function deleteSchedule(jobId) {
   return call('DeleteScheduleRegisterCspResources', { pathParams: { jobId } });
 }
+
+// ── NS Sync (IAM) ─────────────────────────────────────────────────────────────
+
+const IAM_BASE = '/api/mc-iam-manager/';
+
+async function iamCall(operationId, opts = {}) {
+  return webconsolejs['common/api/http'].commonAPIPost(IAM_BASE + operationId, opts);
+}
+
+/**
+ * Infra NS ↔ IAM Project 동기화 차이 조회
+ * GET /api/setup/projects/sync-diff
+ */
+export async function getProjectSyncDiff() {
+  const res = await iamCall('GetProjectSyncDiff');
+  return res?.data?.responseData || { missingProjects: [], unassignedProjects: [] };
+}
+
+/**
+ * NS 동기화 적용 — Project 생성 + Workspace 할당
+ * POST /api/setup/projects/sync
+ * @param {string} workspaceId
+ * @param {string[]} nsIds
+ */
+export async function applyProjectSync(workspaceId, nsIds) {
+  const res = await iamCall('ApplyProjectSync', { request: { workspaceId, nsIds } });
+  return res?.data?.responseData || {};
+}

--- a/front/assets/js/common/api/services/cspimport_api.js
+++ b/front/assets/js/common/api/services/cspimport_api.js
@@ -46,6 +46,15 @@ export async function inspectResources(connectionName, resourceType) {
   return res?.data?.responseData;
 }
 
+/**
+ * 전체 커넥션 자원 현황 요약 조회 (Resource Sync 대시보드용)
+ * GET /inspectResourcesOverview
+ */
+export async function getResourcesOverview() {
+  const res = await call('InspectResourcesOverview');
+  return res?.data?.responseData;
+}
+
 // ── Register ─────────────────────────────────────────────────────────────────
 
 /**
@@ -61,16 +70,16 @@ export async function registerVNet(nsId, connectionName, cspResourceId, name) {
 }
 
 /**
- * SecurityGroup / sshKey / DataDisk 일괄 등록 (Connection 단위)
- * POST /registerCspResources?option=securityGroup&option=sshKey&...
+ * CSP 자원 등록 (신규 API: provider/region/zone 기반)
+ * POST /registerCspResources?option=vNet&option=securityGroup&...
  * @param {string} nsId
- * @param {string} connectionName
- * @param {string[]} options  e.g. ['securityGroup'], ['sshKey'], ['dataDisk']
+ * @param {{ provider: string, region?: string, zone?: string }} filter
+ * @param {string[]} resourceTypes  e.g. ['vNet','securityGroup','sshKey']
  */
-export async function registerCspNativeResources(nsId, connectionName, options) {
+export async function registerCspNativeResources(nsId, filter, resourceTypes) {
   const res = await call('RegisterCspNativeResources', {
-    queryParams: { option: options },
-    request: { nsId, connectionName },
+    queryParams: resourceTypes?.length ? { option: resourceTypes } : undefined,
+    request: { nsId, ...filter },
   });
   return res?.data?.responseData;
 }

--- a/front/assets/js/pages/settings/environment/cloudresources/csp.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/csp.js
@@ -258,7 +258,7 @@ async function submitImmediate(nsId, connectionName, targetTypes, mciName) {
   // securityGroup: Connection 단위 일괄
   if (targetTypes.includes('securityGroup')) {
     try {
-      await api().registerCspNativeResources(nsId, connectionName, ['securityGroup']);
+      await api().registerCspNativeResources(nsId, { connectionName }, ['securityGroup']);
       successCount++;
     } catch (e) {
       if (httpStatus(e) === 409) {
@@ -273,7 +273,7 @@ async function submitImmediate(nsId, connectionName, targetTypes, mciName) {
   // sshKey: Connection 단위 일괄
   if (targetTypes.includes('sshKey')) {
     try {
-      await api().registerCspNativeResources(nsId, connectionName, ['sshKey']);
+      await api().registerCspNativeResources(nsId, { connectionName }, ['sshKey']);
       successCount++;
     } catch (e) {
       if (httpStatus(e) === 409) {

--- a/front/assets/js/pages/settings/environment/cloudresources/resourcesync.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/resourcesync.js
@@ -27,6 +27,7 @@ function api() {
 window.syncShowTab = function (tab, link) {
   document.getElementById('tab-overview').style.display = tab === 'overview' ? '' : 'none';
   document.getElementById('tab-result').style.display   = tab === 'result'   ? '' : 'none';
+  document.getElementById('tab-nssync').style.display   = tab === 'nssync'   ? '' : 'none';
   document.querySelectorAll('#sync-tabs .nav-link').forEach(a => a.classList.remove('active'));
   if (link) link.classList.add('active');
   if (tab === 'result') renderResultTab();
@@ -393,14 +394,18 @@ window.syncToggleResType = function () {
 
 // ── 동기화 실행 ───────────────────────────────────────────────────────────────
 
-// connectionName에서 provider, region 추출
-// e.g. "aws-ap-northeast-2" → { provider: "aws", region: "ap-northeast-2" }
+// connectionName → { provider, region } — allConnections의 regionZoneInfo 우선 사용
+// string split 방식은 "alibaba-us-east-1-us-east-1b" → region="us-east-1-us-east-1b" 오파싱 발생
 function getProviderRegion(connectionName) {
-  const parts = connectionName.split('-');
-  return {
-    provider: parts[0],
-    region:   parts.slice(1).join('-'),
-  };
+  const conn = AppState.allConnections.find(c => c.configName === connectionName);
+  if (conn) {
+    return {
+      provider: conn.providerName,
+      region:   conn.regionZoneInfo?.assignedRegion || '',
+    };
+  }
+  // fallback: provider만 추출 (region 필터 없음)
+  return { provider: connectionName.split('-')[0], region: '' };
 }
 
 // 연결 목록 → 중복 제거된 { provider, region } 필터 배열 반환
@@ -550,7 +555,11 @@ function renderResultTab() {
     totalElapsed   += data.elapsedTime || 0;
     totalAvail     += data.availableConnection || 0;
 
-    const connResults = Array.isArray(data.registerationResult) ? data.registerationResult : [];
+    // 단일 connection 응답 ({ connectionName, registerationOutputs })과
+    // 다중 connection 응답 ({ registerationResult: [...] }) 두 형태 모두 처리
+    const connResults = Array.isArray(data.registerationResult)
+      ? data.registerationResult
+      : data.connectionName ? [data] : [];
     for (const connResult of connResults) {
       const connName = connResult.connectionName || '';
       const outputs  = connResult.registerationOutputs?.output || [];
@@ -604,13 +613,117 @@ function renderResultTab() {
 // ── NS 드롭다운 ───────────────────────────────────────────────────────────────
 
 async function loadNsDropdown() {
-  const nsList = await api().getAllNs().catch(() => []);
   const sel = document.getElementById('sync-ns');
+  const wsApi = webconsolejs['common/api/services/workspace_api'];
+  const curWs = wsApi.getCurrentWorkspace();
+  if (curWs?.Id) {
+    const projects = await wsApi.getUserProjectList(curWs.Id).catch(() => []);
+    const nsIds = projects.map(p => p.nsid || p.NsId).filter(Boolean);
+    if (nsIds.length > 0) {
+      nsIds.forEach(id => sel.appendChild(new Option(id, id)));
+      return;
+    }
+  }
+  const nsList = await api().getAllNs().catch(() => []);
   nsList.forEach(n => {
     const id = n.id || n.nsId || n.name || String(n);
     sel.appendChild(new Option(id, id));
   });
 }
+
+// ── NS 동기화 ─────────────────────────────────────────────────────────────────
+
+window.nsSyncQuery = async function () {
+  const area = document.getElementById('nssync-diff-area');
+  area.innerHTML = '<p>조회 중...</p>';
+  const diff = await api().getProjectSyncDiff().catch(() => null);
+  if (!diff) {
+    area.innerHTML = '<p class="text-danger">조회 실패 — API 연결을 확인하세요.</p>';
+    return;
+  }
+  renderNsSyncDiff(diff);
+};
+
+function renderNsSyncDiff(diff) {
+  const missing    = diff.missingProjects    || [];
+  const unassigned = diff.unassignedProjects || [];
+  const hasIssue   = missing.length > 0 || unassigned.length > 0;
+  let html = '';
+  if (!hasIssue) {
+    html = '<p class="text-success fw-semibold">동기화 상태 정상 — 모든 Namespace가 Workspace에 할당되어 있습니다.</p>';
+  } else {
+    if (missing.length > 0) {
+      html += `<h6 class="mb-2">Project 미생성 Namespace (${missing.length}건)</h6>
+      <table class="table table-sm table-bordered mb-3">
+        <thead class="table-light"><tr><th>NS ID</th><th>NS Name</th></tr></thead>
+        <tbody>${missing.map(r => `<tr><td>${r.nsId}</td><td>${r.nsName || ''}</td></tr>`).join('')}</tbody>
+      </table>`;
+    }
+    if (unassigned.length > 0) {
+      html += `<h6 class="mb-2">Workspace 미할당 Project (${unassigned.length}건)</h6>
+      <table class="table table-sm table-bordered mb-3">
+        <thead class="table-light"><tr><th>Project ID</th><th>Name</th><th>NS ID</th></tr></thead>
+        <tbody>${unassigned.map(r => `<tr><td>${r.id}</td><td>${r.name}</td><td>${r.nsId || ''}</td></tr>`).join('')}</tbody>
+      </table>`;
+    }
+  }
+  document.getElementById('nssync-diff-area').innerHTML = html;
+  const applyCard = document.getElementById('nssync-apply-card');
+  if (hasIssue) {
+    loadNsSyncWorkspaceDropdown();
+    applyCard.style.display = '';
+  } else {
+    applyCard.style.display = 'none';
+  }
+}
+
+async function loadNsSyncWorkspaceDropdown() {
+  const sel = document.getElementById('nssync-workspace-sel');
+  sel.innerHTML = '';
+  const wsApi = webconsolejs['common/api/services/workspace_api'];
+  const list = typeof wsApi.getWorkspaceList === 'function'
+    ? await wsApi.getWorkspaceList().catch(() => [])
+    : [];
+  if (list.length === 0) {
+    const cur = wsApi.getCurrentWorkspace();
+    if (cur?.Id) sel.appendChild(new Option(cur.Name || cur.Id, cur.Id));
+    return;
+  }
+  list.forEach(ws => sel.appendChild(new Option(ws.name || ws.Name || ws.id, ws.id || ws.Id)));
+}
+
+window.nsSyncApply = async function () {
+  const workspaceId = document.getElementById('nssync-workspace-sel').value;
+  if (!workspaceId) { alert('Workspace를 선택하세요.'); return; }
+  const resultDiv = document.getElementById('nssync-apply-result');
+  resultDiv.innerHTML = '<p>적용 중...</p>';
+
+  const diff = await api().getProjectSyncDiff().catch(() => null);
+  if (!diff) { resultDiv.innerHTML = '<p class="text-danger">차이 조회 실패</p>'; return; }
+
+  const nsIds = [
+    ...(diff.missingProjects    || []).map(r => r.nsId),
+    ...(diff.unassignedProjects || []).map(r => r.nsId),
+  ].filter(Boolean);
+
+  if (nsIds.length === 0) {
+    resultDiv.innerHTML = '<p class="text-success">적용할 항목이 없습니다.</p>';
+    return;
+  }
+
+  const result = await api().applyProjectSync(workspaceId, nsIds).catch(() => null);
+  if (!result) { resultDiv.innerHTML = '<p class="text-danger">적용 실패</p>'; return; }
+
+  resultDiv.innerHTML = `
+    <ul class="list-unstyled mb-0">
+      <li>생성: <strong>${(result.created || []).length}</strong>건</li>
+      <li>할당: <strong>${(result.assigned || []).length}</strong>건</li>
+      <li>스킵: <strong>${(result.skipped || []).length}</strong>건</li>
+      <li>실패: <strong>${(result.failed  || []).length}</strong>건</li>
+    </ul>`;
+
+  await window.nsSyncQuery();
+};
 
 // ── Init ──────────────────────────────────────────────────────────────────────
 

--- a/front/assets/js/pages/settings/environment/cloudresources/resourcesync.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/resourcesync.js
@@ -73,14 +73,14 @@ function syncUpdateConnCheckboxes() {
   group.innerHTML = providers.map(p => `
     <div class="mb-2 w-100">
       <label class="form-check mb-1">
-        <input class="form-check-input qry-provider-group-cb" type="checkbox" value="${p}" checked
+        <input class="form-check-input qry-provider-group-cb" type="checkbox" value="${p}"
                onchange="syncToggleProviderConns('${p}', this.checked)">
         <span class="form-check-label fw-semibold text-uppercase">${p}</span>
       </label>
       <div class="ms-3 d-flex gap-3 flex-wrap">
         ${byProvider[p].map(conn =>
           `<label class="form-check mb-0">
-             <input class="form-check-input qry-conn-cb" type="checkbox" value="${conn}" data-provider="${p}" checked>
+             <input class="form-check-input qry-conn-cb" type="checkbox" value="${conn}" data-provider="${p}">
              <span class="form-check-label small">${conn}</span>
            </label>`
         ).join('')}

--- a/front/assets/js/pages/settings/environment/cloudresources/resourcesync.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/resourcesync.js
@@ -369,12 +369,13 @@ window.syncFilterTable = function (val) {
 // ── 동기화 실행 카드: Provider / ResType toggles ──────────────────────────────
 
 // 동기화 실행 섹션의 provider 체크박스 — 조회 결과에서 추출
+// 기본: disabled + unchecked — "부분 선택" 라디오 클릭 시 활성화
 function populateSyncProviderCheckboxes() {
   const providers = [...new Set(AppState.overviewRows.map(r => getProvider(r.connectionName)))].sort();
   const group = document.getElementById('provider-cb-group');
   group.innerHTML = providers.map(p =>
     `<label class="form-check mb-0">
-       <input class="form-check-input sync-provider-cb" type="checkbox" value="${p}" checked>
+       <input class="form-check-input sync-provider-cb" type="checkbox" value="${p}" disabled>
        <span class="form-check-label">${p.toUpperCase()}</span>
      </label>`
   ).join('');
@@ -382,12 +383,12 @@ function populateSyncProviderCheckboxes() {
 
 window.syncToggleProvider = function () {
   const partial = document.querySelector('input[name="provider-radio"]:checked')?.value === 'partial';
-  document.getElementById('provider-cb-group').style.setProperty('display', partial ? 'flex' : 'none', 'important');
+  document.querySelectorAll('.sync-provider-cb').forEach(cb => { cb.disabled = !partial; });
 };
 
 window.syncToggleResType = function () {
   const partial = document.querySelector('input[name="restype-radio"]:checked')?.value === 'partial';
-  document.getElementById('restype-cb-group').style.setProperty('display', partial ? 'flex' : 'none', 'important');
+  document.querySelectorAll('.sync-type-cb').forEach(cb => { cb.disabled = !partial; });
 };
 
 // ── 동기화 실행 ───────────────────────────────────────────────────────────────

--- a/front/assets/js/pages/settings/environment/cloudresources/resourcesync.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/resourcesync.js
@@ -36,10 +36,9 @@ window.syncShowTab = function (tab, link) {
 
 window.syncOnProviderModeChange = function () {
   const partial = document.querySelector('input[name="query-provider-radio"]:checked')?.value === 'partial';
-  const providerGroup = document.getElementById('qry-provider-cb-group');
-  const connSection   = document.getElementById('qry-conn-section');
+  const connSection = document.getElementById('qry-conn-section');
 
-  providerGroup.style.setProperty('display', partial ? 'flex' : 'none', 'important');
+  document.querySelectorAll('.qry-provider-cb').forEach(cb => { cb.disabled = !partial; });
   connSection.style.display = partial ? '' : 'none';
 
   if (partial) syncUpdateConnCheckboxes();
@@ -102,12 +101,13 @@ window.syncSelectAllConn = function (checked) {
 };
 
 // Provider 체크박스 초기 생성 (allConnections 로드 후 호출)
+// 기본: disabled + unchecked — "부분 선택" 라디오 클릭 시 활성화
 function populateQueryProviderCheckboxes() {
   const providers = [...new Set(AppState.allConnections.map(c => getProvider(c.configName)))].sort();
   const group = document.getElementById('qry-provider-cb-group');
   group.innerHTML = providers.map(p =>
     `<label class="form-check mb-0">
-       <input class="form-check-input qry-provider-cb" type="checkbox" value="${p}" checked onchange="syncOnProviderChange()">
+       <input class="form-check-input qry-provider-cb" type="checkbox" value="${p}" disabled onchange="syncOnProviderChange()">
        <span class="form-check-label">${p.toUpperCase()}</span>
      </label>`
   ).join('');
@@ -392,6 +392,31 @@ window.syncToggleResType = function () {
 
 // ── 동기화 실행 ───────────────────────────────────────────────────────────────
 
+// connectionName에서 provider, region 추출
+// e.g. "aws-ap-northeast-2" → { provider: "aws", region: "ap-northeast-2" }
+function getProviderRegion(connectionName) {
+  const parts = connectionName.split('-');
+  return {
+    provider: parts[0],
+    region:   parts.slice(1).join('-'),
+  };
+}
+
+// 연결 목록 → 중복 제거된 { provider, region } 필터 배열 반환
+function buildFilters(connNames) {
+  const seen = new Set();
+  const filters = [];
+  for (const name of connNames) {
+    const { provider, region } = getProviderRegion(name);
+    const key = `${provider}|${region}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      filters.push({ provider, region });
+    }
+  }
+  return filters;
+}
+
 window.syncExecute = async function () {
   const nsId = document.getElementById('sync-ns').value;
   if (!nsId) { alert('먼저 Namespace를 선택하세요.'); return; }
@@ -405,48 +430,56 @@ window.syncExecute = async function () {
     types = ['vNet', 'securityGroup', 'sshKey', 'vm', 'dataDisk', 'customImage'];
   }
 
-  let targetConns;
+  // 대상 connection 결정 → provider/region 필터 목록 생성
+  let filters;
   const selectedRows = AppState.overviewTable ? AppState.overviewTable.getSelectedData() : [];
   if (selectedRows.length > 0) {
-    targetConns = selectedRows.map(r => r.connectionName);
+    filters = buildFilters(selectedRows.map(r => r.connectionName));
   } else {
     const providerPartial = document.querySelector('input[name="provider-radio"]:checked')?.value === 'partial';
     if (providerPartial) {
       const selProviders = new Set(
         Array.from(document.querySelectorAll('.sync-provider-cb:checked')).map(c => c.value)
       );
-      targetConns = AppState.overviewRows
+      const conns = AppState.overviewRows
         .filter(r => selProviders.has(getProvider(r.connectionName)))
         .map(r => r.connectionName);
+      filters = buildFilters(conns);
     } else {
-      targetConns = AppState.overviewRows.map(r => r.connectionName);
+      filters = [{}]; // 전체 — provider/region 필터 없음
     }
   }
 
-  if (!confirm(`동기화를 실행합니다.\nNS: ${nsId}\n자원 유형: ${types.join(', ')}\n\n계속하시겠습니까?`)) return;
+  const filterDesc = filters.length === 1 && !filters[0].provider
+    ? '전체'
+    : filters.map(f => `${f.provider}/${f.region}`).join(', ');
+
+  if (!confirm(`동기화를 실행합니다.\nNS: ${nsId}\n대상: ${filterDesc}\n자원 유형: ${types.join(', ')}\n\n계속하시겠습니까?`)) return;
 
   const statusEl = document.getElementById('sync-exec-status');
   statusEl.className = 'text-secondary small';
-  statusEl.textContent = '동기화 실행 중… (시간이 걸릴 수 있습니다)';
+  statusEl.textContent = `동기화 실행 중… (${filters.length}개 요청)`;
 
   AppState.lastSyncResult = [];
-  try {
-    // API는 필터에 관계없이 전체 connection을 대상으로 실행됨 → 1회 호출
-    const result = await api().registerCspNativeResources(nsId, {}, types);
-    AppState.lastSyncResult = [{ success: true, data: result }];
+  let totalSucceeded = 0;
+  let totalFailed = 0;
 
-    const ov = result?.registerationOverview || {};
-    const failed    = ov.failed || 0;
-    const succeeded = Object.entries(ov)
-      .filter(([k]) => k !== 'failed' && k !== 'nlb')
-      .reduce((s, [, v]) => s + (Number(v) || 0), 0);
-    statusEl.className = failed > 0 ? 'text-warning small' : 'text-success small';
-    statusEl.textContent = `완료: ${succeeded}개 등록, ${failed}개 실패`;
-  } catch (e) {
-    AppState.lastSyncResult = [{ success: false, error: e?.response?.data?.message || e.message }];
-    statusEl.className = 'text-danger small';
-    statusEl.textContent = `실패: ${e?.response?.data?.message || e.message}`;
+  for (const filter of filters) {
+    try {
+      const result = await api().registerCspNativeResources(nsId, filter, types);
+      AppState.lastSyncResult.push({ success: true, filter, data: result });
+      const ov = result?.registerationOverview || {};
+      totalFailed    += ov.failed || 0;
+      totalSucceeded += Object.entries(ov)
+        .filter(([k]) => k !== 'failed' && k !== 'nlb')
+        .reduce((s, [, v]) => s + (Number(v) || 0), 0);
+    } catch (e) {
+      AppState.lastSyncResult.push({ success: false, filter, error: e?.response?.data?.message || e.message });
+    }
   }
+
+  statusEl.className = totalFailed > 0 ? 'text-warning small' : 'text-success small';
+  statusEl.textContent = `완료: ${totalSucceeded}개 등록, ${totalFailed}개 실패`;
 
   const resultTabLink = document.querySelector('#sync-tabs .nav-item:last-child .nav-link');
   syncShowTab('result', resultTabLink);
@@ -480,46 +513,60 @@ function renderResultTab() {
     return;
   }
 
-  const entry = AppState.lastSyncResult[0];
-  if (!entry.success) {
-    empty.style.display   = '';
+  const hasSuccess = AppState.lastSyncResult.some(r => r.success);
+  if (!hasSuccess) {
+    empty.style.display = '';
     content.style.display = 'none';
-    document.getElementById('result-empty').textContent = `동기화 실패: ${entry.error}`;
+    document.getElementById('result-empty').textContent =
+      `동기화 실패: ${AppState.lastSyncResult.map(r => r.error).join(', ')}`;
     return;
   }
 
   empty.style.display   = 'none';
   content.style.display = '';
 
-  const data     = entry.data || {};
-  const globalOv = data.registerationOverview || {};
-  const elapsed  = data.elapsedTime ?? '';
-  const avail    = data.availableConnection ?? '';
+  // 전체 결과 집계 (다중 호출 합산)
+  let totalSucceeded = 0;
+  let totalFailed    = 0;
+  let totalElapsed   = 0;
+  let totalAvail     = 0;
 
-  const failed    = globalOv.failed || 0;
-  const succeeded = Object.entries(globalOv)
-    .filter(([k]) => k !== 'failed' && k !== 'nlb')
-    .reduce((s, [, v]) => s + (Number(v) || 0), 0);
-
-  document.getElementById('result-elapsed').textContent = elapsed ? `소요 시간: ${elapsed}초` : '';
-  document.getElementById('result-summary').innerHTML = `
-    <span class="text-secondary small">가용 커넥션: <strong>${avail}</strong></span>
-    <span class="text-success small">등록 성공: <strong>${succeeded}</strong></span>
-    ${failed > 0 ? `<span class="text-danger small">실패: <strong>${failed}</strong></span>` : ''}
-  `;
-
-  // 각 connection별 output[] 문자열 파싱 → flat row 배열
   const rows = [];
-  const connResults = Array.isArray(data.registerationResult) ? data.registerationResult : [];
-  for (const connResult of connResults) {
-    const connName = connResult.connectionName || '';
-    const outputs  = connResult.registerationOutputs?.output || [];
-    if (outputs.length === 0) {
-      rows.push({ connectionName: connName, resourceType: '—', resourceId: '(결과 없음)', status: '—', message: '', _failed: false });
-    } else {
-      outputs.forEach(str => rows.push(parseOutputString(str, connName)));
+  for (const entry of AppState.lastSyncResult) {
+    if (!entry.success) {
+      const filterLabel = entry.filter?.provider
+        ? `${entry.filter.provider}/${entry.filter.region}`
+        : '전체';
+      rows.push({ connectionName: filterLabel, resourceType: '—', resourceId: entry.error, status: 'Error', message: '', _failed: true });
+      continue;
+    }
+    const data     = entry.data || {};
+    const globalOv = data.registerationOverview || {};
+    totalFailed    += globalOv.failed || 0;
+    totalSucceeded += Object.entries(globalOv)
+      .filter(([k]) => k !== 'failed' && k !== 'nlb')
+      .reduce((s, [, v]) => s + (Number(v) || 0), 0);
+    totalElapsed   += data.elapsedTime || 0;
+    totalAvail     += data.availableConnection || 0;
+
+    const connResults = Array.isArray(data.registerationResult) ? data.registerationResult : [];
+    for (const connResult of connResults) {
+      const connName = connResult.connectionName || '';
+      const outputs  = connResult.registerationOutputs?.output || [];
+      if (outputs.length === 0) {
+        rows.push({ connectionName: connName, resourceType: '—', resourceId: '(결과 없음)', status: '—', message: '', _failed: false });
+      } else {
+        outputs.forEach(str => rows.push(parseOutputString(str, connName)));
+      }
     }
   }
+
+  document.getElementById('result-elapsed').textContent = totalElapsed ? `소요 시간: ${totalElapsed}초` : '';
+  document.getElementById('result-summary').innerHTML = `
+    <span class="text-secondary small">가용 커넥션: <strong>${totalAvail}</strong></span>
+    <span class="text-success small">등록 성공: <strong>${totalSucceeded}</strong></span>
+    ${totalFailed > 0 ? `<span class="text-danger small">실패: <strong>${totalFailed}</strong></span>` : ''}
+  `;
 
   if (AppState.resultTable) {
     AppState.resultTable.destroy();

--- a/front/assets/js/pages/settings/environment/cloudresources/resourcesync.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/resourcesync.js
@@ -1,0 +1,585 @@
+import { TabulatorFull as Tabulator } from 'tabulator-tables';
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+const AppState = {
+  overviewTable: null,
+  resultTable: null,
+  overviewRows: [],
+  overviewRaw: [],      // raw { connectionName, resourceType, resourceOverview }[]
+  allConnections: [],   // from getConnConfigList: { configName, providerName, ... }[]
+  lastSyncResult: [],
+};
+
+// connection name 첫 세그먼트가 provider
+function getProvider(connectionName) {
+  return connectionName.split('-')[0].toLowerCase();
+}
+
+// ── API shorthand ─────────────────────────────────────────────────────────────
+
+function api() {
+  return webconsolejs['common/api/services/cspimport_api'];
+}
+
+// ── Tab ───────────────────────────────────────────────────────────────────────
+
+window.syncShowTab = function (tab, link) {
+  document.getElementById('tab-overview').style.display = tab === 'overview' ? '' : 'none';
+  document.getElementById('tab-result').style.display   = tab === 'result'   ? '' : 'none';
+  document.querySelectorAll('#sync-tabs .nav-link').forEach(a => a.classList.remove('active'));
+  if (link) link.classList.add('active');
+  if (tab === 'result') renderResultTab();
+};
+
+// ── 조회 조건: Provider mode toggle ──────────────────────────────────────────
+
+window.syncOnProviderModeChange = function () {
+  const partial = document.querySelector('input[name="query-provider-radio"]:checked')?.value === 'partial';
+  const providerGroup = document.getElementById('qry-provider-cb-group');
+  const connSection   = document.getElementById('qry-conn-section');
+
+  providerGroup.style.setProperty('display', partial ? 'flex' : 'none', 'important');
+  connSection.style.display = partial ? '' : 'none';
+
+  if (partial) syncUpdateConnCheckboxes();
+};
+
+// provider 체크박스 변경 시 connection 목록 갱신
+window.syncOnProviderChange = function () {
+  syncUpdateConnCheckboxes();
+};
+
+function syncUpdateConnCheckboxes() {
+  const selectedProviders = new Set(
+    Array.from(document.querySelectorAll('.qry-provider-cb:checked')).map(c => c.value)
+  );
+  const group = document.getElementById('qry-conn-cb-group');
+
+  // provider별로 그룹 생성
+  const byProvider = {};
+  AppState.allConnections.forEach(c => {
+    const p = getProvider(c.configName);
+    if (!selectedProviders.has(p)) return;
+    if (!byProvider[p]) byProvider[p] = [];
+    byProvider[p].push(c.configName);
+  });
+
+  const providers = Object.keys(byProvider).sort();
+  if (providers.length === 0) {
+    group.innerHTML = '<span class="text-secondary small">선택된 Provider에 해당하는 Connection이 없습니다</span>';
+    return;
+  }
+
+  group.innerHTML = providers.map(p => `
+    <div class="mb-2 w-100">
+      <label class="form-check mb-1">
+        <input class="form-check-input qry-provider-group-cb" type="checkbox" value="${p}" checked
+               onchange="syncToggleProviderConns('${p}', this.checked)">
+        <span class="form-check-label fw-semibold text-uppercase">${p}</span>
+      </label>
+      <div class="ms-3 d-flex gap-3 flex-wrap">
+        ${byProvider[p].map(conn =>
+          `<label class="form-check mb-0">
+             <input class="form-check-input qry-conn-cb" type="checkbox" value="${conn}" data-provider="${p}" checked>
+             <span class="form-check-label small">${conn}</span>
+           </label>`
+        ).join('')}
+      </div>
+    </div>`
+  ).join('');
+}
+
+window.syncToggleProviderConns = function (provider, checked) {
+  document.querySelectorAll(`.qry-conn-cb[data-provider="${provider}"]`).forEach(cb => {
+    cb.checked = checked;
+  });
+};
+
+window.syncSelectAllConn = function (checked) {
+  document.querySelectorAll('.qry-conn-cb').forEach(cb => { cb.checked = checked; });
+  document.querySelectorAll('.qry-provider-group-cb').forEach(cb => { cb.checked = checked; });
+};
+
+// Provider 체크박스 초기 생성 (allConnections 로드 후 호출)
+function populateQueryProviderCheckboxes() {
+  const providers = [...new Set(AppState.allConnections.map(c => getProvider(c.configName)))].sort();
+  const group = document.getElementById('qry-provider-cb-group');
+  group.innerHTML = providers.map(p =>
+    `<label class="form-check mb-0">
+       <input class="form-check-input qry-provider-cb" type="checkbox" value="${p}" checked onchange="syncOnProviderChange()">
+       <span class="form-check-label">${p.toUpperCase()}</span>
+     </label>`
+  ).join('');
+}
+
+// ── 조회 조건: 자원 유형 mode toggle ─────────────────────────────────────────
+
+window.syncOnResTypeModeChange = function () {
+  const partial = document.querySelector('input[name="query-restype-radio"]:checked')?.value === 'partial';
+  document.getElementById('qry-restype-cb-group').style.setProperty('display', partial ? 'flex' : 'none', 'important');
+};
+
+const ALL_QUERY_TYPES = ['vNet', 'securityGroup', 'sshKey', 'node'];
+
+function getSelectedQueryTypes() {
+  const mode = document.querySelector('input[name="query-restype-radio"]:checked')?.value;
+  if (mode === 'all') return ALL_QUERY_TYPES.slice();
+  return Array.from(document.querySelectorAll('.qry-restype-cb:checked')).map(c => c.value);
+}
+
+// ── 조회 실행 ─────────────────────────────────────────────────────────────────
+
+window.syncQuery = async function () {
+  const resourceTypes = getSelectedQueryTypes();
+  if (resourceTypes.length === 0) { alert('자원 유형을 하나 이상 선택하세요.'); return; }
+
+  const mode = document.querySelector('input[name="query-provider-radio"]:checked')?.value;
+
+  if (mode === 'all') {
+    await queryAll();
+  } else {
+    const selectedConns = Array.from(document.querySelectorAll('.qry-conn-cb:checked')).map(c => c.value);
+    if (selectedConns.length === 0) { alert('Connection을 하나 이상 선택하세요.'); return; }
+    await queryPartial(selectedConns, resourceTypes);
+  }
+};
+
+// 전체 조회: InspectResourcesOverview
+async function queryAll() {
+  const statusEl = document.getElementById('qry-status');
+  const loading  = document.getElementById('sync-overview-loading');
+  const summary  = document.getElementById('sync-summary');
+
+  statusEl.textContent = '조회 중…';
+  loading.style.display = '';
+  summary.style.display = 'none';
+
+  try {
+    const data = await api().getResourcesOverview();
+    loading.style.display = 'none';
+    if (!data) { renderOverviewTable([], []); statusEl.textContent = ''; return; }
+
+    const selectedTypes = Array.from(document.querySelectorAll('.qry-restype-cb:checked')).map(c => c.value);
+
+    AppState.overviewRaw = Array.isArray(data.inspectResult) ? data.inspectResult : [];
+
+    const connMap = {};
+    for (const item of AppState.overviewRaw) {
+      const conn = item.connectionName;
+      if (!connMap[conn]) {
+        connMap[conn] = { connectionName: conn, hasUnsynced: false };
+        selectedTypes.forEach(t => { connMap[conn][t] = '-'; });
+      }
+      // InspectResourcesOverview uses 'vm'; map to 'node' if user selected 'node'
+      const displayType = item.resourceType === 'vm' && selectedTypes.includes('node')
+        ? 'node'
+        : item.resourceType;
+      if (selectedTypes.includes(displayType)) {
+        const onTb   = item.resourceOverview?.onTumblebug ?? 0;
+        const onCsp  = item.resourceOverview?.onCspTotal  ?? 0;
+        const onOnly = item.resourceOverview?.onCspOnly   ?? 0;
+        connMap[conn][displayType] = `${onTb}/${onCsp}`;
+        if (onOnly > 0) connMap[conn].hasUnsynced = true;
+      }
+    }
+
+    AppState.overviewRows = Object.values(connMap);
+
+    const unsyncedCount = AppState.overviewRows.filter(r => r.hasUnsynced).length;
+    document.getElementById('sum-total').textContent    = data.registeredConnection ?? AppState.overviewRows.length;
+    document.getElementById('sum-avail').textContent    = data.availableConnection  ?? AppState.overviewRows.length;
+    document.getElementById('sum-unsynced').textContent = unsyncedCount;
+    document.getElementById('sync-elapsed').textContent = data.elapsedTime ? `조회 시간: ${data.elapsedTime}초` : '';
+    summary.style.display = '';
+
+    populateSyncProviderCheckboxes();
+    renderOverviewTable(AppState.overviewRows, selectedTypes);
+    statusEl.textContent = '';
+  } catch (e) {
+    loading.style.display = 'none';
+    statusEl.textContent = '조회 실패';
+    console.error('InspectResourcesOverview failed', e);
+    renderOverviewTable([], []);
+  }
+}
+
+// 부분 조회: 선택된 connection × resource type 마다 InspectResources 호출
+async function queryPartial(connections, resourceTypes) {
+  const statusEl = document.getElementById('qry-status');
+  const loading  = document.getElementById('sync-overview-loading');
+  const summary  = document.getElementById('sync-summary');
+
+  loading.style.display = '';
+  summary.style.display = 'none';
+  statusEl.textContent = `0 / ${connections.length * resourceTypes.length} 조회 중…`;
+
+  AppState.overviewRaw = [];
+  const connMap = {};
+  connections.forEach(conn => {
+    connMap[conn] = { connectionName: conn, hasUnsynced: false };
+    resourceTypes.forEach(t => { connMap[conn][t] = '-'; });
+  });
+
+  let done = 0;
+  const tasks = [];
+  for (const conn of connections) {
+    for (const rt of resourceTypes) {
+      tasks.push(
+        api().inspectResources(conn, rt)
+          .then(data => {
+            const onTb   = data?.resources?.onTumblebug?.count ?? 0;
+            const onCsp  = data?.resources?.onCspTotal?.count  ?? 0;
+            const onOnly = data?.resources?.onCspOnly?.count   ?? 0;
+            AppState.overviewRaw.push({
+              connectionName: conn,
+              resourceType: rt,
+              resourceOverview: { onTumblebug: onTb, onCspTotal: onCsp, onCspOnly: onOnly },
+            });
+            connMap[conn][rt] = `${onTb}/${onCsp}`;
+            if (onOnly > 0) connMap[conn].hasUnsynced = true;
+          })
+          .catch(e => { console.warn(`InspectResources failed: ${conn}/${rt}`, e); })
+          .finally(() => {
+            done++;
+            statusEl.textContent = `${done} / ${connections.length * resourceTypes.length} 조회 중…`;
+          })
+      );
+    }
+  }
+
+  await Promise.allSettled(tasks);
+  loading.style.display = 'none';
+
+  AppState.overviewRows = Object.values(connMap);
+  const unsyncedCount = AppState.overviewRows.filter(r => r.hasUnsynced).length;
+  document.getElementById('sum-total').textContent    = connections.length;
+  document.getElementById('sum-avail').textContent    = AppState.overviewRows.length;
+  document.getElementById('sum-unsynced').textContent = unsyncedCount;
+  document.getElementById('sync-elapsed').textContent = '';
+  summary.style.display = '';
+
+  populateSyncProviderCheckboxes();
+  renderOverviewTable(AppState.overviewRows, resourceTypes);
+  statusEl.textContent = '';
+}
+
+// ── 현황 테이블 ───────────────────────────────────────────────────────────────
+
+const TYPE_LABELS = {
+  vNet: 'vNet', securityGroup: 'Security Group', sshKey: 'SSH Key', node: 'Node',
+};
+
+function renderOverviewTable(data, resourceTypes) {
+  // 기존 테이블이 있으면 destroy 후 재생성 (컬럼이 달라질 수 있음)
+  if (AppState.overviewTable) {
+    AppState.overviewTable.destroy();
+    AppState.overviewTable = null;
+  }
+
+  const typeCols = (resourceTypes || []).map(t => ({
+    title: TYPE_LABELS[t] || t,
+    field: t,
+    sorter: 'string',
+    width: 110,
+    hozAlign: 'center',
+  }));
+
+  AppState.overviewTable = new Tabulator('#sync-overview-table', {
+    data,
+    layout: 'fitColumns',
+    placeholder: '조회 버튼을 클릭하여 현황을 조회하세요.',
+    pagination: 'local',
+    paginationSize: 10,
+    selectable: true,
+    rowFormatter: (row) => {
+      if (row.getData().hasUnsynced) row.getElement().classList.add('table-warning');
+    },
+    columns: [
+      { formatter: 'rowSelection', titleFormatter: 'rowSelection', hozAlign: 'center', headerHozAlign: 'center', width: 40, headerSort: false },
+      { title: 'Connection', field: 'connectionName', sorter: 'string', minWidth: 160 },
+      ...typeCols,
+    ],
+  });
+
+  AppState.overviewTable.on('rowClick', (e, row) => {
+    renderDetailCard(row.getData(), resourceTypes || []);
+  });
+
+  AppState.overviewTable.on('rowSelectionChanged', (rows) => {
+    const el = document.getElementById('sync-selected-conn');
+    if (!rows || rows.length === 0) {
+      el.textContent = '현황 테이블에서 Connection을 선택하세요 (미선택 시 전체 대상)';
+      el.className = 'form-control bg-light text-secondary';
+    } else {
+      el.textContent = rows.map(r => r.connectionName).join(', ');
+      el.className = 'form-control bg-light text-dark';
+    }
+  });
+}
+
+// ── Detail Card ───────────────────────────────────────────────────────────────
+
+function renderDetailCard(rowData, resourceTypes) {
+  document.getElementById('detail-conn-name').textContent = rowData.connectionName;
+
+  const rawMap = {};
+  AppState.overviewRaw
+    .filter(i => i.connectionName === rowData.connectionName)
+    .forEach(i => { rawMap[i.resourceType] = i.resourceOverview; });
+
+  const types = resourceTypes.length ? resourceTypes : Object.keys(TYPE_LABELS);
+  const rows = types.map(t => {
+    const ov     = rawMap[t];
+    const onTb   = ov?.onTumblebug ?? '-';
+    const onCsp  = ov?.onCspTotal  ?? '-';
+    const onOnly = ov?.onCspOnly;
+    let badge;
+    if (typeof onOnly === 'number') {
+      badge = onOnly > 0
+        ? `<span class="badge bg-warning text-dark">${onOnly}개 미등록</span>`
+        : `<span class="badge bg-success">동기화됨</span>`;
+    } else {
+      badge = `<span class="text-secondary small">-</span>`;
+    }
+    return `<tr>
+      <td>${TYPE_LABELS[t] || t}</td>
+      <td class="text-center">${onTb}</td>
+      <td class="text-center">${onCsp}</td>
+      <td class="text-center">${onOnly ?? '-'}</td>
+      <td class="text-center">${badge}</td>
+    </tr>`;
+  });
+
+  document.getElementById('detail-tbody').innerHTML = rows.join('');
+  document.getElementById('sync-detail-card').style.display = '';
+}
+
+// ── Search ────────────────────────────────────────────────────────────────────
+
+window.syncFilterTable = function (val) {
+  if (!AppState.overviewTable) return;
+  if (val) {
+    AppState.overviewTable.setFilter('connectionName', 'like', val);
+  } else {
+    AppState.overviewTable.clearFilter();
+  }
+};
+
+// ── 동기화 실행 카드: Provider / ResType toggles ──────────────────────────────
+
+// 동기화 실행 섹션의 provider 체크박스 — 조회 결과에서 추출
+function populateSyncProviderCheckboxes() {
+  const providers = [...new Set(AppState.overviewRows.map(r => getProvider(r.connectionName)))].sort();
+  const group = document.getElementById('provider-cb-group');
+  group.innerHTML = providers.map(p =>
+    `<label class="form-check mb-0">
+       <input class="form-check-input sync-provider-cb" type="checkbox" value="${p}" checked>
+       <span class="form-check-label">${p.toUpperCase()}</span>
+     </label>`
+  ).join('');
+}
+
+window.syncToggleProvider = function () {
+  const partial = document.querySelector('input[name="provider-radio"]:checked')?.value === 'partial';
+  document.getElementById('provider-cb-group').style.setProperty('display', partial ? 'flex' : 'none', 'important');
+};
+
+window.syncToggleResType = function () {
+  const partial = document.querySelector('input[name="restype-radio"]:checked')?.value === 'partial';
+  document.getElementById('restype-cb-group').style.setProperty('display', partial ? 'flex' : 'none', 'important');
+};
+
+// ── 동기화 실행 ───────────────────────────────────────────────────────────────
+
+window.syncExecute = async function () {
+  const nsId = document.getElementById('sync-ns').value;
+  if (!nsId) { alert('먼저 Namespace를 선택하세요.'); return; }
+
+  const restypePartial = document.querySelector('input[name="restype-radio"]:checked')?.value === 'partial';
+  let types;
+  if (restypePartial) {
+    types = Array.from(document.querySelectorAll('.sync-type-cb:checked')).map(c => c.value);
+    if (types.length === 0) { alert('자원 유형을 하나 이상 선택하세요.'); return; }
+  } else {
+    types = ['vNet', 'securityGroup', 'sshKey', 'vm', 'dataDisk', 'customImage'];
+  }
+
+  let targetConns;
+  const selectedRows = AppState.overviewTable ? AppState.overviewTable.getSelectedData() : [];
+  if (selectedRows.length > 0) {
+    targetConns = selectedRows.map(r => r.connectionName);
+  } else {
+    const providerPartial = document.querySelector('input[name="provider-radio"]:checked')?.value === 'partial';
+    if (providerPartial) {
+      const selProviders = new Set(
+        Array.from(document.querySelectorAll('.sync-provider-cb:checked')).map(c => c.value)
+      );
+      targetConns = AppState.overviewRows
+        .filter(r => selProviders.has(getProvider(r.connectionName)))
+        .map(r => r.connectionName);
+    } else {
+      targetConns = AppState.overviewRows.map(r => r.connectionName);
+    }
+  }
+
+  if (!confirm(`동기화를 실행합니다.\nNS: ${nsId}\n자원 유형: ${types.join(', ')}\n\n계속하시겠습니까?`)) return;
+
+  const statusEl = document.getElementById('sync-exec-status');
+  statusEl.className = 'text-secondary small';
+  statusEl.textContent = '동기화 실행 중… (시간이 걸릴 수 있습니다)';
+
+  AppState.lastSyncResult = [];
+  try {
+    // API는 필터에 관계없이 전체 connection을 대상으로 실행됨 → 1회 호출
+    const result = await api().registerCspNativeResources(nsId, {}, types);
+    AppState.lastSyncResult = [{ success: true, data: result }];
+
+    const ov = result?.registerationOverview || {};
+    const failed    = ov.failed || 0;
+    const succeeded = Object.entries(ov)
+      .filter(([k]) => k !== 'failed' && k !== 'nlb')
+      .reduce((s, [, v]) => s + (Number(v) || 0), 0);
+    statusEl.className = failed > 0 ? 'text-warning small' : 'text-success small';
+    statusEl.textContent = `완료: ${succeeded}개 등록, ${failed}개 실패`;
+  } catch (e) {
+    AppState.lastSyncResult = [{ success: false, error: e?.response?.data?.message || e.message }];
+    statusEl.className = 'text-danger small';
+    statusEl.textContent = `실패: ${e?.response?.data?.message || e.message}`;
+  }
+
+  const resultTabLink = document.querySelector('#sync-tabs .nav-item:last-child .nav-link');
+  syncShowTab('result', resultTabLink);
+};
+
+// ── 결과 탭 ───────────────────────────────────────────────────────────────────
+
+// output 문자열 파싱: "vNet: some-id [Failed] reason message"
+const OUTPUT_RE = /^(\w+):\s+(.+?)\s+\[(\w+)\]\s*(.*)$/;
+
+function parseOutputString(str, connectionName) {
+  const m = OUTPUT_RE.exec(str.trim());
+  if (!m) return { connectionName, resourceType: '—', resourceId: str, status: '—', message: '', _failed: false };
+  return {
+    connectionName,
+    resourceType: m[1],
+    resourceId:   m[2],
+    status:       m[3],
+    message:      m[4] || '',
+    _failed:      m[3].toLowerCase() !== 'success',
+  };
+}
+
+function renderResultTab() {
+  const empty   = document.getElementById('result-empty');
+  const content = document.getElementById('result-content');
+
+  if (!AppState.lastSyncResult || AppState.lastSyncResult.length === 0) {
+    empty.style.display   = '';
+    content.style.display = 'none';
+    return;
+  }
+
+  const entry = AppState.lastSyncResult[0];
+  if (!entry.success) {
+    empty.style.display   = '';
+    content.style.display = 'none';
+    document.getElementById('result-empty').textContent = `동기화 실패: ${entry.error}`;
+    return;
+  }
+
+  empty.style.display   = 'none';
+  content.style.display = '';
+
+  const data     = entry.data || {};
+  const globalOv = data.registerationOverview || {};
+  const elapsed  = data.elapsedTime ?? '';
+  const avail    = data.availableConnection ?? '';
+
+  const failed    = globalOv.failed || 0;
+  const succeeded = Object.entries(globalOv)
+    .filter(([k]) => k !== 'failed' && k !== 'nlb')
+    .reduce((s, [, v]) => s + (Number(v) || 0), 0);
+
+  document.getElementById('result-elapsed').textContent = elapsed ? `소요 시간: ${elapsed}초` : '';
+  document.getElementById('result-summary').innerHTML = `
+    <span class="text-secondary small">가용 커넥션: <strong>${avail}</strong></span>
+    <span class="text-success small">등록 성공: <strong>${succeeded}</strong></span>
+    ${failed > 0 ? `<span class="text-danger small">실패: <strong>${failed}</strong></span>` : ''}
+  `;
+
+  // 각 connection별 output[] 문자열 파싱 → flat row 배열
+  const rows = [];
+  const connResults = Array.isArray(data.registerationResult) ? data.registerationResult : [];
+  for (const connResult of connResults) {
+    const connName = connResult.connectionName || '';
+    const outputs  = connResult.registerationOutputs?.output || [];
+    if (outputs.length === 0) {
+      rows.push({ connectionName: connName, resourceType: '—', resourceId: '(결과 없음)', status: '—', message: '', _failed: false });
+    } else {
+      outputs.forEach(str => rows.push(parseOutputString(str, connName)));
+    }
+  }
+
+  if (AppState.resultTable) {
+    AppState.resultTable.destroy();
+    AppState.resultTable = null;
+  }
+
+  AppState.resultTable = new Tabulator('#sync-result-table', {
+    data: rows,
+    layout: 'fitColumns',
+    pagination: 'local',
+    paginationSize: 20,
+    placeholder: '등록된 자원이 없습니다.',
+    rowFormatter: (row) => {
+      if (row.getData()._failed) row.getElement().classList.add('table-danger');
+    },
+    columns: [
+      { title: 'Connection',   field: 'connectionName', sorter: 'string', minWidth: 160 },
+      { title: 'Type',         field: 'resourceType',   sorter: 'string', width: 120 },
+      { title: 'Resource ID',  field: 'resourceId',     sorter: 'string' },
+      {
+        title: 'Status', field: 'status', sorter: 'string', width: 110, hozAlign: 'center',
+        formatter: (cell) => {
+          const v = cell.getValue();
+          if (!v || v === '—') return v;
+          const cls = v.toLowerCase() === 'success' ? 'bg-success' : 'bg-danger';
+          return `<span class="badge ${cls}">${v}</span>`;
+        },
+      },
+      { title: 'Message', field: 'message', sorter: 'string' },
+    ],
+  });
+}
+
+// ── NS 드롭다운 ───────────────────────────────────────────────────────────────
+
+async function loadNsDropdown() {
+  const nsList = await api().getAllNs().catch(() => []);
+  const sel = document.getElementById('sync-ns');
+  nsList.forEach(n => {
+    const id = n.id || n.nsId || n.name || String(n);
+    sel.appendChild(new Option(id, id));
+  });
+}
+
+// ── Init ──────────────────────────────────────────────────────────────────────
+
+document.addEventListener('DOMContentLoaded', async function () {
+  const btnList = document.getElementById('page-header-btn-list');
+  if (btnList) {
+    btnList.innerHTML = `
+      <a href="/webconsole/settings/environment/cloudresources/csp" class="btn btn-outline-secondary me-2">CSP Import</a>
+      <a href="/webconsole/settings/environment/cloudresources/cspschedule" class="btn btn-outline-secondary">CSP Schedule</a>`;
+  }
+
+  // connection 목록 로드 (빠름) — provider 체크박스 생성용
+  const conns = await api().getConnConfigList().catch(() => []);
+  AppState.allConnections = conns;
+  populateQueryProviderCheckboxes();
+
+  // NS 드롭다운
+  await loadNsDropdown();
+  // 자동 조회 없음 — 사용자가 조회 버튼 클릭 시 실행
+});

--- a/front/templates/pages/settings/environment/cloudresources/resourcesync.html
+++ b/front/templates/pages/settings/environment/cloudresources/resourcesync.html
@@ -40,7 +40,7 @@
                       <input class="form-check-input" type="radio" name="query-provider-radio" value="partial" onchange="syncOnProviderModeChange()">
                       <span class="form-check-label">부분 선택</span>
                     </label>
-                    <div id="qry-provider-cb-group" class="d-flex gap-3 flex-wrap" style="display:none!important">
+                    <div id="qry-provider-cb-group" class="d-flex gap-3 flex-wrap">
                       <!-- 동적 생성 -->
                     </div>
                   </div>

--- a/front/templates/pages/settings/environment/cloudresources/resourcesync.html
+++ b/front/templates/pages/settings/environment/cloudresources/resourcesync.html
@@ -73,10 +73,10 @@
                       <span class="form-check-label">부분 선택</span>
                     </label>
                     <div id="qry-restype-cb-group" class="d-flex gap-3 flex-wrap" style="display:none!important">
-                      <label class="form-check mb-0"><input class="form-check-input qry-restype-cb" type="checkbox" value="vNet" checked><span class="form-check-label">vNet</span></label>
-                      <label class="form-check mb-0"><input class="form-check-input qry-restype-cb" type="checkbox" value="securityGroup" checked><span class="form-check-label">Security Group</span></label>
-                      <label class="form-check mb-0"><input class="form-check-input qry-restype-cb" type="checkbox" value="sshKey" checked><span class="form-check-label">SSH Key</span></label>
-                      <label class="form-check mb-0"><input class="form-check-input qry-restype-cb" type="checkbox" value="node" checked><span class="form-check-label">Node</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input qry-restype-cb" type="checkbox" value="vNet"><span class="form-check-label">vNet</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input qry-restype-cb" type="checkbox" value="securityGroup"><span class="form-check-label">Security Group</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input qry-restype-cb" type="checkbox" value="sshKey"><span class="form-check-label">SSH Key</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input qry-restype-cb" type="checkbox" value="node"><span class="form-check-label">Node</span></label>
                     </div>
                   </div>
                 </div>
@@ -216,9 +216,9 @@
                       <span class="form-check-label">부분 선택</span>
                     </label>
                     <div id="restype-cb-group" class="d-flex gap-3 flex-wrap" style="display:none!important">
-                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="vNet" checked><span class="form-check-label">vNet</span></label>
-                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="securityGroup" checked><span class="form-check-label">Security Group</span></label>
-                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="sshKey" checked><span class="form-check-label">SSH Key</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="vNet"><span class="form-check-label">vNet</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="securityGroup"><span class="form-check-label">Security Group</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="sshKey"><span class="form-check-label">SSH Key</span></label>
                       <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="node"><span class="form-check-label">Node</span></label>
                       <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="dataDisk"><span class="form-check-label">Data Disk</span></label>
                       <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="customImage"><span class="form-check-label">Custom Image</span></label>

--- a/front/templates/pages/settings/environment/cloudresources/resourcesync.html
+++ b/front/templates/pages/settings/environment/cloudresources/resourcesync.html
@@ -199,7 +199,7 @@
                       <input class="form-check-input" type="radio" name="provider-radio" value="partial" onchange="syncToggleProvider()">
                       <span class="form-check-label">부분 선택</span>
                     </label>
-                    <div id="provider-cb-group" class="d-flex gap-3 flex-wrap" style="display:none!important"></div>
+                    <div id="provider-cb-group" class="d-flex gap-3 flex-wrap"></div>
                   </div>
                 </div>
 
@@ -215,13 +215,13 @@
                       <input class="form-check-input" type="radio" name="restype-radio" value="partial" onchange="syncToggleResType()">
                       <span class="form-check-label">부분 선택</span>
                     </label>
-                    <div id="restype-cb-group" class="d-flex gap-3 flex-wrap" style="display:none!important">
-                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="vNet"><span class="form-check-label">vNet</span></label>
-                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="securityGroup"><span class="form-check-label">Security Group</span></label>
-                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="sshKey"><span class="form-check-label">SSH Key</span></label>
-                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="node"><span class="form-check-label">Node</span></label>
-                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="dataDisk"><span class="form-check-label">Data Disk</span></label>
-                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="customImage"><span class="form-check-label">Custom Image</span></label>
+                    <div id="restype-cb-group" class="d-flex gap-3 flex-wrap">
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="vNet" disabled><span class="form-check-label">vNet</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="securityGroup" disabled><span class="form-check-label">Security Group</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="sshKey" disabled><span class="form-check-label">SSH Key</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="node" disabled><span class="form-check-label">Node</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="dataDisk" disabled><span class="form-check-label">Data Disk</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="customImage" disabled><span class="form-check-label">Custom Image</span></label>
                     </div>
                   </div>
                 </div>

--- a/front/templates/pages/settings/environment/cloudresources/resourcesync.html
+++ b/front/templates/pages/settings/environment/cloudresources/resourcesync.html
@@ -1,0 +1,276 @@
+<div class="page-body">
+  <div class="container-xl">
+
+    <!-- 탭 네비게이션 -->
+    <div class="row mb-3">
+      <div class="col-12">
+        <ul class="nav nav-tabs" id="sync-tabs">
+          <li class="nav-item">
+            <a class="nav-link active" href="#" onclick="syncShowTab('overview', this); return false;">동기화 현황</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#" onclick="syncShowTab('result', this); return false;">동기화 결과</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- ── 동기화 현황 탭 ──────────────────────────────────────────────── -->
+    <div id="tab-overview">
+
+      <!-- 조회 조건 카드 -->
+      <div class="row row-cards mb-3">
+        <div class="col-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">조회 조건</h3>
+            </div>
+            <div class="card-body">
+              <div class="row g-3">
+
+                <!-- Provider -->
+                <div class="col-12">
+                  <label class="form-label">Provider</label>
+                  <div class="d-flex gap-3 align-items-center flex-wrap">
+                    <label class="form-check mb-0">
+                      <input class="form-check-input" type="radio" name="query-provider-radio" value="all" checked onchange="syncOnProviderModeChange()">
+                      <span class="form-check-label">전체</span>
+                    </label>
+                    <label class="form-check mb-0">
+                      <input class="form-check-input" type="radio" name="query-provider-radio" value="partial" onchange="syncOnProviderModeChange()">
+                      <span class="form-check-label">부분 선택</span>
+                    </label>
+                    <div id="qry-provider-cb-group" class="d-flex gap-3 flex-wrap" style="display:none!important">
+                      <!-- 동적 생성 -->
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Connection (부분 선택 시 표시) -->
+                <div id="qry-conn-section" class="col-12" style="display:none">
+                  <label class="form-label">Connection
+                    <span class="ms-2">
+                      <a href="#" class="text-secondary small" onclick="syncSelectAllConn(true); return false;">전체 선택</a>
+                      /
+                      <a href="#" class="text-secondary small" onclick="syncSelectAllConn(false); return false;">전체 해제</a>
+                    </span>
+                  </label>
+                  <div id="qry-conn-cb-group" class="border rounded p-2" style="max-height:200px; overflow-y:auto; background:#f8f9fa">
+                    <span class="text-secondary small">Provider를 먼저 선택하세요</span>
+                  </div>
+                </div>
+
+                <!-- 자원 유형 -->
+                <div class="col-12">
+                  <label class="form-label">자원 유형</label>
+                  <div class="d-flex gap-3 align-items-center flex-wrap">
+                    <label class="form-check mb-0">
+                      <input class="form-check-input" type="radio" name="query-restype-radio" value="all" checked onchange="syncOnResTypeModeChange()">
+                      <span class="form-check-label">전체</span>
+                    </label>
+                    <label class="form-check mb-0">
+                      <input class="form-check-input" type="radio" name="query-restype-radio" value="partial" onchange="syncOnResTypeModeChange()">
+                      <span class="form-check-label">부분 선택</span>
+                    </label>
+                    <div id="qry-restype-cb-group" class="d-flex gap-3 flex-wrap" style="display:none!important">
+                      <label class="form-check mb-0"><input class="form-check-input qry-restype-cb" type="checkbox" value="vNet" checked><span class="form-check-label">vNet</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input qry-restype-cb" type="checkbox" value="securityGroup" checked><span class="form-check-label">Security Group</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input qry-restype-cb" type="checkbox" value="sshKey" checked><span class="form-check-label">SSH Key</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input qry-restype-cb" type="checkbox" value="node" checked><span class="form-check-label">Node</span></label>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- 조회 버튼 -->
+                <div class="col-12 d-flex align-items-center gap-2">
+                  <button class="btn btn-primary" onclick="syncQuery()">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="16" height="16" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15" y2="15"/></svg>
+                    조회
+                  </button>
+                  <span id="qry-status" class="text-secondary small"></span>
+                </div>
+
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 현황 테이블 카드 -->
+      <div class="row row-cards mb-3">
+        <div class="col-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">CSP 자원 동기화 현황</h3>
+              <div class="card-options ms-auto d-flex align-items-center gap-2">
+                <span id="sync-elapsed" class="text-secondary small"></span>
+                <div class="input-group input-group-sm" style="width:200px">
+                  <span class="input-group-text">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="14" height="14" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><circle cx="10" cy="10" r="7"/><line x1="21" y1="21" x2="15" y2="15"/></svg>
+                  </span>
+                  <input type="text" id="sync-table-search" class="form-control" placeholder="Connection 검색" oninput="syncFilterTable(this.value)">
+                </div>
+              </div>
+            </div>
+            <div id="sync-overview-loading" class="card-footer text-center text-secondary small py-2" style="display:none">
+              <div class="spinner-border spinner-border-sm me-1"></div>
+              자원 현황 조회 중… (시간이 걸릴 수 있습니다)
+            </div>
+            <div id="sync-summary" class="card-body border-bottom py-2" style="display:none">
+              <div class="d-flex gap-4 flex-wrap">
+                <span class="text-secondary small">조회된 커넥션: <strong id="sum-total"></strong></span>
+                <span class="text-secondary small">정상 연결: <strong id="sum-avail"></strong></span>
+                <span class="text-danger small">미등록 자원 있는 커넥션: <strong id="sum-unsynced"></strong></span>
+              </div>
+            </div>
+            <div class="card-body p-0">
+              <div id="sync-overview-table"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Connection 상세 카드 (행 클릭 시 표시) -->
+      <div id="sync-detail-card" class="row row-cards mb-3" style="display:none">
+        <div class="col-12">
+          <div class="card border-primary">
+            <div class="card-header">
+              <h3 class="card-title">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon text-primary me-1" width="16" height="16" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><circle cx="12" cy="12" r="9"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+                Connection 상세: <span id="detail-conn-name" class="text-primary"></span>
+              </h3>
+              <div class="card-options ms-auto">
+                <button class="btn btn-sm btn-outline-secondary" onclick="document.getElementById('sync-detail-card').style.display='none'">✕</button>
+              </div>
+            </div>
+            <div class="card-body p-0">
+              <table class="table table-vcenter table-sm mb-0">
+                <thead>
+                  <tr>
+                    <th>자원 유형</th>
+                    <th class="text-center">TB 등록</th>
+                    <th class="text-center">CSP 전체</th>
+                    <th class="text-center">미등록</th>
+                    <th class="text-center">상태</th>
+                  </tr>
+                </thead>
+                <tbody id="detail-tbody"></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 동기화 실행 카드 -->
+      <div class="row row-cards">
+        <div class="col-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">동기화 실행</h3>
+            </div>
+            <div class="card-body">
+              <div class="row g-3">
+
+                <!-- Namespace -->
+                <div class="col-md-4">
+                  <label class="form-label required">Namespace</label>
+                  <select id="sync-ns" class="form-select">
+                    <option value="">Select Namespace</option>
+                  </select>
+                </div>
+
+                <!-- 대상 Connection (테이블 선택 표시) -->
+                <div class="col-md-8">
+                  <label class="form-label">대상 Connection</label>
+                  <div id="sync-selected-conn" class="form-control bg-light text-secondary" style="min-height:38px; font-size:0.875rem">
+                    현황 테이블에서 Connection을 선택하세요 (미선택 시 전체 대상)
+                  </div>
+                </div>
+
+                <!-- 대상 Provider -->
+                <div class="col-12">
+                  <label class="form-label">대상 Provider</label>
+                  <div class="d-flex gap-3 align-items-center flex-wrap">
+                    <label class="form-check mb-0">
+                      <input class="form-check-input" type="radio" name="provider-radio" value="all" checked onchange="syncToggleProvider()">
+                      <span class="form-check-label">전체</span>
+                    </label>
+                    <label class="form-check mb-0">
+                      <input class="form-check-input" type="radio" name="provider-radio" value="partial" onchange="syncToggleProvider()">
+                      <span class="form-check-label">부분 선택</span>
+                    </label>
+                    <div id="provider-cb-group" class="d-flex gap-3 flex-wrap" style="display:none!important"></div>
+                  </div>
+                </div>
+
+                <!-- 자원 유형 -->
+                <div class="col-12">
+                  <label class="form-label">자원 유형</label>
+                  <div class="d-flex gap-3 align-items-center flex-wrap">
+                    <label class="form-check mb-0">
+                      <input class="form-check-input" type="radio" name="restype-radio" value="all" checked onchange="syncToggleResType()">
+                      <span class="form-check-label">전체</span>
+                    </label>
+                    <label class="form-check mb-0">
+                      <input class="form-check-input" type="radio" name="restype-radio" value="partial" onchange="syncToggleResType()">
+                      <span class="form-check-label">부분 선택</span>
+                    </label>
+                    <div id="restype-cb-group" class="d-flex gap-3 flex-wrap" style="display:none!important">
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="vNet" checked><span class="form-check-label">vNet</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="securityGroup" checked><span class="form-check-label">Security Group</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="sshKey" checked><span class="form-check-label">SSH Key</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="node"><span class="form-check-label">Node</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="dataDisk"><span class="form-check-label">Data Disk</span></label>
+                      <label class="form-check mb-0"><input class="form-check-input sync-type-cb" type="checkbox" value="customImage"><span class="form-check-label">Custom Image</span></label>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- 실행 버튼 -->
+                <div class="col-12 d-flex gap-2 align-items-center">
+                  <button class="btn btn-primary" onclick="syncExecute()">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="16" height="16" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M7 4v16l13 -8z"/></svg>
+                    동기화 실행
+                  </button>
+                  <span id="sync-exec-status" class="text-secondary small"></span>
+                </div>
+
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── 동기화 결과 탭 ──────────────────────────────────────────────── -->
+    <div id="tab-result" style="display:none">
+      <div class="row row-cards">
+        <div class="col-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">동기화 실행 결과</h3>
+              <div class="card-options ms-auto">
+                <span id="result-elapsed" class="text-secondary small"></span>
+              </div>
+            </div>
+            <div id="result-empty" class="card-body text-center text-secondary py-5">
+              동기화 실행 후 결과가 표시됩니다.
+            </div>
+            <div id="result-content" style="display:none">
+              <div class="card-body border-bottom py-2">
+                <div class="d-flex gap-4 flex-wrap" id="result-summary"></div>
+              </div>
+              <div class="card-body p-0">
+                <div id="sync-result-table"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+{{ javascriptTag("common/api/services/cspimport_api.js") | raw }}
+{{ javascriptTag("pages/settings/environment/cloudresources/resourcesync.js") | raw }}

--- a/front/templates/pages/settings/environment/cloudresources/resourcesync.html
+++ b/front/templates/pages/settings/environment/cloudresources/resourcesync.html
@@ -11,6 +11,9 @@
           <li class="nav-item">
             <a class="nav-link" href="#" onclick="syncShowTab('result', this); return false;">동기화 결과</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" id="tab-nssync-link" href="#" onclick="syncShowTab('nssync', this); return false;">NS 동기화</a>
+          </li>
         </ul>
       </div>
     </div>
@@ -263,6 +266,40 @@
               <div class="card-body p-0">
                 <div id="sync-result-table"></div>
               </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── NS 동기화 탭 ──────────────────────────────────────────────── -->
+    <div id="tab-nssync" style="display:none;">
+      <div class="row row-cards mb-3">
+        <div class="col-12">
+          <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+              <h3 class="card-title">동기화 차이 조회</h3>
+              <button type="button" class="btn btn-sm btn-secondary" onclick="nsSyncQuery()">조회</button>
+            </div>
+            <div class="card-body" id="nssync-diff-area">
+              <p class="text-muted">조회 버튼을 눌러 Namespace ↔ Project 불일치 현황을 확인하세요.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row row-cards" id="nssync-apply-card" style="display:none;">
+        <div class="col-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">동기화 적용</h3>
+            </div>
+            <div class="card-body">
+              <div class="mb-3">
+                <label class="form-label">대상 Workspace</label>
+                <select id="nssync-workspace-sel" class="form-select" style="max-width:320px;"></select>
+              </div>
+              <button type="button" class="btn btn-primary" onclick="nsSyncApply()">적용</button>
+              <div id="nssync-apply-result" class="mt-3"></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- 클라우드 자원 동기화 현황 조회 및 실행 화면 신규 구현 (RQ-CLOUD-ADMIN-005)
- `InspectResourcesOverview` / `InspectResources` 기반 Provider·Connection·자원유형 필터 조회
- `registerCspNativeResources` API를 통한 동기화 실행 및 결과 탭 표시
- QueryParams 배열 전송 지원 (`map[string]interface{}` + 반복 키 직렬화)

## Changes

- `resourcesync.html` — 동기화 현황/결과 2탭 화면 신규
- `resourcesync.js` — 전체/부분 조회, 현황 테이블(Tabulator), Connection 상세 카드, 동기화 실행, 결과 파싱
- `cspimport_api.js` — `getResourcesOverview()` 추가, `registerCspNativeResources` provider/region 필터 지원
- `api/internal/model/request.go` — `QueryParams map[string]interface{}` 배열 값 지원
- `api/internal/handler/proxy.go` — 배열 queryParams `?key=v1&key=v2` 반복 직렬화
- `conf/api.yaml` — `InspectResourcesOverview` operationId 추가
- `conf/webconsole_menu_resources.yaml` — Resource Sync 메뉴 등록 (menunumber: 1580)

## Key Design Decisions

- **전체 조회**: `InspectResourcesOverview` 단일 호출 → Connection × 자원유형 집계 테이블
- **부분 조회**: 선택 Connection × 자원유형 `InspectResources` N×M 병렬 호출
- **Provider 추출**: `connectionName.split('-')[0]` (e.g. `aws-ap-northeast-2` → `aws`)
- **동기화 실행**: 선택 Connection에서 unique (provider, region) 추출 → 조합별 API 호출
- **output 파싱**: `/^(\w+):\s+(.+?)\s+\[(\w+)\]\s*(.*)$/` 정규식으로 type/id/status/message 추출
- **체크박스 UX**: 전체/부분 선택 라디오 — 체크박스는 항상 표시, 기본 disabled+unchecked, 부분 선택 시 enabled

## Test Plan

- [x] 페이지 진입 및 초기 상태 (disabled 체크박스, 탭 구조)
- [x] 전체 조회 — InspectResourcesOverview 호출 및 테이블 렌더링
- [x] 부분 조회 — 선택 Connection × 자원유형 병렬 호출 및 진행 표시
- [x] 미등록 자원 있는 행 노란 강조
- [x] Connection 행 클릭 → 상세 카드 표시
- [x] 동기화 실행 → provider/region 추출 확인 (Network 탭)
- [x] option 배열 쿼리 파라미터 전송 확인
- [x] 결과 탭 — output 문자열 파싱 및 Success/Failed 배지 표시
- [x] 다중 API 호출 결과 병합 및 요약 집계

## Related

- RQ-CLOUD-ADMIN-005 (자원 동기화)
- PR #166 (RQ-CLOUD-ADMIN-007 CSP Import — 참조 패턴)