### PR TITLE
fix(mci): update vm→node field names for tumblebug API change

### DIFF
--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -75,7 +75,7 @@ export async function getMci(nsId, mciId) {
   const data = {
     pathParams: {
       nsId: nsId,
-      mciId: mciId
+      infraId: mciId
     }
   }
 
@@ -112,7 +112,7 @@ export async function getMciVm(nsId, mciId, vmId) {
   const data = {
     pathParams: {
       nsId: nsId,
-      mciId: mciId,
+      infraId: mciId,
       vmId: vmId
     }
   }
@@ -145,7 +145,7 @@ export function mciLifeCycle(type, currentMciId, nsId) {
   let data = {
     pathParams: {
       nsId: nsId,
-      mciId: currentMciId,
+      infraId: currentMciId,
     },
     queryParams: {
       "action": type,
@@ -164,7 +164,7 @@ export function mciDelete(currentMciId, nsId) {
   let data = {
     pathParams: {
       nsId: nsId,
-      mciId: currentMciId,
+      infraId: currentMciId,
     },
     queryParams: {
       option: "force"
@@ -182,7 +182,7 @@ export function vmDelete(mciId, nsId, vmId) {
   let data = {
     pathParams: {
       nsId: nsId,
-      mciId: mciId,
+      infraId: mciId,
       vmId: vmId
     },
     queryParams: {
@@ -203,7 +203,7 @@ export function vmLifeCycle(type, mciId, nsId, vmid) {
   let data = {
     pathParams: {
       nsId: nsId,
-      mciId: mciId,
+      infraId: mciId,
       vmId: vmid
     },
     queryParams: {
@@ -323,7 +323,7 @@ export async function vmDynamic(mciId, nsId, Express_Server_Config_Arr) {
   const data = {
     pathParams: {
       nsId: nsId,
-      mciId: mciId,
+      infraId: mciId,
     },
     request: {
       "imageId": obj.commonImage,
@@ -724,7 +724,7 @@ export async function postScaleOutSubGroup(nsId, mciId, subgroupId, numVMsToAdd)
   var data = {
     pathParams: {
       nsId: nsId,
-      mciId: mciId,
+      infraId: mciId,
       subgroupId: subgroupId
     },
     Request: {
@@ -789,7 +789,7 @@ export async function deletePolicy(nsId, mciId) {
   let data = {
     pathParams: {
       nsId: nsId,
-      mciId: mciId,
+      infraId: mciId,
     },
     queryParams: {
       option: "force"
@@ -810,7 +810,7 @@ export async function createPolicy(nsId, mciId, policy) {
   let data = {
     pathParams: {
       nsId: nsId,
-      mciId: mciId,
+      infraId: mciId,
     },
     Request: {
       policy: policy

--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -253,7 +253,7 @@ export async function mciDynamicReview(mciName, mciDesc, Express_Server_Config_A
         "command": command,
         "userName": "cb-user"
       },
-      "subGroups": subGroups,
+      "nodeGroups": subGroups,
       "systemLabel": ""
     }
   }
@@ -293,7 +293,7 @@ export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, ns
     Request: {
       "name": mciName,
       "description": mciDesc,
-      "subGroups": subGroups,
+      "nodeGroups": subGroups,
       "policyOnPartialFailure": policyOnPartialFailure,
       "postCommand": {
         "command": command,
@@ -520,7 +520,7 @@ export function getMciStatusIconFormatter(mciDispStatus) {
 // Mci에 구성된 vm들의 provider들 imgTag로ㅋ
 export function getMciInfoProviderNames(mciData) {
   var mciProviderNames = "";
-  var vmCloudConnectionMap = calculateConnectionCount(mciData.vm);
+  var vmCloudConnectionMap = calculateConnectionCount(mciData.node);
 
   if (vmCloudConnectionMap) {
     vmCloudConnectionMap.forEach((value, key) => {

--- a/front/assets/js/pages/operation/manage/mci.js
+++ b/front/assets/js/pages/operation/manage/mci.js
@@ -160,7 +160,7 @@ function refreshDisplay() {
       var aMci = window.totalMciListObj[mciIndex];
 
       if (window.currentMciId == aMci.id) {
-        displayServerStatusList(window.currentMciId, aMci.vm)
+        displayServerStatusList(window.currentMciId, aMci.node)
         break;
       }
     }
@@ -181,8 +181,8 @@ function refreshRowData(rowId, newData) {
     });
 
 
-  displayServerStatusList(rowId, newData.vm)
-  displayServerGroupStatusList(rowId, newData.vm)
+  displayServerStatusList(rowId, newData.node)
+  displayServerGroupStatusList(rowId, newData.node)
 }
 
 // Policy Info 상태 초기화 함수
@@ -506,7 +506,7 @@ function setMciInfoData(mciData) {
     // var mciDispStatus = webconsolejs["common/api/services/mci_api"].getMciStatusFormatter(mciStatus);
     // var mciStatusIcon = webconsolejs["common/api/services/mci_api"].getMciStatusIconFormatter(mciDispStatus);
     var mciProviderNames = webconsolejs["common/api/services/mci_api"].getMciInfoProviderNames(mciData); //MCI에 사용 된 provider
-    var totalvmCount = mciData.vm.length; //mci의 vm개수
+    var totalvmCount = (mciData.node || []).length; //mci의 node개수
 
     var mciStatusCell = "";
 
@@ -708,6 +708,10 @@ document.addEventListener('DOMContentLoaded', () => {
 function displayServerStatusList(mciID, vmList) {
   var mciName = mciID;
   var vmLi = "";
+  if (!vmList || vmList.length === 0) {
+    $("#mci_server_info_box").empty();
+    return;
+  }
   vmList.sort();
 
   vmList.forEach((aVm) => {
@@ -1039,10 +1043,10 @@ export async function vmDetailInfo(vmId) {
       aMci = totalMciListObj[mciIndex];
 
       if (aMci.id == currentMciId) {
-        for (var vmIndex in aMci.vm) {
-          var tempVms = aMci.vm
+        for (var vmIndex in aMci.node) {
+          var tempVms = aMci.node
           if (currentVmId == tempVms.id) {
-            aMci.vm[vmIndex] = aVm;
+            aMci.node[vmIndex] = aVm;
             break;
           }
         }
@@ -1055,12 +1059,12 @@ export async function vmDetailInfo(vmId) {
     clearServerInfo();
 
 
-    if (!aMci || !aMci.vm) {
+    if (!aMci || !aMci.node) {
       return;
     }
 
     var mciName = aMci.name;
-    var vmList = aMci.vm;
+    var vmList = aMci.node;
 
     var vmExist = false;
     var data = new Object();
@@ -1265,10 +1269,10 @@ export async function subGroup_vmDetailInfo(vmId) {
       aMci = totalMciListObj[mciIndex];
 
       if (aMci.id == currentMciId) {
-        for (var vmIndex in aMci.vm) {
-          var tempVms = aMci.vm
+        for (var vmIndex in aMci.node) {
+          var tempVms = aMci.node
           if (currentVmId == tempVms.id) {
-            aMci.vm[vmIndex] = aVm;
+            aMci.node[vmIndex] = aVm;
             break;
           }
         }
@@ -1281,13 +1285,13 @@ export async function subGroup_vmDetailInfo(vmId) {
     clearServerInfo();
 
 
-    if (!aMci || !aMci.vm) {
-      console.error("aMci or vmList is not defined");
+    if (!aMci || !aMci.node) {
+      console.error("aMci or nodeList is not defined");
       return;
     }
 
     var mciName = aMci.name;
-    var vmList = aMci.vm;
+    var vmList = aMci.node;
 
     var vmExist = false;
     var data = new Object();
@@ -2036,7 +2040,7 @@ function statusFormatter(cell) {
 // provider를 table에서 표시하기 위해 감싸기
 function providerFormatter(data) {
   var vmCloudConnectionMap = webconsolejs["common/api/services/mci_api"].calculateConnectionCount(
-    data.getData().vm
+    data.getData().node
   );
   var mciProviderCell = "";
   vmCloudConnectionMap.forEach((value, key) => {
@@ -2056,7 +2060,7 @@ function providerFormatter(data) {
 function providerFormatterString(data) {
 
   var vmCloudConnectionMap = webconsolejs["common/api/services/mci_api"].calculateConnectionCount(
-    data.getData().vm
+    data.getData().node
   );
 
   var mciProviderCell = "";
@@ -2338,7 +2342,7 @@ function providerFilter(data) {
   // equal only
   if (typeEl.value == "=") {
     var vmCloudConnectionMap = webconsolejs["common/api/services/mci_api"].calculateConnectionCount(
-      data.vm
+      data.node
     );
     var valueElValue = valueEl.value;
     if (valueElValue != "") {


### PR DESCRIPTION
## Summary

- Replace all mci.vm references with mci.node in mci.js (tumblebug API change)
- Fix mciDynamic/mciDynamicReview requests: subGroups → nodeGroups
- Add null guard in displayServerStatusList to prevent crash on empty node list
- Fix provider formatters: data.getData().vm → data.getData().node

## Root Cause

tumblebug API renamed MCI response field vm → node and creation request field subGroups → nodeGroups. Frontend still used old names causing VM list panel to always show empty.

## Test plan
- [x] E2E C4-S2 UI test passes — VM detail shows node with non-Failed status
- [x] MCI created with correct node count (1 VM provisioned)