### PR TITLE
fix(WEB-BUG-011): fix sidebar Organizations menu not expanding

### DIFF
--- a/front/assets/js/partials/layout/sidebar.js
+++ b/front/assets/js/partials/layout/sidebar.js
@@ -43,7 +43,7 @@ function generateMenuHTML(menus) {
             html += ` </li>`
             if (category.menus && category.menus.length > 0) {
                 category.menus.forEach(menu => {
-                    if (menu.menus === null){
+                    if (!menu.menus || menu.menus.length === 0){
                         html +=`<li class="nav-item">`
                         html +=`<a class="nav-link" ${stringToBool(menu.isAction) ? `href="/webconsole/${title.id}/${category.id}/${menu.id}"` : ""}" name="sidebar_${menu.id}">`
                         html +=`<span class="nav-link-icon d-md-none d-lg-inline-block">${iconsArr[menu.id] ? iconsArr[menu.id] : iconsArr["undefined"] }</span>`; // svg
@@ -52,7 +52,7 @@ function generateMenuHTML(menus) {
                         html +=`</li>`
                     }else {
                         html += `<li class="nav-item box-link dropdown" name="sidebar_${menu.id}">`;
-                        html += `<div class="nav-link dropdown-toggle" name="sidebar_${menu.id}" href="${stringToBool(menu.isAction) ? `/webconsole/${title.id}/${category.id}/${menu.id}` : "#navbar-extra"}" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button" aria-expanded="false">`;
+                        html += `<div class="nav-link dropdown-toggle" name="sidebar_${menu.id}" href="${stringToBool(menu.isAction) ? `/webconsole/${title.id}/${category.id}/${menu.id}` : "#navbar-extra"}" role="button" aria-expanded="false">`;
                         html += `<span class="nav-link-icon d-md-none d-lg-inline-block">${iconsArr[menu.id] ? iconsArr[menu.id] : iconsArr["undefined"] }</span>`; // svg
                         html += `<span class="nav-link-title">${menu.displayName}</span>`;
                         html += `</div>`;


### PR DESCRIPTION
## Summary

- **Issue**: WEB-BUG-011 — Organizations 사이드바 메뉴 클릭 시 하위 메뉴가 펼쳐지지 않음
- Fix `menu.menus === null` → `!menu.menus || menu.menus.length === 0` in `generateMenuHTML()`
- Remove `data-bs-toggle="dropdown"` to prevent Bootstrap handler conflicting with custom toggle handler

## Root Cause

1. `convertToMenuTree()` initializes every node with `menus: []`, so `menu.menus === null` was always false — leaf items were incorrectly rendered as dropdown toggles with no content.
2. `data-bs-toggle="dropdown"` caused Bootstrap's built-in click handler and the custom `nextElementSibling` toggle handler to both fire, toggling `show` twice (net effect: menu stays closed).

## Files Changed

- `front/assets/js/partials/layout/sidebar.js`

## Test Plan

- [ ] Login and verify Organizations menu expands on click
- [ ] Verify leaf menu items (without children) render as plain nav links
- [ ] Verify other expandable menus are unaffected