### PR TITLE
[Fix] WEB-BUG-016: 역할 메뉴 저장 후 사이드바 즉시 갱신

### DIFF
--- a/front/assets/js/common/api/services/menus_api.js
+++ b/front/assets/js/common/api/services/menus_api.js
@@ -61,7 +61,12 @@ export async function refreshAvailableMenus() {
             rootMenus.push(node);
         } else {
             const parent = menuMap.get(menu.parentId);
-            if (parent) parent.menus.push(node);
+            if (parent) {
+                parent.menus.push(node);
+            } else {
+                // 부모가 응답에 없는 orphaned 노드 → 루트로 처리
+                rootMenus.push(node);
+            }
         }
     });
     const sortMenus = (menus) => {
@@ -71,6 +76,9 @@ export async function refreshAvailableMenus() {
         menus.forEach(m => { if (m.menus?.length > 0) sortMenus(m.menus); });
     };
     sortMenus(rootMenus);
+
+    // 응답 자체가 빈 배열이면 기존 사이드바 유지 (실수로 localStorage 소거 방지)
+    if (menuList.length === 0) return;
 
     webconsolejs["common/storage/localstorage"].setMenuLocalStorage(rootMenus);
     document.dispatchEvent(new CustomEvent('refresh-sidebar'));

--- a/front/assets/js/common/api/services/menus_api.js
+++ b/front/assets/js/common/api/services/menus_api.js
@@ -41,3 +41,37 @@ export async function listRoles() {
     const response = await webconsolejs["common/api/http"].commonAPIPost(controller, {});
     return response.data.responseData;
 }
+
+// 역할 메뉴 권한 변경 후 사이드바를 즉시 갱신하기 위해 호출.
+// GetAllAvailableMenus를 재조회하여 localStorage를 갱신하고
+// refresh-sidebar 이벤트를 dispatch하면 sidebar.js가 updatemenu()를 재호출한다.
+export async function refreshAvailableMenus() {
+    const response = await webconsolejs["common/api/http"].commonAPIPost(
+        "/api/mc-iam-manager/GetAllAvailableMenus"
+    );
+    const menuList = response?.data?.responseData;
+    if (!menuList) return;
+
+    const menuMap = new Map();
+    menuList.forEach(menu => menuMap.set(menu.id, { ...menu, menus: [] }));
+    const rootMenus = [];
+    menuList.forEach(menu => {
+        const node = menuMap.get(menu.id);
+        if (menu.parentId === 'home' || !menu.parentId) {
+            rootMenus.push(node);
+        } else {
+            const parent = menuMap.get(menu.parentId);
+            if (parent) parent.menus.push(node);
+        }
+    });
+    const sortMenus = (menus) => {
+        menus.sort((a, b) =>
+            a.priority !== b.priority ? a.priority - b.priority : a.menuNumber - b.menuNumber
+        );
+        menus.forEach(m => { if (m.menus?.length > 0) sortMenus(m.menus); });
+    };
+    sortMenus(rootMenus);
+
+    webconsolejs["common/storage/localstorage"].setMenuLocalStorage(rootMenus);
+    document.dispatchEvent(new CustomEvent('refresh-sidebar'));
+}

--- a/front/assets/js/pages/auth/login.js
+++ b/front/assets/js/pages/auth/login.js
@@ -76,15 +76,17 @@ function convertToMenuTree(menuList) {
     const rootMenus = [];
     menuList.forEach(menu => {
         const menuNode = menuMap.get(menu.id);
-        
+
         if (menu.parentId === 'home' || !menu.parentId) {
             // 최상위 메뉴
             rootMenus.push(menuNode);
         } else {
-            // 하위 메뉴
+            // 하위 메뉴 — 부모가 응답에 없으면(orphaned) 루트로 처리
             const parentMenu = menuMap.get(menu.parentId);
             if (parentMenu) {
                 parentMenu.menus.push(menuNode);
+            } else {
+                rootMenus.push(menuNode);
             }
         }
     });

--- a/front/assets/js/pages/operation/workspace/roles.js
+++ b/front/assets/js/pages/operation/workspace/roles.js
@@ -2819,6 +2819,9 @@ async function saveRole() {
       // 헤더 클릭 이벤트 리스너 재설정 (DOM 재생성 후 이벤트 연결)
       setupHeaderClickEvents();
 
+      // 사이드바 메뉴 즉시 갱신 (역할 메뉴 권한 변경 반영)
+      await webconsolejs["common/api/services/menus_api"].refreshAvailableMenus();
+
       // 페이지를 맨 위로 스크롤
       window.scrollTo({ top: 0, behavior: 'smooth' });
     }
@@ -3220,6 +3223,9 @@ async function updateRole() {
 
       // 헤더 클릭 이벤트 리스너 재설정 (DOM 재생성 후 이벤트 연결)
       setupHeaderClickEvents();
+
+      // 사이드바 메뉴 즉시 갱신 (역할 메뉴 권한 변경 반영)
+      await webconsolejs["common/api/services/menus_api"].refreshAvailableMenus();
 
       // 페이지를 맨 위로 스크롤
       window.scrollTo({ top: 0, behavior: 'smooth' });

--- a/front/assets/js/pages/settings/accountnaccess/organizations/menus.js
+++ b/front/assets/js/pages/settings/accountnaccess/organizations/menus.js
@@ -71,6 +71,7 @@ const MenuManager = {
             AppState.menus.selectedMenu = null;
             UIManager.hideDetailPanel();
             await this.loadTree();
+            await webconsolejs["common/api/services/menus_api"].refreshAvailableMenus();
         } catch (error) {
             console.error("Error creating menu:", error);
             alert("Failed to create menu: " + (error.message || error));
@@ -86,6 +87,7 @@ const MenuManager = {
                 AppState.menus.selectedMenu = updated;
                 UIManager.showDetailPanel(updated);
             }
+            await webconsolejs["common/api/services/menus_api"].refreshAvailableMenus();
         } catch (error) {
             console.error("Error updating menu:", error);
             alert("Failed to update menu: " + (error.message || error));
@@ -98,6 +100,7 @@ const MenuManager = {
             AppState.menus.selectedMenu = null;
             UIManager.hideDetailPanel();
             await this.loadTree();
+            await webconsolejs["common/api/services/menus_api"].refreshAvailableMenus();
         } catch (error) {
             console.error("Error deleting menu:", error);
             alert("Failed to delete menu: " + (error.message || error));

--- a/front/assets/js/partials/layout/sidebar.js
+++ b/front/assets/js/partials/layout/sidebar.js
@@ -22,6 +22,10 @@ document.addEventListener("DOMContentLoaded", function () {
     });
     setActiveMenu();
 
+    document.addEventListener("refresh-sidebar", function () {
+        updatemenu();
+    });
+
 });
 
 function updatemenu(){

--- a/front/templates/pages/operations/manage/workspaces/roles.html
+++ b/front/templates/pages/operations/manage/workspaces/roles.html
@@ -725,6 +725,6 @@
 {{ partial("partials/layout/pageloader.html") | raw }}
 
 <!-- javascript -->
-{{ javascriptTag("common/api/services/roles_api.js") | raw }} {{ javascriptTag("pages/operation/workspace/roles.js") | raw }}
+{{ javascriptTag("common/api/services/roles_api.js") | raw }} {{ javascriptTag("common/api/services/menus_api.js") | raw }} {{ javascriptTag("pages/operation/workspace/roles.js") | raw }}
 {{ javascriptTag("common/api/services/users_api.js") | raw }}
 {{ javascriptTag("common/api/services/csproles_api.js") | raw }}


### PR DESCRIPTION
## Summary

`roles` 페이지에서 역할 메뉴 권한 저장 후 사이드바가 즉시 갱신되지 않는 버그 수정.

- **근본 원인**: `roles.html` 템플릿에 `menus_api.js` 번들이 로드되지 않아 `webconsolejs["common/api/services/menus_api"]`가 `undefined`였음
- 역할 저장 후 `refreshAvailableMenus()` 호출 시 TypeError 발생 → outer `catch`에서 무시 → `GetAllAvailableMenus` 미호출 → 사이드바 미갱신

## Changes

- `roles.html`: `menus_api.js` script tag 추가 (`roles_api.js` 뒤)
- `menus_api.js`: orphaned 노드 루트 처리 추가, 빈 배열 방어 로직 (`menuList.length === 0`) 추가
- `login.js`: orphaned 메뉴 노드 루트 처리 (`refreshAvailableMenus`와 동일 패턴 일치)

## Test Plan

- [x] E2E (Playwright): `bug016-role-sidebar-sync.spec.ts` — TC-01/TC-02 PASS
  - TC-01: Workspaces Settings 3개 메뉴 활성화 → Save → `GetAllAvailableMenus` 호출 + localStorage 갱신 확인
  - TC-02: 동일 3개 메뉴 비활성화 → Save → `GetAllAvailableMenus` 호출 + localStorage 갱신 확인
- [x] 브라우저 네트워크 탭: `Updaterole → GetRoleList → GetAllAvailableMenus` 순서 확인