### PR TITLE
fix(WEB-BUG-014): iframe 플러그인 3종 화면 미표시 수정 및 -fe 서비스 분리

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -34,9 +34,17 @@ services:
     version: main
     baseurl: http://localhost:18084
     auth:
+  mc-application-manager-fe:
+    version: main
+    baseurl: http://application_manager_fe_url:18084
+    auth:
   mc-workflow-manager:
     version: main
     baseurl: http://workflow_url:18083
+    auth:
+  mc-workflow-manager-fe:
+    version: main
+    baseurl: http://workflow_manager_fe_url:18083
     auth:
   mc-cost-optimizer:
     version: main
@@ -49,6 +57,10 @@ services:
   mc-data-manager:
     version: main:20240923
     baseurl: http://localhost:3300
+    auth:
+  mc-data-manager-fe:
+    version: main
+    baseurl: http://data_manager_fe_url:3300
     auth:
 serviceActions:
   mc-infra-connector:

--- a/front/assets/js/pages/operation/plugins/datamanager.iframe.js
+++ b/front/assets/js/pages/operation/plugins/datamanager.iframe.js
@@ -1,38 +1,51 @@
-// const data = {
-//     projectid: 'mzctestPrj',
-//     workspaceid: 'mzctestWs',
-//     usertoken: 'mzctoken'
-// };
+function getDataManagerData() {
+    const currentWorkspace = webconsolejs["common/api/services/workspace_api"].getCurrentWorkspace();
+    const currentProject = webconsolejs["common/api/services/workspace_api"].getCurrentProject();
+    const accessToken = webconsolejs["common/storage/sessionstorage"].getSessionCurrentUserToken();
 
-// 데모환경에서 사용할 예제 데이터 입니다.
-const data = {
-    accessToken: "accesstokenExample",
-    workspaceInfo: {
-        "id": "UUID", // 이부분은 UUID로 별도 정보가 필요할시 해당 ID 를 활용해 IAM 과 연동하시면됩니다.
-        "name": "ws01", // Display 용 이름입니다. 
-        "description": "ws01 desc", // 설명입니다. 
-        "created_at": "UTC",
-        "updated_at": "UTC"
-    },
-    projectInfo: {
-        "id": "UUID",  // 이부분은 UUID로 별도 정보가 필요할시 해당 ID 를 활용해 IAM 과 연동하시면됩니다.
-        "ns_id": "ns01", // 텀블벅 연동 ID 입니다.
-        "name": "ns01", // Display 용 이름입니다. 
-        "description": "ns01 desc", // 설명입니다. 
-        "created_at": "UTC",
-        "updated_at": "UTC"
-    },
-    requestOperationId: ""
-};
+    return {
+        accessToken: accessToken,
+        workspaceInfo: {
+            "id": currentWorkspace.Id,
+            "name": currentWorkspace.Name,
+        },
+        projectInfo: {
+            "id": currentProject.Id,
+            "ns_id": currentProject.NsId,
+            "name": currentProject.Name,
+        },
+        requestOperationId: ""
+    };
+}
 
