### PR TITLE
fix(api): add missing POST /api/getapihosts endpoint

### DIFF
--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -99,6 +99,7 @@ func main() {
 
 	// 단일 세그먼트 내부 핸들러
 	api.POST("/disklookup", handler.DiskLookup)
+	api.POST("/getapihosts", handler.GetApiHosts)
 
 	// 관리자 전용 BFF 라우트 (와일드카드보다 먼저 등록되어야 정적 매칭됨)
 	// FR-CLOUD-ADMIN-006-08: 외부 raw YAML 도달성 확인 (CORS 우회 + 토큰 노출 방지)

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -9,12 +9,13 @@ import (
 
 // Config 전체 애플리케이션 설정
 type Config struct {
-	Server          ServerConfig
-	Database        DatabaseConfig
-	MCIAM           MCIAMConfig
-	ApiSpec         *ApiSpec
-	RegistryCache   RegistryCacheInterface
-	SetupYaml       SetupYamlConfig
+	Server             ServerConfig
+	Database           DatabaseConfig
+	MCIAM              MCIAMConfig
+	ApiSpec            *ApiSpec
+	RegistryCache      RegistryCacheInterface
+	SetupYaml          SetupYamlConfig
+	IframeTargetIsHost bool // IFRAME_TARGET_IS_HOST 환경변수
 }
 
 // SetupYamlConfig FR-CLOUD-ADMIN-006-08용 raw yaml 도달성 확인 설정
@@ -32,6 +33,8 @@ type RegistryCacheInterface interface {
 	GetBaseURL(subsystem, operationId string) string
 	// GetActionSpec 캐시의 ServiceActions에서 ActionSpec 반환. nil 이면 api.yaml ActionSpec 사용.
 	GetActionSpec(subsystem, operationId string) *ActionSpec
+	// GetAllServices 캐시의 전체 서비스 목록 반환. 캐시 없음/만료이면 nil 반환.
+	GetAllServices() map[string]Service
 	Store(responseData interface{})
 	Invalidate()
 }
@@ -86,6 +89,7 @@ func Load() (*Config, error) {
 			McWebconsoleMenuYaml: getEnv("MCWEBCONSOLE_MENUYAML", ""),
 			McAdmincliApiYaml:    getEnv("MCADMINCLI_APIYAML", ""),
 		},
+		IframeTargetIsHost: getEnv("IFRAME_TARGET_IS_HOST", "false") == "true",
 	}
 
 	// API 스펙 로드

--- a/api/internal/handler/apihosts.go
+++ b/api/internal/handler/apihosts.go
@@ -1,0 +1,106 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"mc_web_console_api/internal/config"
+	"mc_web_console_api/internal/model"
+
+	"github.com/labstack/echo/v4"
+)
+
+// ServiceNoAuth Auth 정보를 제외한 서비스 호스트 정보 (Buffalo ServiceNoAuth 호환)
+type ServiceNoAuth struct {
+	BaseURL string `json:"BaseURL"`
+}
+
+// GetApiHosts POST /api/getapihosts
+// MCIAM_USE=false: api.yaml Services에서 추출
+// MCIAM_USE=true:  RegistryCache 우선, 미적재 시 ListMcmpApisServices 호출 후 반환
+// IFRAME_TARGET_IS_HOST=true: BaseURL을 :port/path 형식으로 변환
+func GetApiHosts(c echo.Context) error {
+	cfg, _ := c.Get("config").(*config.Config)
+	if cfg == nil {
+		return c.JSON(http.StatusOK, map[string]interface{}{"error": "config not available"})
+	}
+
+	apiHosts := make(map[string]ServiceNoAuth)
+
+	if cfg.MCIAM.Use && cfg.RegistryCache != nil {
+		cached := cfg.RegistryCache.GetAllServices()
+		if cached == nil {
+			// 캐시 미적재 → ListMcmpApisServices 직접 호출하여 채워넣기
+			if err := refreshRegistryCache(cfg, c); err != nil {
+				log.Printf("[GetApiHosts] cache refresh failed: %v", err)
+			}
+			cached = cfg.RegistryCache.GetAllServices()
+		}
+		for k, v := range cached {
+			apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL}
+		}
+	} else {
+		for k, v := range cfg.ApiSpec.Services {
+			apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL}
+		}
+	}
+
+	commonResponse := model.CommonResponseStatusOK(apiHosts)
+
+	if cfg.IframeTargetIsHost {
+		re := regexp.MustCompile(`:(\d+.*)`)
+		for fw, host := range apiHosts {
+			if portURLStr := re.FindString(host.BaseURL); portURLStr != "" {
+				host.BaseURL = portURLStr
+				apiHosts[fw] = host
+			}
+		}
+		commonResponse = model.CommonResponseStatusOK(apiHosts)
+	}
+
+	return c.JSON(commonResponse.Status.Code, commonResponse)
+}
+
+// refreshRegistryCache mc-iam-manager의 ListMcmpApisServices를 직접 호출하여 RegistryCache 갱신.
+// buildAuthHeader는 proxy.go에서 공유 (같은 handler 패키지).
+func refreshRegistryCache(cfg *config.Config, c echo.Context) error {
+	service, actionSpec, err := cfg.ApiSpec.GetAction("mc-iam-manager", "ListMcmpApisServices")
+	if err != nil {
+		return fmt.Errorf("ListMcmpApisServices not found in api.yaml: %w", err)
+	}
+
+	targetURL := service.BaseURL + actionSpec.ResourcePath
+	req, err := http.NewRequest(strings.ToUpper(actionSpec.Method), targetURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if authHeader := buildAuthHeader(c, service); authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return fmt.Errorf("ListMcmpApisServices call failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("ListMcmpApisServices returned %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var responseData interface{}
+	if err := json.Unmarshal(body, &responseData); err != nil {
+		return fmt.Errorf("ListMcmpApisServices response parse failed: %w", err)
+	}
+
+	cfg.RegistryCache.Store(responseData)
+	return nil
+}

--- a/api/internal/service/registry_cache.go
+++ b/api/internal/service/registry_cache.go
@@ -50,6 +50,25 @@ func (rc *RegistryCache) Store(responseData interface{}) {
 	log.Printf("[RegistryCache] stored %d services (actions: %d)", len(services), len(actions))
 }
 
+// GetAllServices 캐시가 유효한 경우 전체 서비스 목록 반환.
+// 캐시 없음/만료이면 nil 반환.
+func (rc *RegistryCache) GetAllServices() map[string]config.Service {
+	rc.mu.RLock()
+	services := rc.services
+	storedAt := rc.storedAt
+	rc.mu.RUnlock()
+
+	if services == nil || rc.isExpired(storedAt) {
+		return nil
+	}
+
+	result := make(map[string]config.Service, len(services))
+	for k, v := range services {
+		result[k] = v
+	}
+	return result
+}
+
 // Invalidate 캐시 무효화. UpdateFrameworkService 성공 시 호출.
 func (rc *RegistryCache) Invalidate() {
 	rc.mu.Lock()


### PR DESCRIPTION
## Summary

- Buffalo→Echo 마이그레이션 과정에서 누락된 `POST /api/getapihosts` 엔드포인트 복구
- `MCIAM_USE=false` 시 api.yaml Services에서 BaseURL 직접 추출
- `MCIAM_USE=true` 시 RegistryCache 우선 조회, 캐시 미적재 시 mc-iam-manager `ListMcmpApisServices` 자동 호출하여 캐시 채운 뒤 반환
- `IFRAME_TARGET_IS_HOST=true` 시 BaseURL을 `:port/path` 형식으로 변환 (Cost Analysis iframe 용)

## 변경 파일

- `api/internal/handler/apihosts.go` — 신규: GetApiHosts 핸들러, ServiceNoAuth 타입, refreshRegistryCache 헬퍼
- `api/internal/config/config.go` — IframeTargetIsHost 필드 추가, RegistryCacheInterface에 GetAllServices() 추가
- `api/internal/service/registry_cache.go` — GetAllServices() 구현 추가
- `api/cmd/main.go` — POST /api/getapihosts 라우트 등록

## 관련 이슈

WEB-TECH-006

## Test plan

- [ ] `MCIAM_USE=false`: `curl -X POST http://localhost:3100/api/getapihosts` → api.yaml 서비스 목록 반환
- [ ] `MCIAM_USE=true`, 캐시 미적재: 첫 호출 시 mc-iam-manager 자동 호출 후 반환
- [ ] `IFRAME_TARGET_IS_HOST=true`: BaseURL이 `:port/path` 형식인지 확인
- [ ] Cost Analysis 화면에서 iframe 정상 로딩 확인