### PR TITLE
fix(WEB-BUG-014): iframe 플러그인 URL 정규화 (resolveIframeUrl)

### DIFF
--- a/front/assets/js/common/iframe/iframe.js
+++ b/front/assets/js/common/iframe/iframe.js
@@ -10,6 +10,41 @@ export function addIframe(targetDiv, srchost, data){
     div.appendChild(iframe);
 }
 
+// Docker 내부 hostname(점 없음)을 브라우저 hostname으로 대체하고,
+// HTTPS 페이지에서 HTTP URL은 프로토콜을 업그레이드한다.
+// localhost 접근 시 http://localhost:PORT 로 변환 (로컬 Docker 개발 환경).
+// mc-admin-cli 배포 환경에서 레지스트리에 컨테이너명이 등록되는 문제를 보정.
+function resolveIframeUrl(baseURL) {
+    try {
+        const urlObj = new URL(baseURL);
+        const port = urlObj.port ? ':' + urlObj.port : '';
+        const rawPath = urlObj.pathname + urlObj.search;
+        const path = rawPath === '/' ? '' : rawPath;
+        const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+
+        // Docker 내부 hostname (점 없음): 브라우저 hostname + protocol로 대체
+        if (!urlObj.hostname.includes('.')) {
+            if (isLocalhost) {
+                return 'http://' + window.location.hostname + port + path;
+            }
+            return window.location.protocol + '//' + window.location.hostname + port + path;
+        }
+
+        // 브라우저가 localhost인 경우: http://localhost:PORT 로 변환
+        if (isLocalhost) {
+            return 'http://' + window.location.hostname + port + path;
+        }
+
+        // HTTPS 페이지에서 HTTP URL → protocol 업그레이드
+        if (window.location.protocol === 'https:' && urlObj.protocol === 'http:') {
+            return 'https://' + urlObj.hostname + port + path;
+        }
+    } catch (e) {
+        // URL 파싱 실패 시 원본 반환
+    }
+    return baseURL;
+}
+
 export async function GetApiHosts(frameworkName){
     var controller = "/api/" + "getapihosts";
     const getapihostsresponse = await webconsolejs["common/api/http"].commonAPIPost(
@@ -18,7 +53,7 @@ export async function GetApiHosts(frameworkName){
 	);
     const framework = getapihostsresponse.data.responseData[frameworkName];
     if (framework && framework.BaseURL) {
-        return framework.BaseURL;
+        return resolveIframeUrl(framework.BaseURL);
     }
     return null;
 }


### PR DESCRIPTION
## Summary

- `resolveIframeUrl()` 함수 추가: `GetApiHosts` 반환값을 브라우저 접근 가능한 URL로 자동 변환
- Docker 내부 hostname(점 없음, e.g. `mc-cost-optimizer-fe`) → 브라우저 hostname + protocol로 대체
- `localhost` 접근 시 → `http://localhost:PORT` 로 강제 변환 (로컬 Docker 개발 환경 지원)
- HTTPS 페이지에서 HTTP URL → HTTPS로 protocol 업그레이드
- trailing slash 제거로 `//web/path` 이중슬래시 방지 (swcatalogs 화면)

## 수정된 화면
- `webconsole/operations/analytics/costanalysis` — cost optimizer iframe
- `webconsole/operations/manage/datamigrations` — data manager iframe
- `webconsole/operations/manage/swcatalogs` — application manager iframe (이중슬래시 수정)
- `webconsole/operations/manage/workflows` — workflow manager iframe
