### PR TITLE
refactor: standardize env var names to MC_WEB_CONSOLE_* / MC_ADMIN_CLI_* prefix

### DIFF
--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -28,15 +28,15 @@ func main() {
 	cfg.RegistryCache = service.NewRegistryCache(60 * time.Second)
 
 	// JWT 시크릿 키 설정 (환경 변수에서 로드, 없으면 기본값)
-	jwtSecret := os.Getenv("JWT_SECRET")
+	jwtSecret := os.Getenv("MC_WEB_CONSOLE_JWT_SECRET")
 	if jwtSecret == "" {
 		jwtSecret = "your-secret-key-change-in-production"
-		log.Println("⚠️  JWT_SECRET not set, using insecure default key")
+		log.Println("⚠️  MC_WEB_CONSOLE_JWT_SECRET not set, using insecure default key")
 	}
 	jwt.SetSecretKey(jwtSecret)
 
-	// 데이터베이스 초기화 (DB_HOST 환경변수가 설정된 경우에만 활성화)
-	if os.Getenv("DB_HOST") != "" {
+	// 데이터베이스 초기화 (MC_WEB_CONSOLE_POSTGRES_HOST 환경변수가 설정된 경우에만 활성화)
+	if os.Getenv("MC_WEB_CONSOLE_POSTGRES_HOST") != "" {
 		if err := repository.InitDatabase(cfg); err != nil {
 			log.Fatalf("Failed to initialize database: %v", err)
 		}
@@ -47,7 +47,7 @@ func main() {
 			log.Fatalf("Failed to migrate database: %v", err)
 		}
 	} else {
-		log.Println("⚠️  DB_HOST not configured, running without database (session management disabled)")
+		log.Println("⚠️  MC_WEB_CONSOLE_POSTGRES_HOST not configured, running without database (session management disabled)")
 	}
 
 	// Echo 인스턴스 생성

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -20,9 +20,9 @@ type Config struct {
 
 // SetupYamlConfig FR-CLOUD-ADMIN-006-08용 raw yaml 도달성 확인 설정
 type SetupYamlConfig struct {
-	// MCWEBCONSOLE_MENUYAML mc-web-console 메뉴 정의 yaml의 raw URL
+	// MC_WEB_CONSOLE_MENUYAML mc-web-console 메뉴 정의 yaml의 raw URL
 	McWebconsoleMenuYaml string
-	// MCADMINCLI_APIYAML mc-admin-cli api 카탈로그 yaml의 raw URL
+	// MC_ADMIN_CLI_APIYAML mc-admin-cli api 카탈로그 yaml의 raw URL
 	McAdmincliApiYaml string
 }
 
@@ -69,27 +69,27 @@ func Load() (*Config, error) {
 
 	cfg := &Config{
 		Server: ServerConfig{
-			Port:    getEnv("API_PORT", "3001"),
-			Address: getEnv("API_ADDR", ""),
-			Env:     getEnv("GO_ENV", "development"),
+			Port:    getEnv("MC_WEB_CONSOLE_API_PORT", "3001"),
+			Address: getEnv("MC_WEB_CONSOLE_API_ADDR", ""),
+			Env:     getEnv("MC_WEB_CONSOLE_GO_ENV", "development"),
 		},
 		Database: DatabaseConfig{
-			Host:     getEnv("DB_HOST", "localhost"),
-			Port:     getEnv("DB_PORT", "5432"),
-			User:     getEnv("DB_USER", "postgres"),
-			Password: getEnv("DB_PASSWORD", ""),
-			DBName:   getEnv("DB_NAME", "mc_web_console"),
-			SSLMode:  getEnv("DB_SSLMODE", "disable"),
+			Host:     getEnv("MC_WEB_CONSOLE_POSTGRES_HOST", "localhost"),
+			Port:     getEnv("MC_WEB_CONSOLE_POSTGRES_PORT", "5432"),
+			User:     getEnv("MC_WEB_CONSOLE_POSTGRES_USER", "postgres"),
+			Password: getEnv("MC_WEB_CONSOLE_POSTGRES_PASSWORD", ""),
+			DBName:   getEnv("MC_WEB_CONSOLE_POSTGRES_DB", "mc_web_console"),
+			SSLMode:  getEnv("MC_WEB_CONSOLE_POSTGRES_SSLMODE", "disable"),
 		},
 		MCIAM: MCIAMConfig{
-			Use:       getEnv("MCIAM_USE", "false") == "true",
-			TicketUse: getEnv("MCIAM_TICKET_USE", "false") == "true",
+			Use:       getEnv("MC_WEB_CONSOLE_USE_IAM", "false") == "true",
+			TicketUse: getEnv("MC_WEB_CONSOLE_USE_TICKET_VALID", "false") == "true",
 		},
 		SetupYaml: SetupYamlConfig{
-			McWebconsoleMenuYaml: getEnv("MCWEBCONSOLE_MENUYAML", ""),
-			McAdmincliApiYaml:    getEnv("MCADMINCLI_APIYAML", ""),
+			McWebconsoleMenuYaml: getEnv("MC_WEB_CONSOLE_MENUYAML", ""),
+			McAdmincliApiYaml:    getEnv("MC_ADMIN_CLI_APIYAML", ""),
 		},
-		IframeTargetIsHost: getEnv("IFRAME_TARGET_IS_HOST", "false") == "true",
+		IframeTargetIsHost: getEnv("MC_WEB_CONSOLE_IFRAME_TARGET_IS_HOST", "false") == "true",
 	}
 
 	// API 스펙 로드

--- a/conf/.env.sample
+++ b/conf/.env.sample
@@ -1,19 +1,32 @@
-export API_ADDR=0.0.0.0
-export API_PORT=3000
+export MC_WEB_CONSOLE_API_ADDR=0.0.0.0
+export MC_WEB_CONSOLE_API_PORT=3000
 
-export FRONT_ADDR=0.0.0.0
-export FRONT_PORT=3001
+export MC_WEB_CONSOLE_FRONT_ADDR=0.0.0.0
+export MC_WEB_CONSOLE_FRONT_PORT=3001
 
-export DATABASE_USER=DATABASE_USER  # Please CHANGE ME (REQUIRE)
-export DATABASE_PASS=DATABASE_PASS  # Please CHANGE ME (REQUIRE)
-export DATABASE_HOST=DATABASE_HOST  # Please CHANGE ME (REQUIRE)
-export DATABASE=DATABASE  # Please CHANGE ME (REQUIRE)
-export DATABASE_URL=postgres://${DATABASE_USER}:${DATABASE_PASS}@${DATABASE_HOST}:5432/${DATABASE}
+export MC_WEB_CONSOLE_POSTGRES_USER=MC_WEB_CONSOLE_POSTGRES_USER  # Please CHANGE ME (REQUIRE)
+export MC_WEB_CONSOLE_POSTGRES_PASSWORD=MC_WEB_CONSOLE_POSTGRES_PASSWORD  # Please CHANGE ME (REQUIRE)
+export MC_WEB_CONSOLE_POSTGRES_HOST=MC_WEB_CONSOLE_POSTGRES_HOST  # Please CHANGE ME (REQUIRE)
+export MC_WEB_CONSOLE_POSTGRES_DB=MC_WEB_CONSOLE_POSTGRES_DB  # Please CHANGE ME (REQUIRE)
+export MC_WEB_CONSOLE_POSTGRES_PORT=5432
+export MC_WEB_CONSOLE_POSTGRES_SSLMODE=disable
 
-# IFRAME_TARGET_IS_HOST [ true || false ] 
-export IFRAME_TARGET_IS_HOST=false 
-# if IFRAME_TARGET_IS_HOST is false, iframe will see the other server
+# MC_WEB_CONSOLE_IFRAME_TARGET_IS_HOST [ true || false ]
+export MC_WEB_CONSOLE_IFRAME_TARGET_IS_HOST=false
+# if MC_WEB_CONSOLE_IFRAME_TARGET_IS_HOST is false, iframe will see the other server
 # if true, iframe will see the host
 
-export MCIAM_USE=true
-export MCIAM_TICKET_USE=false
+export MC_WEB_CONSOLE_USE_IAM=true
+export MC_WEB_CONSOLE_USE_TICKET_VALID=false
+
+export MC_WEB_CONSOLE_GO_ENV=development
+
+export MC_WEB_CONSOLE_JWT_SECRET=your-secret-key-change-in-production  # Please CHANGE ME (REQUIRE)
+export MC_WEB_CONSOLE_SESSION_SECRET=mc-web-console-secret-key  # Please CHANGE ME (REQUIRE)
+
+# Yaml 도달성 점검 (FR-CLOUD-ADMIN-006-08)
+export MC_WEB_CONSOLE_MENUYAML=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_resources.yaml
+export MC_ADMIN_CLI_APIYAML=https://raw.githubusercontent.com/m-cmp/mc-admin-cli/refs/heads/main/conf/api.yaml
+
+# 개발 모드: MC_WEB_CONSOLE_FRONT_DEV=true 로 설정 시 템플릿 디스크 직접 로딩 (재시작 불필요)
+# export MC_WEB_CONSOLE_FRONT_DEV=false

--- a/front/actions/env.go
+++ b/front/actions/env.go
@@ -13,11 +13,11 @@ var SESSION_SECRET string
 
 func init() {
 	// Get environment variables with defaults
-	FRONT_ADDR = getEnvOrDefault("FRONT_ADDR", "0.0.0.0")
-	FRONT_PORT = getEnvOrDefault("FRONT_PORT", "3001")
-	API_ADDR = getEnvOrDefault("API_ADDR", "localhost")
-	API_PORT = getEnvOrDefault("API_PORT", "3000")
-	SESSION_SECRET = getEnvOrDefault("SESSION_SECRET", "mc-web-console-secret-key")
+	FRONT_ADDR = getEnvOrDefault("MC_WEB_CONSOLE_FRONT_ADDR", "0.0.0.0")
+	FRONT_PORT = getEnvOrDefault("MC_WEB_CONSOLE_FRONT_PORT", "3001")
+	API_ADDR = getEnvOrDefault("MC_WEB_CONSOLE_API_ADDR", "localhost")
+	API_PORT = getEnvOrDefault("MC_WEB_CONSOLE_API_PORT", "3000")
+	SESSION_SECRET = getEnvOrDefault("MC_WEB_CONSOLE_SESSION_SECRET", "mc-web-console-secret-key")
 }
 
 func getEnvOrDefault(key, defaultValue string) string {

--- a/front/actions/render.go
+++ b/front/actions/render.go
@@ -29,12 +29,12 @@ var (
 )
 
 func init() {
-	// FRONT_DEV=true 이면 디스크에서 직접 로딩 (템플릿 수정 시 Go 재시작 불필요)
+	// MC_WEB_CONSOLE_FRONT_DEV=true 이면 디스크에서 직접 로딩 (템플릿 수정 시 Go 재시작 불필요)
 	// 프로덕션에서는 embed.FS 사용 (단일 바이너리 배포)
 	var loader jet.Loader
-	if os.Getenv("FRONT_DEV") == "true" {
+	if os.Getenv("MC_WEB_CONSOLE_FRONT_DEV") == "true" {
 		loader = jet.NewOSFileSystemLoader("./templates")
-		log.Printf("Template loader: disk (FRONT_DEV=true) — template changes take effect on browser refresh")
+		log.Printf("Template loader: disk (MC_WEB_CONSOLE_FRONT_DEV=true) — template changes take effect on browser refresh")
 	} else {
 		var err error
 		loader, err = httpfs.NewLoader(http.FS(templates.FS()))


### PR DESCRIPTION
## Summary

- `api/internal/config/config.go`: 14개 `os.Getenv` 인자 rename (`DB_*`, `API_*`, `GO_ENV`, `MCIAM_*`, `MCWEBCONSOLE_MENUYAML`, `MCADMINCLI_APIYAML`, `IFRAME_TARGET_IS_HOST` → `MC_WEB_CONSOLE_*` / `MC_ADMIN_CLI_*`)
- `api/cmd/main.go`: `JWT_SECRET` → `MC_WEB_CONSOLE_JWT_SECRET`, `DB_HOST` check → `MC_WEB_CONSOLE_POSTGRES_HOST`
- `front/actions/env.go`: `FRONT_*`, `API_*`, `SESSION_SECRET` → `MC_WEB_CONSOLE_*`
- `front/actions/render.go`: `FRONT_DEV` → `MC_WEB_CONSOLE_FRONT_DEV`
- `conf/.env.sample`: 새 변수명으로 전면 갱신

## 배경 (WEB-TECH-001)

mc-admin-cli PR #30 이후 docker-compose 측은 `MC_<FRAMEWORK>_*` prefix 체계로 정렬됐으나, mc-web-console Go 코드는 구 이름(`MCIAM_USE`, `DB_HOST`, `API_PORT` 등)을 그대로 읽고 있었다.

특히 `MCWEBCONSOLE_MENUYAML` / `MCADMINCLI_APIYAML` 두 변수는 compose에서 아예 주입되지 않아 FR-CLOUD-ADMIN-006-08 yaml 도달성 점검이 항상 빈 값으로 동작하는 버그가 있었다 — 이번 변경으로 해소된다.
