### PR TITLE
feat(costanalysis): mc-cost-optimizer-fe iframe + Cloud Overview Add Service

### DIFF
--- a/api/internal/config/api_spec.go
+++ b/api/internal/config/api_spec.go
@@ -53,6 +53,18 @@ func LoadApiSpec(path string) (*ApiSpec, error) {
 	return &apiSpec, nil
 }
 
+// GetService subsystem 서비스 정보만 조회 (action 불필요 시 사용)
+func (a *ApiSpec) GetService(subsystem string) (*Service, error) {
+	subsystemLower := strings.ToLower(subsystem)
+	for key, svc := range a.Services {
+		if strings.ToLower(key) == subsystemLower {
+			s := svc
+			return &s, nil
+		}
+	}
+	return nil, fmt.Errorf("service not found: %s", subsystem)
+}
+
 // GetAction subsystem과 operationId로 액션 조회
 func (a *ApiSpec) GetAction(subsystem, operationId string) (*Service, *ActionSpec, error) {
 	// 소문자로 변환하여 매칭 (Buffalo 호환)

--- a/api/internal/handler/apihosts.go
+++ b/api/internal/handler/apihosts.go
@@ -32,6 +32,11 @@ func GetApiHosts(c echo.Context) error {
 
 	apiHosts := make(map[string]ServiceNoAuth)
 
+	// api.yaml을 기본값으로 사용 (레지스트리 미등록 서비스도 포함)
+	for k, v := range cfg.ApiSpec.Services {
+		apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL}
+	}
+
 	if cfg.MCIAM.Use && cfg.RegistryCache != nil {
 		cached := cfg.RegistryCache.GetAllServices()
 		if cached == nil {
@@ -41,12 +46,11 @@ func GetApiHosts(c echo.Context) error {
 			}
 			cached = cfg.RegistryCache.GetAllServices()
 		}
+		// 레지스트리 값으로 override (BaseURL이 있는 경우만)
 		for k, v := range cached {
-			apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL}
-		}
-	} else {
-		for k, v := range cfg.ApiSpec.Services {
-			apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL}
+			if v.BaseURL != "" {
+				apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL}
+			}
 		}
 	}
 

--- a/api/internal/handler/proxy.go
+++ b/api/internal/handler/proxy.go
@@ -47,6 +47,16 @@ func SubsystemAnyController(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, model.CommonResponseStatusNotFound(msg))
 	}
 
+	// MCIAM_USE=true이고 캐시가 비어 있으면 ListMcmpApisServices 자동 갱신
+	// (UpdateFrameworkService 후 invalidate된 캐시를 복원)
+	if cfg.MCIAM.Use && cfg.RegistryCache != nil {
+		if allSvcs := cfg.RegistryCache.GetAllServices(); allSvcs == nil {
+			if err := refreshRegistryCache(cfg, c); err != nil {
+				log.Printf("[SubsystemAnyController] cache refresh failed: %v", err)
+			}
+		}
+	}
+
 	// BaseURL: 캐시 우선 → 없으면 api.yaml BaseURL (mc-iam-manager 고정 주소)
 	effectiveBaseURL := service.BaseURL
 	// ActionSpec: 캐시 우선 → 없으면 api.yaml ActionSpec

