### PR TITLE
fix: update GetInfraNode pathParams

### DIFF
--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -113,7 +113,7 @@ export async function getMciVm(nsId, mciId, vmId) {
     pathParams: {
       nsId: nsId,
       infraId: mciId,
-      vmId: vmId
+      nodeId: vmId
     }
   }
 


### PR DESCRIPTION
## Summary
- `getMciVm()` 함수의 `GetInfraNode` pathParams에서 mc-infra-manager v0.12 변경사항 반영
- `mciId` → `infraId`, `vmId` → `nodeId` 파라미터명 수정
- 기존 코드에서 `{nodeId}` 치환이 누락되어 `/node/{nodeId}` 리터럴이 그대로 전달되는 문제 수정
