### PR TITLE
fix(costanalysis): clear #costIframe before loading iframe

### DIFF
--- a/front/assets/js/pages/operation/plugins/costoptimizer.iframe.js
+++ b/front/assets/js/pages/operation/plugins/costoptimizer.iframe.js
@@ -54,6 +54,7 @@ async function loadCostOptimizer() {
     // }
     const data = getCostOptimizerData();
 
+    document.getElementById("costIframe").innerHTML = '';
     webconsolejs["common/iframe/iframe"].addIframe("costIframe", host, data);
 }
 


### PR DESCRIPTION
## Summary

- `addIframe()`이 기존 innerHTML을 교체하지 않고 append하여, DOMContentLoaded 시 삽입된 경고 div(`Workspace와 Project를 선택해 주세요`)가 workspace/project 선택 후에도 잔류하는 버그 수정
- `loadCostOptimizer()` 내 `addIframe()` 호출 전 `#costIframe` innerHTML을 비워 클린 상태로 iframe 삽입

## Root Cause

```javascript
// Before: addIframe appends to existing content
webconsolejs["common/iframe/iframe"].addIframe("costIframe", host, data);

// After: clear container first
document.getElementById("costIframe").innerHTML = '';
webconsolejs["common/iframe/iframe"].addIframe("costIframe", host, data);
```