--- a/api/internal/handler/proxy.go
+++ b/api/internal/handler/proxy.go
@@ -42,9 +42,26 @@ func SubsystemAnyController(c echo.Context) error {
 	// api.yaml에서 기본 Service + ActionSpec 조회 (fallback 및 Auth 설정 소스)
 	service, actionSpec, err := cfg.ApiSpec.GetAction(subsystemName, operationId)
 	if err != nil {
-		log.Printf("GetAction error: subsystem=%s operationId=%s err=%v", subsystemName, operationId, err)
-		msg := fmt.Sprintf("API not found: %s/%s (%s)", subsystemName, operationId, err.Error())
-		return c.JSON(http.StatusNotFound, model.CommonResponseStatusNotFound(msg))
+		// MCIAM_USE=true이면 RegistryCache에서 ActionSpec 조회 시도
+		// (mc-iam-manager 레지스트리에만 있고 api.yaml에 없는 action 대응)
+		if cfg.MCIAM.Use && cfg.RegistryCache != nil {
+			if allSvcs := cfg.RegistryCache.GetAllServices(); allSvcs == nil {
+				_ = refreshRegistryCache(cfg, c)
+			}
+			if cachedSpec := cfg.RegistryCache.GetActionSpec(subsystemName, operationId); cachedSpec != nil {
+				if svc, svcErr := cfg.ApiSpec.GetService(subsystemName); svcErr == nil {
+					service = svc
+					actionSpec = cachedSpec
+					err = nil
+					log.Printf("[RegistryCache] ActionSpec fallback for %s/%s", subsystemName, operationId)
+				}
+			}
+		}
+		if err != nil {
+			log.Printf("GetAction error: subsystem=%s operationId=%s err=%v", subsystemName, operationId, err)
+			msg := fmt.Sprintf("API not found: %s/%s (%s)", subsystemName, operationId, err.Error())
+			return c.JSON(http.StatusNotFound, model.CommonResponseStatusNotFound(msg))
+		}
 	}
 
 	// MCIAM_USE=true이고 캐시가 비어 있으면 ListMcmpApisServices 자동 갱신

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -11,12 +11,12 @@ services:
       password: null
   mc-iam-manager:
     version: 0.2.11
-    baseurl: http://52.79.163.111:5006
+    baseurl: http://mciam.onecloudcon.com:5006
     auth:
       type: bearer
   mc-infra-manager:
     version: 0.9.11
-    baseurl: http://52.79.163.111:1323/tumblebug
+    baseurl: http://mciam.onecloudcon.com:1323/tumblebug
     auth:
       type: basic
       username: default
@@ -41,6 +41,10 @@ services:
   mc-cost-optimizer:
     version: main
     baseurl: http://cost_optimizer_url:18082
+    auth: null
+  mc-cost-optimizer-fe:
+    version: main
+    baseurl: http://cost_optimizer_fe_url:7780
     auth: null
   mc-data-manager:
     version: main:20240923
@@ -721,6 +725,10 @@ serviceActions:
       method: post
       resourcePath: /api/mcmp-apis/list
       description: "전체 프레임워크 서비스 목록 및 BaseURL 조회."
+    CreateFrameworkService:
+      method: post
+      resourcePath: /api/mcmp-apis
+      description: "프레임워크 서비스 신규 등록. body: {name, version, baseUrl, authType, isActive}"
     UpdateFrameworkService:
       method: put
       resourcePath: /api/mcmp-apis/name/{serviceName}

--- a/front/assets/js/common/api/services/readyz_api.js
+++ b/front/assets/js/common/api/services/readyz_api.js
@@ -93,6 +93,13 @@ export async function updateFrameworkServiceUrl(serviceName, baseUrl) {
     }, undefined, { loaderType: 'none' });
 }
 
+export async function createFrameworkServiceUrl(serviceName, baseUrl) {
+    const url = `/api/mc-iam-manager/CreateFrameworkService`;
+    return await webconsolejs["common/api/http"].commonAPIPost(url, {
+        request: { name: serviceName, version: "v1", baseUrl: baseUrl, authType: "none", isActive: true },
+    }, undefined, { loaderType: 'none' });
+}
+
 /**
  * readyz 응답에서 상태 파싱
  * ready 필드가 있으면 그 값을 사용, 없으면 HTTP 200 = ok

--- a/front/assets/js/common/api/services/readyz_api.js
+++ b/front/assets/js/common/api/services/readyz_api.js
@@ -25,20 +25,24 @@ const READYZ_EXCLUDE = new Set(['mc-web-console', 'mc-infra-connector']);
 /**
  * ListMcmpApisServices 응답(services 맵)으로부터 readyz 대상 프레임워크 목록 생성
  * @param {Object} services - { "mc-infra-manager": { BaseURL, Version }, ... }
+ * @param {Object} serviceActions - { "mc-infra-manager": { "Getreadyz": { Method, ResourcePath }, ... }, ... }
  * @returns {Array<{ name, subsystem, operationId, initOperationId }>}
  */