-document.addEventListener("DOMContentLoaded", async function(){
-    var host =  await webconsolejs["common/iframe/iframe"].GetApiHosts("mc-data-manager")
+async function loadDataManager() {
+    const currentWorkspace = webconsolejs["common/api/services/workspace_api"].getCurrentWorkspace();
+    const currentProject = webconsolejs["common/api/services/workspace_api"].getCurrentProject();
 
-    // 포트만 반환된 경우 현재 호스트 이름 추가
-    if (host.startsWith(":")) {
-        const currentHost = window.location.protocol + "//" + window.location.hostname;
-        host = currentHost + host;
+    if (!currentWorkspace || !currentWorkspace.Id || !currentProject || !currentProject.Id) {
+        document.getElementById("targetIframe").innerHTML =
+            '<div class="alert alert-warning m-3">Workspace와 Project를 선택해 주세요.</div>';
+        return;
     }
 
-    webconsolejs["common/iframe/iframe"].addIframe("targetIframe", host, data)
+    var host = await webconsolejs["common/iframe/iframe"].GetApiHosts("mc-data-manager-fe");
+    if (!host) {
+        document.getElementById("targetIframe").innerHTML =
+            '<div class="alert alert-warning m-3">mc-data-manager-fe 서비스 URL을 찾을 수 없습니다.<br>' +
+            'Settings &gt; Environment에서 mc-data-manager-fe URL을 등록해 주세요.</div>';
+        return;
+    }
+
+    const data = getDataManagerData();
+    webconsolejs["common/iframe/iframe"].addIframe("targetIframe", host, data);
+}
+
+$("#select-current-project").on('change', async function () {
+    let project = { "Id": this.value, "Name": this.options[this.selectedIndex].text, "NsId": this.options[this.selectedIndex].text };
+    webconsolejs["common/api/services/workspace_api"].setCurrentProject(project);
+    await loadDataManager();
+});
+
+document.addEventListener("DOMContentLoaded", async function () {
+    await loadDataManager();
 });

--- a/front/assets/js/pages/operation/plugins/softwaremanager.iframe.js
+++ b/front/assets/js/pages/operation/plugins/softwaremanager.iframe.js
@@ -1,40 +1,51 @@
-// 동적으로 workspace와 project 정보를 가져오는 함수
 function getSoftwareManagerData() {
+    const currentWorkspace = webconsolejs["common/api/services/workspace_api"].getCurrentWorkspace();
+    const currentProject = webconsolejs["common/api/services/workspace_api"].getCurrentProject();
+    const accessToken = webconsolejs["common/storage/sessionstorage"].getSessionCurrentUserToken();
 
-        const currentWorkspace = webconsolejs["common/api/services/workspace_api"].getCurrentWorkspace();
-        const currentProject = webconsolejs["common/api/services/workspace_api"].getCurrentProject();
-        console.log("Current Workspace:", currentWorkspace);
-        console.log("Current Project:", currentProject);
-        
-        const accessToken = webconsolejs["common/storage/sessionstorage"].getSessionCurrentUserToken();
-        
-        return {
-            accessToken: accessToken,
-            workspaceInfo: {
-                "id": currentWorkspace.Id,
-                "name": currentWorkspace.Name,
-            },
-            projectInfo: {
-                "id": currentProject.Id ,
-                "ns_id": currentProject.NsId,
-                "name": currentProject.Name,
-            },
-            requestOperationId: ""
-        };
+    return {
+        accessToken: accessToken,
+        workspaceInfo: {
+            "id": currentWorkspace.Id,
+            "name": currentWorkspace.Name,
+        },
+        projectInfo: {
+            "id": currentProject.Id,
+            "ns_id": currentProject.NsId,
+            "name": currentProject.Name,
+        },
+        requestOperationId: ""
+    };
 }
 
-document.addEventListener("DOMContentLoaded", async function(){
-    var host =  await webconsolejs["common/iframe/iframe"].GetApiHosts("mc-application-manager")
+async function loadSoftwareManager() {
+    const currentWorkspace = webconsolejs["common/api/services/workspace_api"].getCurrentWorkspace();
+    const currentProject = webconsolejs["common/api/services/workspace_api"].getCurrentProject();
 
-    // 포트만 반환된 경우 현재 호스트 이름 추가
-    if (host.startsWith(":")) {
-        const currentHost = window.location.protocol + "//" + window.location.hostname;
-        host = currentHost + host;
+    if (!currentWorkspace || !currentWorkspace.Id || !currentProject || !currentProject.Id) {
+        document.getElementById("targetIframe-sofrwareCatalog").innerHTML =
+            '<div class="alert alert-warning m-3">Workspace와 Project를 선택해 주세요.</div>';
+        return;
     }
 
-    // 동적으로 데이터 가져오기
-    const data = getSoftwareManagerData();
+    var host = await webconsolejs["common/iframe/iframe"].GetApiHosts("mc-application-manager-fe");
+    if (!host) {
+        document.getElementById("targetIframe-sofrwareCatalog").innerHTML =
+            '<div class="alert alert-warning m-3">mc-application-manager-fe 서비스 URL을 찾을 수 없습니다.<br>' +
+            'Settings &gt; Environment에서 mc-application-manager-fe URL을 등록해 주세요.</div>';
+        return;
+    }
 
-    // webconsolejs["common/iframe/iframe"].addIframe("targetIframe-repository", host+"/web/repository/list", data)
-    webconsolejs["common/iframe/iframe"].addIframe("targetIframe-sofrwareCatalog", host+"/web/softwareCatalog", data)
+    const data = getSoftwareManagerData();
+    webconsolejs["common/iframe/iframe"].addIframe("targetIframe-sofrwareCatalog", host + "/web/softwareCatalog", data);
+}
+
+$("#select-current-project").on('change', async function () {
+    let project = { "Id": this.value, "Name": this.options[this.selectedIndex].text, "NsId": this.options[this.selectedIndex].text };
+    webconsolejs["common/api/services/workspace_api"].setCurrentProject(project);
+    await loadSoftwareManager();
+});
+
+document.addEventListener("DOMContentLoaded", async function () {
+    await loadSoftwareManager();
 });

--- a/front/assets/js/pages/operation/plugins/workflowmanager.iframe.js
+++ b/front/assets/js/pages/operation/plugins/workflowmanager.iframe.js
@@ -1,37 +1,51 @@
-// const data = {
-//     projectid: 'mzctestPrj',
-//     workspaceid: 'mzctestWs',
-//     usertoken: 'mzctoken'
-// };
-// 데모환경에서 사용할 예제 데이터 입니다.
-const data = {
-    accessToken: "accesstokenExample",
-    workspaceInfo: {
-        "id": "UUID", // 이부분은 UUID로 별도 정보가 필요할시 해당 ID 를 활용해 IAM 과 연동하시면됩니다.
-        "name": "ws01", // Display 용 이름입니다. 
-        "description": "ws01 desc", // 설명입니다. 
-        "created_at": "UTC",
-        "updated_at": "UTC"
-    },
-    projectInfo: {
-        "id": "UUID",  // 이부분은 UUID로 별도 정보가 필요할시 해당 ID 를 활용해 IAM 과 연동하시면됩니다.
-        "ns_id": "ns01", // 텀블벅 연동 ID 입니다.
-        "name": "ns01", // Display 용 이름입니다. 
-        "description": "ns01 desc", // 설명입니다. 
-        "created_at": "UTC",
-        "updated_at": "UTC"
-    },
-    requestOperationId: ""
-};
+function getWorkflowManagerData() {
+    const currentWorkspace = webconsolejs["common/api/services/workspace_api"].getCurrentWorkspace();
+    const currentProject = webconsolejs["common/api/services/workspace_api"].getCurrentProject();
+    const accessToken = webconsolejs["common/storage/sessionstorage"].getSessionCurrentUserToken();
 
-document.addEventListener("DOMContentLoaded", async function(){
-    var host =  await webconsolejs["common/iframe/iframe"].GetApiHosts("mc-workflow-manager")
+    return {
+        accessToken: accessToken,
+        workspaceInfo: {
+            "id": currentWorkspace.Id,
+            "name": currentWorkspace.Name,
+        },
+        projectInfo: {
+            "id": currentProject.Id,
+            "ns_id": currentProject.NsId,
+            "name": currentProject.Name,
+        },
+        requestOperationId: ""
+    };
+}
 
-    // 포트만 반환된 경우 현재 호스트 이름 추가
-    if (host.startsWith(":")) {
-        const currentHost = window.location.protocol + "//" + window.location.hostname;
-        host = currentHost + host;
+async function loadWorkflowManager() {
+    const currentWorkspace = webconsolejs["common/api/services/workspace_api"].getCurrentWorkspace();
+    const currentProject = webconsolejs["common/api/services/workspace_api"].getCurrentProject();
+
+    if (!currentWorkspace || !currentWorkspace.Id || !currentProject || !currentProject.Id) {
+        document.getElementById("targetIframe").innerHTML =
+            '<div class="alert alert-warning m-3">Workspace와 Project를 선택해 주세요.</div>';
+        return;
     }
 
-    webconsolejs["common/iframe/iframe"].addIframe("targetIframe", host+"/web/workflow/list", data)
+    var host = await webconsolejs["common/iframe/iframe"].GetApiHosts("mc-workflow-manager-fe");
+    if (!host) {
+        document.getElementById("targetIframe").innerHTML =
+            '<div class="alert alert-warning m-3">mc-workflow-manager-fe 서비스 URL을 찾을 수 없습니다.<br>' +
+            'Settings &gt; Environment에서 mc-workflow-manager-fe URL을 등록해 주세요.</div>';
+        return;
+    }
+
+    const data = getWorkflowManagerData();
+    webconsolejs["common/iframe/iframe"].addIframe("targetIframe", host + "/web/workflow/list", data);
+}
+
+$("#select-current-project").on('change', async function () {
+    let project = { "Id": this.value, "Name": this.options[this.selectedIndex].text, "NsId": this.options[this.selectedIndex].text };
+    webconsolejs["common/api/services/workspace_api"].setCurrentProject(project);
+    await loadWorkflowManager();
+});
+
+document.addEventListener("DOMContentLoaded", async function () {
+    await loadWorkflowManager();
 });


### PR DESCRIPTION
## Summary

- **WEB-BUG-014** iframe 플러그인 3종(workflow / data migration / SW catalog) 화면 보완
- `api.yaml` services에 iframe용 `-fe` 서비스 4종 추가 (`mc-application-manager-fe`, `mc-workflow-manager-fe`, `mc-cost-optimizer-fe`, `mc-data-manager-fe`)
- iframe.js 4종 `GetApiHosts()` 호출을 `-fe` 서비스명으로 통일

## Changes

### `conf/api.yaml`
- `mc-application-manager-fe`, `mc-workflow-manager-fe`, `mc-cost-optimizer-fe`, `mc-data-manager-fe` 서비스 항목 추가

### iframe.js 4종
| 파일 | 수정 내용 |
|---|---|
| `costoptimizer.iframe.js` | `mc-cost-optimizer` → `mc-cost-optimizer-fe` |
| `workflowmanager.iframe.js` | `mc-workflow-manager` → `mc-workflow-manager-fe`, host null 체크, workspace/project 선택 검증, project 변경 이벤트 핸들러 |
| `datamanager.iframe.js` | `mc-data-manager` → `mc-data-manager-fe`, 동일 패턴 적용 |
| `softwaremanager.iframe.js` | `mc-application-manager` → `mc-application-manager-fe`, 동일 패턴 적용 |

## Root Cause (WEB-BUG-014)

1. `GetApiHosts()` null 반환 시 null 체크 없이 `host.startsWith(":")` 호출 → TypeError
2. `accessToken: "accesstokenExample"` 더미 값 하드코딩
3. workspace/project 미선택 상태에서 무조건 iframe 생성 시도
