### PR TITLE
fix: MCI 동적 생성 시 subGroups → nodeGroups 필드명 수정

### DIFF
--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -253,7 +253,7 @@ export async function mciDynamicReview(mciName, mciDesc, Express_Server_Config_A
         "command": command,
         "userName": "cb-user"
       },
-      "subGroups": subGroups,
+      "nodeGroups": subGroups,
       "systemLabel": ""
     }
   }
@@ -293,7 +293,7 @@ export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, ns
     Request: {
       "name": mciName,
       "description": mciDesc,
-      "subGroups": subGroups,
+      "nodeGroups": subGroups,
       "policyOnPartialFailure": policyOnPartialFailure,
       "postCommand": {
         "command": command,


### PR DESCRIPTION
## Summary

- `mciDynamic`, `mciDynamicReview` 함수에서 tumblebug `/infraDynamic` API 요청 본문의 필드명을 `subGroups` → `nodeGroups` 로 수정

## 원인

tumblebug `InfraReq` 구조체는 `nodeGroups` 필드를 `required` 태그로 선언한다. 기존 코드가 `subGroups` 로 전송하면 tumblebug가 `nodeGroups: null` 로 인식해 VM 프로비저닝이 수행되지 않고 MCI가 `Prepared` 상태에 머물렀다.

```
ERR failed to create Infra dynamically
error="Key: 'InfraReq.nodeGroups' Error:Field validation for 'nodeGroups' failed on the 'required' tag"
```

## 변경 내용

```diff
// mciDynamicReview
-      "subGroups": subGroups,
+      "nodeGroups": subGroups,

// mciDynamic
-      "subGroups": subGroups,
+      "nodeGroups": subGroups,
```

## 검증

E2E 테스트(`C4-S2 UI: MCI 생성 마법사`)에서 수정 후 VM 정상 프로비저닝 확인:
```
id=e2e-mci-c4  status=Running:1 (R:1/1)
  node id=e2e-mci-c4-vm-0-1  status=Running
```