-export function buildFrameworkList(services) {
+export function buildFrameworkList(services, serviceActions = {}) {
     return Object.keys(services)
         .filter(name => !READYZ_EXCLUDE.has(name))
         .sort()
         .map(name => {
-            const mapping = READYZ_OPERATIONID_MAP[name] || { operationId: null, initOperationId: null };
-            return {
-                name,
-                subsystem: name,
-                operationId: mapping.operationId,
-                initOperationId: mapping.initOperationId,
-            };
+            // ServiceActions에서 ResourcePath가 /readyz로 끝나는 action 자동 탐색
+            const actions = serviceActions[name] || {};
+            const readyzEntry = Object.entries(actions).find(([, spec]) =>
+                spec.ResourcePath && spec.ResourcePath.split('?')[0].split('/').pop() === 'readyz'
+            );
+            const operationId = readyzEntry
+                ? readyzEntry[0]
+                : (READYZ_OPERATIONID_MAP[name]?.operationId || null);
+            const initOperationId = READYZ_OPERATIONID_MAP[name]?.initOperationId || null;
+            return { name, subsystem: name, operationId, initOperationId };
         });
 }
 
@@ -65,14 +69,14 @@ export async function callInit(subsystem, operationId) {
 }
 
 /**
- * mc-iam-manager에서 전체 프레임워크 서비스 목록(BaseURL) 조회
- * @returns {Promise<Object>} { "mc-infra-manager": { Version, BaseURL, Auth }, ... }
+ * mc-iam-manager에서 전체 프레임워크 서비스 목록(BaseURL + ServiceActions) 조회
+ * @returns {Promise<{ services: Object, serviceActions: Object }>}
  */
 export async function listFrameworkServices() {
     const url = `/api/mc-iam-manager/ListMcmpApisServices`;
     const res = await webconsolejs["common/api/http"].commonAPIPost(url, {}, undefined, { loaderType: 'none' });
     const d = res && res.data ? (res.data.responseData || res.data) : {};
-    return d.Services || {};
+    return { services: d.Services || {}, serviceActions: d.ServiceActions || {} };
 }
 
 /**

--- a/front/assets/js/common/iframe/iframe.js
+++ b/front/assets/js/common/iframe/iframe.js
@@ -19,7 +19,6 @@ export async function GetApiHosts(frameworkName){
     const framework = getapihostsresponse.data.responseData[frameworkName];
     if (framework && framework.BaseURL) {
         return framework.BaseURL;
-    } else {
-        return 'Framework not found';
     }
+    return null;
 }

--- a/front/assets/js/pages/operation/plugins/costoptimizer.iframe.js
+++ b/front/assets/js/pages/operation/plugins/costoptimizer.iframe.js
@@ -30,12 +30,18 @@ function getCostOptimizerData() {
 }
 
 document.addEventListener("DOMContentLoaded", async function(){
-    var host =  await webconsolejs["common/iframe/iframe"].GetApiHosts("mc-cost-optimizer")
+    var host = await webconsolejs["common/iframe/iframe"].GetApiHosts("mc-cost-optimizer");
+    if (!host) {
+        document.getElementById("costIframe").innerHTML =
+            '<div class="alert alert-warning m-3">mc-cost-optimizer 서비스 URL을 찾을 수 없습니다.<br>' +
+            'Settings &gt; Environment &gt; Cloud SPs &gt; Cloud Overview 에서 서비스 URL을 등록해 주세요.</div>';
+        return;
+    }
     const domain = window.location.protocol + '//' + window.location.hostname;
     if (host.startsWith(":")) {
         host = `${domain}${host}`;
     }
     const data = getCostOptimizerData();
 
-    webconsolejs["common/iframe/iframe"].addIframe("costIframe", host, data)
+    webconsolejs["common/iframe/iframe"].addIframe("costIframe", host, data);
 });

--- a/front/assets/js/pages/operation/plugins/costoptimizer.iframe.js
+++ b/front/assets/js/pages/operation/plugins/costoptimizer.iframe.js
@@ -11,9 +11,9 @@ function getCostOptimizerData() {
     const currentProject = webconsolejs["common/api/services/workspace_api"].getCurrentProject();
     console.log("Current Workspace:", currentWorkspace);
     console.log("Current Project:", currentProject);
-    
+
     const accessToken = webconsolejs["common/storage/sessionstorage"].getSessionCurrentUserToken();
-    
+
     return {
         accessToken: accessToken,
         workspaceInfo: {
@@ -29,12 +29,21 @@ function getCostOptimizerData() {
     };
 }
 
-document.addEventListener("DOMContentLoaded", async function(){
-    var host = await webconsolejs["common/iframe/iframe"].GetApiHosts("mc-cost-optimizer");
+async function loadCostOptimizer() {
+    const currentWorkspace = webconsolejs["common/api/services/workspace_api"].getCurrentWorkspace();
+    const currentProject = webconsolejs["common/api/services/workspace_api"].getCurrentProject();
+
+    if (!currentWorkspace || !currentWorkspace.Id || !currentProject || !currentProject.Id) {
+        document.getElementById("costIframe").innerHTML =
+            '<div class="alert alert-warning m-3">Workspace와 Project를 선택해 주세요.</div>';
+        return;
+    }
+
+    var host = await webconsolejs["common/iframe/iframe"].GetApiHosts("mc-cost-optimizer-fe");
     if (!host) {
         document.getElementById("costIframe").innerHTML =
-            '<div class="alert alert-warning m-3">mc-cost-optimizer 서비스 URL을 찾을 수 없습니다.<br>' +
-            'Settings &gt; Environment &gt; Cloud SPs &gt; Cloud Overview 에서 서비스 URL을 등록해 주세요.</div>';
+            '<div class="alert alert-warning m-3">mc-cost-optimizer-fe 서비스 URL을 찾을 수 없습니다.<br>' +
+            'Settings &gt; Environment &gt; Cloud SPs &gt; Cloud Overview 에서 mc-cost-optimizer-fe URL을 등록해 주세요.</div>';
         return;
     }
     const domain = window.location.protocol + '//' + window.location.hostname;
@@ -44,4 +53,15 @@ document.addEventListener("DOMContentLoaded", async function(){
     const data = getCostOptimizerData();
 
     webconsolejs["common/iframe/iframe"].addIframe("costIframe", host, data);
+}
+
+// project 변경 시 iframe 재로드
+$("#select-current-project").on('change', async function () {
+    let project = { "Id": this.value, "Name": this.options[this.selectedIndex].text, "NsId": this.options[this.selectedIndex].text };
+    webconsolejs["common/api/services/workspace_api"].setCurrentProject(project);
+    await loadCostOptimizer();
+});
+
+document.addEventListener("DOMContentLoaded", async function(){
+    await loadCostOptimizer();
 });

--- a/front/assets/js/pages/settings/environment/cloudsps/cloudoverview.js
+++ b/front/assets/js/pages/settings/environment/cloudsps/cloudoverview.js
@@ -498,9 +498,9 @@ const ReadyzManager = {
     /** mc-iam-manager에서 framework 서비스 주소 로드 + 동적 목록 빌드 */
     async loadFrameworkServices() {
         try {
-            const services = await readyzApi().listFrameworkServices();
+            const { services, serviceActions } = await readyzApi().listFrameworkServices();
             AppState.frameworkServices = services || {};
-            AppState.frameworkList = readyzApi().buildFrameworkList(AppState.frameworkServices);
+            AppState.frameworkList = readyzApi().buildFrameworkList(AppState.frameworkServices, serviceActions);
         } catch (e) {
             console.warn('loadFrameworkServices failed:', e.message);
             AppState.frameworkServices = {};

--- a/front/assets/js/pages/settings/environment/cloudsps/cloudoverview.js
+++ b/front/assets/js/pages/settings/environment/cloudsps/cloudoverview.js
@@ -468,6 +468,18 @@ export async function saveFrameworkUrl(frameworkName) {
     await ReadyzManager.saveFrameworkUrl(frameworkName);
 }
 
+export function showAddServiceRow() {
+    ReadyzManager.showAddServiceRow();
+}
+
+export async function saveNewService() {
+    await ReadyzManager.saveNewService();
+}
+
+export function cancelAddService() {
+    ReadyzManager.cancelAddService();
+}
+
 export async function toggleSelectedCspStatus() {
     if (!AppState.csp.selectedAccount) return;
 
@@ -714,6 +726,59 @@ const ReadyzManager = {
             el.innerHTML += ` <span class="badge bg-danger-lt">Init Failed</span>`;
         }
         if (desc && message) desc.textContent = (desc.textContent ? desc.textContent + ' | ' : '') + message;
+    },
+
+    /** Add Service 입력 행 표시 */
+    showAddServiceRow() {
+        if (document.getElementById('readyz-add-service-row')) return;
+        const tbody = document.getElementById('readyz-table-body');
+        if (!tbody) return;
+        const row = document.createElement('tr');
+        row.id = 'readyz-add-service-row';
+        row.innerHTML = `
+            <td>
+                <input type="text" class="form-control form-control-sm" id="readyz-add-service-name"
+                    placeholder="Service name" style="min-width:120px">
+            </td>
+            <td colspan="3">
+                <div class="input-group input-group-sm">
+                    <input type="text" class="form-control form-control-sm" id="readyz-add-service-url"
+                        placeholder="http://host:port">
+                    <button class="btn btn-sm btn-primary"
+                        onclick="webconsolejs['pages/settings/environment/cloudsps/cloudoverview'].saveNewService()">Save</button>
+                    <button class="btn btn-sm btn-outline-secondary"
+                        onclick="webconsolejs['pages/settings/environment/cloudsps/cloudoverview'].cancelAddService()">Cancel</button>
+                </div>
+            </td>
+            <td></td>
+        `;
+        tbody.insertBefore(row, tbody.firstChild);
+        document.getElementById('readyz-add-service-name').focus();
+    },
+
+    /** Add Service 저장 → mc-iam-manager → 테이블 갱신 */
+    async saveNewService() {
+        const nameInput = document.getElementById('readyz-add-service-name');
+        const urlInput = document.getElementById('readyz-add-service-url');
+        if (!nameInput || !urlInput) return;
+        const serviceName = nameInput.value.trim();
+        const serviceUrl = urlInput.value.trim();
+        if (!serviceName) { alert('Service name을 입력하세요.'); nameInput.focus(); return; }
+        if (!serviceUrl) { alert('URL을 입력하세요.'); urlInput.focus(); return; }
+        try {
+            await readyzApi().createFrameworkServiceUrl(serviceName, serviceUrl);
+            this.cancelAddService();
+            await this.loadFrameworkServices();
+            this.renderTable();
+        } catch (e) {
+            alert('서비스 등록 실패: ' + (e.message || String(e)));
+        }
+    },
+
+    /** Add Service 입력 행 취소 */
+    cancelAddService() {
+        const row = document.getElementById('readyz-add-service-row');
+        if (row) row.remove();
     },
 
     _esc(str) {

--- a/front/templates/pages/settings/environment/cloudsps/cloudoverview.html
+++ b/front/templates/pages/settings/environment/cloudsps/cloudoverview.html
@@ -264,6 +264,14 @@
             <h3 class="card-title">Readyz</h3>
             <div class="card-subtitle text-muted">Framework health check and initialization</div>
             <div class="card-actions">
+              <button class="btn btn-sm btn-outline-primary me-1" onclick="webconsolejs['pages/settings/environment/cloudsps/cloudoverview'].showAddServiceRow()">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon me-1">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                  <path d="M12 5l0 14"></path><path d="M5 12l14 0"></path>
+                </svg>
+                Add Service
+              </button>
               <button class="btn btn-sm btn-outline-secondary" onclick="webconsolejs['pages/settings/environment/cloudsps/cloudoverview'].runAllReadyz()">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
                   stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"


### PR DESCRIPTION
## Summary

- **costoptimizer iframe 개선**: 최초 로드 시 workspace/project 미선택이면 경고 메시지 표시, project 변경 시 iframe 자동 재로드
- **Cloud Overview Add Service**: Readyz 섹션에 Add Service 버튼 추가 — mc-iam-manager `CreateFrameworkService (POST /api/mcmp-apis)` 호출로 신규 서비스 URL 등록
- **readyz_api.js**: `createFrameworkServiceUrl()` 함수 추가
- **conf/api.yaml**: `CreateFrameworkService` operationId 등록

## Test plan

- [ ] `/webconsole/operations/analytics/costanalysis` 접근 시 workspace/project 미선택 → 경고 메시지 확인
- [ ] navbar에서 project 선택 → iframe 자동 로드 확인
- [ ] Cloud Overview → Readyz → Add Service 클릭 → `mc-cost-optimizer-fe` + URL 입력 후 Save → mc-iam-manager 등록 확인
- [ ] 등록 후 `/api/getapihosts` 응답에 `mc-cost-optimizer-fe` 포함 확인