### PR TITLE
fix(apihosts): remove IFRAME_TARGET_IS_HOST port-only transform (HTTPS/HSTS)

### DIFF
--- a/api/internal/handler/apihosts.go
+++ b/api/internal/handler/apihosts.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"regexp"
+	// "regexp"
 	"strings"
 
 	"mc_web_console_api/internal/config"
@@ -56,16 +56,19 @@ func GetApiHosts(c echo.Context) error {
 
 	commonResponse := model.CommonResponseStatusOK(apiHosts)
 
-	if cfg.IframeTargetIsHost {
-		re := regexp.MustCompile(`:(\d+.*)`)
-		for fw, host := range apiHosts {
-			if portURLStr := re.FindString(host.BaseURL); portURLStr != "" {
-				host.BaseURL = portURLStr
-				apiHosts[fw] = host
-			}
-		}
-		commonResponse = model.CommonResponseStatusOK(apiHosts)
-	}
+	// IFRAME_TARGET_IS_HOST=true 시 :port/path 형식으로 변환하는 로직.
+	// HTTPS(HSTS) 환경에서 브라우저 protocol이 강제되어 http 서비스 접근 불가 문제로 비활성화.
+	// DB에 외부 접근 가능한 full URL을 그대로 저장하고 전달하는 방식으로 변경.
+	// if cfg.IframeTargetIsHost {
+	// 	re := regexp.MustCompile(`:(\d+.*)`)
+	// 	for fw, host := range apiHosts {
+	// 		if portURLStr := re.FindString(host.BaseURL); portURLStr != "" {
+	// 			host.BaseURL = portURLStr
+	// 			apiHosts[fw] = host
+	// 		}
+	// 	}
+	// 	commonResponse = model.CommonResponseStatusOK(apiHosts)
+	// }
 
 	return c.JSON(commonResponse.Status.Code, commonResponse)
 }

--- a/front/assets/js/pages/operation/plugins/costoptimizer.iframe.js
+++ b/front/assets/js/pages/operation/plugins/costoptimizer.iframe.js
@@ -46,10 +46,12 @@ async function loadCostOptimizer() {
             'Settings &gt; Environment &gt; Cloud SPs &gt; Cloud Overview 에서 mc-cost-optimizer-fe URL을 등록해 주세요.</div>';
         return;
     }
-    const domain = window.location.protocol + '//' + window.location.hostname;
-    if (host.startsWith(":")) {
-        host = `${domain}${host}`;
-    }
+    // IFRAME_TARGET_IS_HOST=true 환경에서 :port 형식으로 오던 값에 browser origin을 붙이던 로직.
+    // GetApiHosts가 DB full URL을 그대로 전달하도록 변경되어 비활성화.
+    // const domain = window.location.protocol + '//' + window.location.hostname;
+    // if (host.startsWith(":")) {
+    //     host = `${domain}${host}`;
+    // }
     const data = getCostOptimizerData();
 
     webconsolejs["common/iframe/iframe"].addIframe("costIframe", host, data);


### PR DESCRIPTION
## Summary

- `GetApiHosts`에서 `IFRAME_TARGET_IS_HOST=true`일 때 DB URL에서 `:port`만 추출 후 브라우저 origin을 붙이는 변환 로직 비활성화
- DB full URL을 그대로 전달하도록 변경
- `costoptimizer.iframe.js`의 browser origin 붙이는 로직도 함께 비활성화

## 근본 원인

HSTS가 적용된 HTTPS 환경에서 브라우저 `window.location.protocol`이 `https://`로 강제되어,
http 전용 포트(e.g. 7780)에 `https://`로 접근하게 되어 연결 실패.

```
DB: http://mc-cost-optimizer-fe:7780
→ GetApiHosts(:port 추출): :7780
→ JS(browser origin 붙이기): https://mciam.onecloudcon.com:7780  ← HTTPS 강제
```

## 해결 방법

GetApiHosts가 DB full URL을 그대로 반환. DB에 외부 접근 가능한 URL을 직접 등록.

## Test plan

- [ ] `POST /api/getapihosts` 응답에 DB full URL이 그대로 반환되는지 확인
- [ ] Cloud Overview → Add Service로 `mc-cost-optimizer-fe` 등록 후 costanalysis iframe 로드 확인