### PR TITLE
feat: credential form에 지원 CSP 10개 전체 반영

### DIFF
--- a/front/assets/js/pages/settings/environment/cloudsps/connections.js
+++ b/front/assets/js/pages/settings/environment/cloudsps/connections.js
@@ -20,8 +20,10 @@ const PROVIDER_BADGE = {
     azure:    '<span class="badge bg-indigo-lt">Azure</span>',
     alibaba:  '<span class="badge bg-yellow-lt">Alibaba</span>',
     ncp:      '<span class="badge bg-green-lt">NCP</span>',
-    nhncloud: '<span class="badge bg-cyan-lt">NHN</span>',
-    ktcloud:  '<span class="badge bg-teal-lt">KT</span>',
+    ibm:      '<span class="badge bg-purple-lt">IBM</span>',
+    nhn:      '<span class="badge bg-cyan-lt">NHN</span>',
+    kt:       '<span class="badge bg-teal-lt">KT</span>',
+    openstack: '<span class="badge bg-red-lt">OpenStack</span>',
     tencent:  '<span class="badge bg-red-lt">Tencent</span>',
 };
 

--- a/front/assets/js/pages/settings/environment/cloudsps/credentials.js
+++ b/front/assets/js/pages/settings/environment/cloudsps/credentials.js
@@ -20,9 +20,12 @@ const PROVIDER_KEYS = {
     gcp:       ['ClientEmail', 'PrivateKey', 'ProjectID'],
     azure:     ['ClientId', 'ClientSecret', 'TenantId', 'SubscriptionId'],
     alibaba:   ['ClientId', 'ClientSecret'],
+    ibm:       ['ApiKey', 'S3AccessKey', 'S3SecretKey'],
     ncp:       ['ClientId', 'ClientSecret'],
-    nhncloud:  ['ClientId', 'ClientSecret', 'TenantId'],
-    ktcloud:   ['ClientId', 'ClientSecret'],
+    nhn:       ['IdentityEndpoint', 'Username', 'Password', 'DomainName', 'TenantId'],
+    kt:        ['IdentityEndpoint', 'Username', 'Password', 'DomainName', 'ProjectID'],
+    openstack: ['IdentityEndpoint', 'Username', 'Password', 'DomainName', 'ProjectID'],
+    tencent:   ['SecretId', 'SecretKey'],
 };
 
 const PROVIDER_BADGE = {

--- a/front/templates/pages/settings/environment/cloudsps/credentials.html
+++ b/front/templates/pages/settings/environment/cloudsps/credentials.html
@@ -118,9 +118,12 @@
               <option value="gcp">GCP</option>
               <option value="azure">Azure</option>
               <option value="alibaba">Alibaba</option>
+              <option value="ibm">IBM</option>
               <option value="ncp">NCP</option>
-              <option value="nhncloud">NHN Cloud</option>
-              <option value="ktcloud">KT Cloud</option>
+              <option value="nhn">NHN Cloud</option>
+              <option value="kt">KT Cloud</option>
+              <option value="openstack">OpenStack</option>
+              <option value="tencent">Tencent</option>
             </select>
             <div class="invalid-feedback"></div>
           </div>


### PR DESCRIPTION
## Summary

- `credentials.html` CSP Provider select에 ibm, openstack, tencent 추가 및 nhncloud→nhn, ktcloud→kt 수정 (백엔드 일치)
- `credentials.js` PROVIDER_KEYS에 신규 3개 CSP의 cb-spider 기대 key 이름 추가 및 nhn/kt key 수정 (IdentityEndpoint 기반)
- `connections.js` PROVIDER_BADGE에 ibm, openstack, nhn, kt 배지 추가/수정
