### PR TITLE
feat: add user approval screen for platform admin (FR-PLATFORM-ADMIN-001)

### DIFF
--- a/conf/webconsole_menu_resources.yaml
+++ b/conf/webconsole_menu_resources.yaml
@@ -52,7 +52,7 @@ menus:
     parentid: organizations
     displayname: Approvals
     restype: menu
-    isaction: false
+    isaction: true
     priority: 2
     menunumber: 1230
 

--- a/front/assets/js/pages/settings/accountnaccess/organizations/approvals.js
+++ b/front/assets/js/pages/settings/accountnaccess/organizations/approvals.js
@@ -1,0 +1,338 @@
+import { TabulatorFull as Tabulator } from "tabulator-tables";
+
+const DOM = {
+  approvalsTable: document.getElementById('approvals-table'),
+  viewModeCards: document.getElementById('view-mode-cards'),
+  approvalInfoUsername: document.getElementById('approval-info-username'),
+  approvalInfoUsernameText: document.getElementById('approval-info-username-text'),
+  approvalInfoFirstname: document.getElementById('approval-info-firstname'),
+  approvalInfoLastname: document.getElementById('approval-info-lastname'),
+  approvalInfoEmail: document.getElementById('approval-info-email'),
+  approvalInfoUserid: document.getElementById('approval-info-userid'),
+  approvalInfoCreatedAt: document.getElementById('approval-info-created-at'),
+};
+
+const AppState = {
+  users: {
+    list: [],
+    pendingList: [],
+    selectedUser: null,
+  },
+  tables: {
+    approvalsTable: null,
+  },
+};
+
+var checked_array = [];
+var _rejectTargetUserId = null;
+
+function filterPendingUsers(list) {
+  return list.filter(function(user) {
+    const enabled = user.enabled !== undefined ? user.enabled :
+                    user.Enabled !== undefined ? user.Enabled :
+                    user.status === 'active' || user.Status === 'active';
+    return enabled === false;
+  });
+}
+
+function formatDate(dateStr) {
+  if (!dateStr) return '-';
+  return new Date(dateStr).toLocaleString();
+}
+
+const UIManager = {
+  showViewMode() {
+    if (DOM.viewModeCards) DOM.viewModeCards.classList.add('show');
+  },
+
+  hideViewMode() {
+    if (DOM.viewModeCards) DOM.viewModeCards.classList.remove('show');
+  },
+
+  updateDetail(user) {
+    if (!user) { this.clearDetail(); return; }
+
+    const firstName  = user.firstName  || user.first_name  || user.FirstName  || '';
+    const lastName   = user.lastName   || user.last_name   || user.LastName   || '';
+    const email      = user.email      || user.Email       || '';
+    const username   = user.username   || user.userName    || user.UserName   || user.id || '';
+    const createdAt  = user.createdAt  || user.created_at  || user.CreatedAt
+                    || user.createdTimestamp || '';
+
+    if (DOM.approvalInfoFirstname)  DOM.approvalInfoFirstname.textContent  = firstName;
+    if (DOM.approvalInfoLastname)   DOM.approvalInfoLastname.textContent   = lastName;
+    if (DOM.approvalInfoEmail)      DOM.approvalInfoEmail.textContent      = email;
+    if (DOM.approvalInfoUserid)     DOM.approvalInfoUserid.textContent     = username;
+    if (DOM.approvalInfoCreatedAt)  DOM.approvalInfoCreatedAt.textContent  = formatDate(createdAt);
+
+    if (DOM.approvalInfoUsername && DOM.approvalInfoUsernameText) {
+      const displayName = (`${firstName} ${lastName}`).trim() || email;
+      DOM.approvalInfoUsernameText.textContent = displayName;
+      DOM.approvalInfoUsername.style.display = 'inline';
+    }
+  },
+
+  clearDetail() {
+    if (DOM.approvalInfoFirstname)  DOM.approvalInfoFirstname.textContent  = '';
+    if (DOM.approvalInfoLastname)   DOM.approvalInfoLastname.textContent   = '';
+    if (DOM.approvalInfoEmail)      DOM.approvalInfoEmail.textContent      = '';
+    if (DOM.approvalInfoUserid)     DOM.approvalInfoUserid.textContent     = '';
+    if (DOM.approvalInfoCreatedAt)  DOM.approvalInfoCreatedAt.textContent  = '';
+    if (DOM.approvalInfoUsername)   DOM.approvalInfoUsername.style.display = 'none';
+  },
+};
+
+const TableManager = {
+  async initApprovalsTable() {
+    return new Promise(function(resolve, reject) {
+      if (AppState.tables.approvalsTable) {
+        AppState.tables.approvalsTable.destroy();
+        AppState.tables.approvalsTable = null;
+      }
+
+      const tableElement = DOM.approvalsTable;
+      if (!tableElement) {
+        reject(new Error("approvals-table element not found"));
+        return;
+      }
+
+      try {
+        const table = new Tabulator("#approvals-table", {
+          data: [],
+          layout: "fitColumns",
+          height: 400,
+          pagination: true,
+          paginationSize: 10,
+          paginationSizeSelector: [10, 25, 50],
+          reactiveData: true,
+          columns: TableManager.getColumns(),
+        });
+
+        AppState.tables.approvalsTable = table;
+
+        table.on("tableBuilt", function() {
+          resolve();
+        });
+
+        table.on("rowClick", function(e, row) {
+          row.toggleSelect();
+          const userId = row.getCell("id").getValue();
+          const user = AppState.users.pendingList.find(function(u) { return u.id === userId; });
+          if (user) {
+            AppState.users.selectedUser = user;
+            UIManager.updateDetail(user);
+            UIManager.showViewMode();
+          }
+        });
+
+        table.on("rowSelectionChanged", function(data) {
+          checked_array = data;
+        });
+
+      } catch (error) {
+        console.error("Error initializing approvals table:", error);
+        reject(error);
+      }
+    });
+  },
+
+  getColumns() {
+    return [
+      {
+        formatter: "rowSelection",
+        titleFormatter: "rowSelection",
+        vertAlign: "middle",
+        hozAlign: "center",
+        headerHozAlign: "center",
+        headerSort: false,
+        width: 60,
+      },
+      { title: "Id", field: "id", visible: false },
+      {
+        title: "Name",
+        field: "name",
+        sorter: "string",
+        formatter: function(cell) {
+          const u = cell.getRow().getData();
+          const fn = u.firstName || u.first_name || u.FirstName || '';
+          const ln = u.lastName  || u.last_name  || u.LastName  || '';
+          return (`${fn} ${ln}`).trim() || u.email || u.Email || '';
+        },
+      },
+      {
+        title: "Email",
+        field: "email",
+        sorter: "string",
+        formatter: function(cell) {
+          const u = cell.getRow().getData();
+          return u.email || u.Email || '';
+        },
+      },
+      {
+        title: "Username",
+        field: "username",
+        formatter: function(cell) {
+          const u = cell.getRow().getData();
+          return u.username || u.userName || u.UserName || '';
+        },
+      },
+      {
+        title: "Requested At",
+        field: "createdAt",
+        sorter: "string",
+        formatter: function(cell) {
+          const u = cell.getRow().getData();
+          const dt = u.createdAt || u.created_at || u.CreatedAt || u.createdTimestamp || '';
+          return formatDate(dt);
+        },
+      },
+      {
+        title: "Actions",
+        field: "actions",
+        headerSort: false,
+        hozAlign: "center",
+        width: 160,
+        formatter: function(cell) {
+          const u = cell.getRow().getData();
+          return `<div class="btn-list flex-nowrap">
+            <button class="btn btn-sm btn-success"
+              onclick="event.stopPropagation(); approveUser('${u.id}')">Approve</button>
+            <button class="btn btn-sm btn-danger"
+              onclick="event.stopPropagation(); openRejectModal('${u.id}')">Reject</button>
+          </div>`;
+        },
+      },
+    ];
+  },
+};
+
+// 목록 재조회 및 테이블 갱신
+async function initApprovals() {
+  try {
+    UIManager.hideViewMode();
+    UIManager.clearDetail();
+    AppState.users.selectedUser = null;
+    checked_array = [];
+
+    await TableManager.initApprovalsTable();
+
+    const userList = await webconsolejs["common/api/services/users_api"].getUserList();
+    const allUsers = userList || [];
+    const pending  = filterPendingUsers(allUsers);
+
+    AppState.users.list        = allUsers;
+    AppState.users.pendingList = pending;
+
+    if (AppState.tables.approvalsTable) {
+      AppState.tables.approvalsTable.setData(pending);
+    }
+  } catch (error) {
+    console.error("Error in initApprovals:", error);
+  }
+}
+
+// 단건 승인 (행 액션 버튼)
+window.approveUser = async function(userId) {
+  if (!confirm('Approve this user?')) return;
+  try {
+    await webconsolejs["common/api/services/users_api"].updateUserStatus(userId, 'approved');
+    await initApprovals();
+  } catch (error) {
+    console.error('Error approving user:', error);
+    alert('Failed to approve user: ' + error.message);
+  }
+};
+
+// 일괄 승인 (페이지 헤더 버튼)
+window.approveSelected = async function() {
+  if (checked_array.length === 0) {
+    alert('No users selected.');
+    return;
+  }
+  if (!confirm(`Approve ${checked_array.length} user(s)?`)) return;
+  try {
+    for (const user of checked_array) {
+      await webconsolejs["common/api/services/users_api"].updateUserStatus(user.id, 'approved');
+    }
+    checked_array = [];
+    await initApprovals();
+  } catch (error) {
+    console.error('Error approving selected users:', error);
+    alert('Failed to approve users: ' + error.message);
+  }
+};
+
+// 상세 패널에서 선택된 사용자 승인
+window.approveSelectedUser = async function() {
+  const user = AppState.users.selectedUser;
+  if (!user) { alert('Please select a user.'); return; }
+  if (!confirm(`Approve user "${user.username || user.userName || user.id}"?`)) return;
+  try {
+    await webconsolejs["common/api/services/users_api"].updateUserStatus(user.id, 'approved');
+    await initApprovals();
+  } catch (error) {
+    console.error('Error approving user:', error);
+    alert('Failed to approve user: ' + error.message);
+  }
+};
+
+// 행 액션 버튼 — 거부 모달 오픈
+window.openRejectModal = function(userId) {
+  _rejectTargetUserId = userId;
+  const textarea = document.getElementById('reject-reason-text');
+  if (textarea) textarea.value = '';
+  const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('reject-reason-modal'));
+  modal.show();
+};
+
+// 상세 패널에서 선택된 사용자 거부 모달 오픈
+window.openRejectModalForSelected = function() {
+  const user = AppState.users.selectedUser;
+  if (!user) { alert('Please select a user.'); return; }
+  openRejectModal(user.id);
+};
+
+// 거부 확인
+window.confirmReject = async function() {
+  if (!_rejectTargetUserId) return;
+  try {
+    await webconsolejs["common/api/services/users_api"].updateUserStatus(_rejectTargetUserId, 'disabled');
+    const modal = bootstrap.Modal.getInstance(document.getElementById('reject-reason-modal'));
+    if (modal) modal.hide();
+    _rejectTargetUserId = null;
+    await initApprovals();
+  } catch (error) {
+    console.error('Error rejecting user:', error);
+    alert('Failed to reject user: ' + error.message);
+  }
+};
+
+// webconsolejs 등록 (refresh용 외부 호출 허용)
+if (typeof webconsolejs !== 'undefined') {
+  webconsolejs["pages/settings/accountnaccess/organizations/approvals"] = { initApprovals };
+}
+
+document.addEventListener("DOMContentLoaded", async function() {
+  // 페이지 헤더 버튼: Approve Selected + Refresh
+  const btnList = document.getElementById('page-header-btn-list');
+  if (btnList) {
+    btnList.innerHTML = `
+      <button type="button" class="btn btn-success" onclick="approveSelected()">
+        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+          <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+          <path d="M5 12l5 5l10 -10"></path>
+        </svg>
+        Approve Selected
+      </button>
+      <button type="button" class="btn btn-outline-secondary ms-2" onclick="webconsolejs['pages/settings/accountnaccess/organizations/approvals'].initApprovals()">
+        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+          <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+          <path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"></path>
+          <path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4"></path>
+        </svg>
+        Refresh
+      </button>`;
+  }
+
+  await initApprovals();
+});

--- a/front/assets/js/partials/layout/sidebar.js
+++ b/front/assets/js/partials/layout/sidebar.js
@@ -192,4 +192,13 @@ const iconsArr = {
         class="icon"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M9 11l3 3l8 -8">
         </path><path d="M20 12v6a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2h9"></path>
         </svg>`,
+
+    "approvals" : `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+        fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+        class="icon icon-tabler icons-tabler-outline icon-tabler-user-check">
+        <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+        <path d="M8 7a4 4 0 1 0 8 0a4 4 0 0 0 -8 0"/>
+        <path d="M6 21v-2a4 4 0 0 1 4 -4h4"/>
+        <path d="M15 19l2 2l4 -4"/>
+        </svg>`,
 }

--- a/front/templates/pages/settings/accountnaccess/organizations/approvals.html
+++ b/front/templates/pages/settings/accountnaccess/organizations/approvals.html
@@ -1,0 +1,205 @@
+<div class="page-body">
+  <div class="container-xl">
+    <!-- APPROVAL LIST SECTION -->
+    <div id="index" class="section">
+      <div class="row row-cards">
+        <div class="col-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">Pending Approval Requests</h3>
+              <div class="card-actions btn-actions">
+                <!-- refresh -->
+                <a
+                  class="btn-action"
+                  onclick="webconsolejs['pages/settings/accountnaccess/organizations/approvals'].initApprovals()"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    class="icon icon-tabler icons-tabler-outline icon-tabler-refresh"
+                  >
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                    <path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"></path>
+                    <path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4"></path>
+                  </svg>
+                </a>
+              </div>
+            </div>
+
+            <div
+              class="card-table table-responsive"
+              style="max-height: 400px; overflow: hidden"
+            >
+              <div id="approvals-table" class="approvals-table-container"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- VIEW 모드 카드 -->
+      <div id="view-mode-cards" class="collapse bg-secondary-lt">
+        <div class="card" id="approval-detail-card">
+          <div class="card-header">
+            <h3 class="card-title">
+              Applicant Info
+              <span
+                id="approval-info-username"
+                class="ms-2 text-primary"
+                style="display: none; font-weight: normal"
+              >
+                [<span id="approval-info-username-text"></span>]
+              </span>
+            </h3>
+            <div class="card-actions btn-actions">
+              <button
+                class="btn btn-success"
+                onclick="approveSelectedUser()"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                  <path d="M5 12l5 5l10 -10"></path>
+                </svg>
+                Approve
+              </button>
+              <button
+                class="btn btn-danger ms-2"
+                onclick="openRejectModalForSelected()"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                  <path d="M18 6l-12 12"></path>
+                  <path d="M6 6l12 12"></path>
+                </svg>
+                Reject
+              </button>
+            </div>
+          </div>
+          <div class="card-body">
+            <div
+              class="row p-4 mb-4"
+              style="background-color: #f8f9fa; border-radius: 8px; border: 1px solid #e9ecef;"
+            >
+              <div class="datagrid">
+                <div class="datagrid-item">
+                  <div class="datagrid-title">First Name</div>
+                  <div class="datagrid-content" id="approval-info-firstname"></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Last Name</div>
+                  <div class="datagrid-content" id="approval-info-lastname"></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Email</div>
+                  <div class="datagrid-content" id="approval-info-email"></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Username</div>
+                  <div class="datagrid-content" id="approval-info-userid"></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Requested At</div>
+                  <div class="datagrid-content" id="approval-info-created-at"></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Status</div>
+                  <div class="datagrid-content">
+                    <span class="badge bg-warning">Pending Approval</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Reject Reason Modal -->
+<div
+  class="modal modal-blur fade"
+  id="reject-reason-modal"
+  tabindex="-1"
+  style="display: none"
+  aria-hidden="true"
+>
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Reject Signup Request</h5>
+        <button
+          type="button"
+          class="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="Close"
+        ></button>
+      </div>
+      <div class="modal-body">
+        <p class="text-muted mb-3">
+          The user account will be deactivated.
+          Note: rejection reason is for reference only and is not stored on the server.
+        </p>
+        <div class="mb-3">
+          <label class="form-label">Reason (optional)</label>
+          <textarea
+            class="form-control"
+            id="reject-reason-text"
+            rows="3"
+            placeholder="Enter reason for rejection..."
+          ></textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button
+          type="button"
+          class="btn btn-secondary"
+          data-bs-dismiss="modal"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="btn btn-danger"
+          onclick="confirmReject()"
+        >
+          Confirm Reject
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- pageloader -->
+{{ partial("partials/layout/pageloader.html") | raw }}
+
+<style>
+  .card-table {
+    border: none;
+    box-shadow: none;
+  }
+
+  .card-table tbody tr:hover {
+    background: linear-gradient(135deg, #f8f9ff 0%, #f0f4ff 100%);
+    transition: all 0.2s ease;
+  }
+
+  .btn-list {
+    gap: 4px;
+  }
+
+  .btn-list .btn {
+    border-radius: 6px;
+    transition: all 0.2s ease;
+  }
+</style>
+
+<!-- javascript -->
+{{ javascriptTag("common/api/services/users_api.js") | raw }}
+{{ javascriptTag("pages/settings/accountnaccess/organizations/approvals.js") | raw }}


### PR DESCRIPTION
## Summary

- 플랫폼 관리자용 가입 신청 승인 화면 구현 (FR-PLATFORM-ADMIN-001-01·02)
- `enabled=false` pending 사용자 목록 조회 및 승인/거부 UI 제공

## Changes

- `conf/webconsole_menu_resources.yaml` — `approvals` 메뉴 `isaction: true` 활성화
- `front/assets/js/partials/layout/sidebar.js` — `iconsArr`에 approvals 아이콘 추가
- `front/templates/pages/settings/accountnaccess/organizations/approvals.html` — 승인 화면 템플릿 (Tabulator 테이블 + 상세 패널 + 거부 사유 모달)
- `front/assets/js/pages/settings/accountnaccess/organizations/approvals.js` — 승인 로직 (단건/일괄 승인, 거부, 목록 재조회)

## Test plan

- [x] TC-SU01-API: 가입 → API 직접 승인 → 로그인 (Playwright E2E 통과)
- [x] TC-SU01-UI: 가입 → 승인 화면 Approve 버튼 → 로그인 (Playwright E2E 통과)
- [x] TC-SU01-UI-RESET: 가입 → 승인 화면 → 비밀번호 재설정 → 새 비밀번호 로그인 (Playwright E2E 통과)
- [x] 수동 검증: 브라우저에서 승인 화면 접속, 승인 후 행 제거 확인