### PR TITLE
feat: workspace 사용자 assign/unassign 기능 구현

### DIFF
--- a/front/assets/js/common/api/services/workspace_api.js
+++ b/front/assets/js/common/api/services/workspace_api.js
@@ -459,12 +459,12 @@ export async function deleteResourcePermissionPolicesByOperationId(reqFramework,
 // handle workspace user role mapping
 
 export async function createWorkspaceUserRoleMappingByName(wsId, reqRoleID, UserID) {
-  const controller = '/api/mc-iam-manager/CreateWorkspaceUserRoleMappingByName'
+  const controller = '/api/mc-iam-manager/assignWorkspaceRole'
   var data = {
     request: {
-      workspaceId: wsId,
-      roleId: reqRoleID,
-      userId: UserID,
+      workspaceId: String(wsId),
+      roleId: String(reqRoleID),
+      userId: String(UserID),
     }
   };
   const response = await webconsolejs["common/api/http"].commonAPIPost(
@@ -498,12 +498,13 @@ export async function getWorkspaceUserRoleMappingListByWorkspaceId(wsId) {
   return response.data.responseData
 }
 
-export async function deleteWorkspaceUserRoleMapping(wsId, requserId) {
-  const controller = '/api/mc-iam-manager/DeleteWorkspaceUserRoleMapping'
+export async function removeWorkspaceUserRoleMapping(wsId, roleId, userId) {
+  const controller = '/api/mc-iam-manager/removeWorkspaceRole'
   var data = {
-    pathParams: {
-      workspaceId: wsId,
-      userId: requserId,
+    request: {
+      workspaceId: String(wsId),
+      roleId: String(roleId),
+      userId: String(userId),
     },
   };
   const response = await webconsolejs["common/api/http"].commonAPIPost(

--- a/front/assets/js/pages/operation/workspace/workspaces.js
+++ b/front/assets/js/pages/operation/workspace/workspaces.js
@@ -612,8 +612,8 @@ function initUserAddSeletor(users) {
 
   users.forEach(user => {
     let option = document.createElement('option');
-    option.value = user;
-    option.text = user;
+    option.value = user.id;       // numeric userId (string) — assignWorkspaceRole 요구
+    option.text = user.username;
     selectElement.add(option);
   });
 
@@ -635,23 +635,23 @@ function initUserAddSeletor(users) {
   });
 }
 
-// function initUserAddRoleSeletor(roles) {
-//   var selectElement = document.getElementById('user-modal-add-roleselector');
-//   if (selectElement.tomselect) {
-//     selectElement.tomselect.destroy();
-//   }
-//   selectElement.innerHTML = '';
-//   let option = document.createElement('option');
-//   option.value = "";
-//   option.text = "select Role";
-//   selectElement.add(option);
-//   roles.forEach(role => {
-//     let option = document.createElement('option');
-//     option.value = role.id;
-//     option.text = role.name;
-//     selectElement.add(option);
-//   });
-// }
+function initUserAddRoleSeletor(roles) {
+  var selectElement = document.getElementById('user-modal-add-roleselector');
+  if (selectElement.tomselect) {
+    selectElement.tomselect.destroy();
+  }
+  selectElement.innerHTML = '';
+  let option = document.createElement('option');
+  option.value = "";
+  option.text = "select Role";
+  selectElement.add(option);
+  roles.forEach(role => {
+    let option = document.createElement('option');
+    option.value = role.id;
+    option.text = role.name;
+    selectElement.add(option);
+  });
+}
 
 function updateSummary() {
   document.getElementById('workspaces_count').textContent = workspaceListInfoSummary.workspaceCount;
@@ -749,6 +749,7 @@ async function setWokrspaceUserTableData(wsId) {
     username: userInfo.username,
     name: userInfo.username,
     role: userInfo.role_name,
+    role_id: userInfo.role_id,
     // TODO: Approved(enabled) 항목은 workspace 초대/수락 기능 추가 시 반영
     //       사용자를 workspace에 초대(invited)하고 초대받은 사용자가 수락(accepted)하는 상태값 표시
     //       현재 해당 상태 필드 미제공 (listUsersAndRolesByWorkspaces 응답에 없음)
@@ -1159,38 +1160,47 @@ export async function addWorkspaceProject() {
 //// User Tab Modal
 export async function addUserModalInit() {
   const resp = await webconsolejs["common/api/services/workspace_api"].getWorkspaceUserRoleMappingListByWorkspaceId(currentClickedWorkspaceId);
-  var wsUser = Array.isArray(resp.userinfo) && resp.userinfo.length > 0
-    ? resp.userinfo.map(item => item.userid)
-    : [];
-  var allUserIds = Array.isArray(listData.userList) && listData.userList.length > 0
-    ? listData.userList.map(item => item.username)
-    : [];
-  var availUser = allUserIds.filter(item => !wsUser.includes(item))
+  const mappingData = resp.responseData || resp;
+  const mappingArray = Array.isArray(mappingData) ? mappingData : (Array.isArray(resp.userinfo) ? resp.userinfo : []);
+  var wsUsernames = mappingArray.map(item => item.username || item.userid).filter(Boolean);
+  var allUsers = Array.isArray(listData.userList) ? listData.userList : [];
+  var availUser = allUsers
+    .filter(item => !wsUsernames.includes(item.username))
+    .map(item => ({ id: String(item.id), username: item.username }));
   initUserAddSeletor(availUser)
 
-
-  // const roleResp = await webconsolejs["common/api/services/workspace_api"].getRoleList();
-  // initUserAddRoleSeletor(roleResp)
+  const roleResp = await webconsolejs["common/api/services/workspace_api"].getRoleList();
+  initUserAddRoleSeletor(roleResp)
 
   var modal = new bootstrap.Modal(document.getElementById('user-modal-add'));
   modal.show();
 }
 
-// export async function assignUser() {
-//   var usersSelector = document.getElementById('user-modal-add-userselector');
-//   var roleId = document.getElementById('user-modal-add-roleselector').value;
-//   var users = Array.from(usersSelector.selectedOptions, option => option.value);
-//   users.forEach(async function (user) {
-//     const resp = await webconsolejs["common/api/services/workspace_api"].createWorkspaceUserRoleMappingByName(currentClickedWorkspaceId, roleId, user);
-//   })
-//   location.reload()
-// }
+export async function assignUser() {
+  var usersSelector = document.getElementById('user-modal-add-userselector');
+  var roleId = document.getElementById('user-modal-add-roleselector').value;
+  var users = Array.from(usersSelector.selectedOptions, option => option.value);
+  if (!roleId) {
+    webconsolejs["common/util"].showToast("Please select a role.", 'error');
+    return;
+  }
+  for (const user of users) {
+    await webconsolejs["common/api/services/workspace_api"].createWorkspaceUserRoleMappingByName(currentClickedWorkspaceId, roleId, user);
+  }
+  const modal = bootstrap.Modal.getInstance(document.getElementById('user-modal-add'));
+  if (modal) modal.hide();
+  await setWokrspaceUserTableData(currentClickedWorkspaceId);
+}
 
 export async function deassignUser() {
-  checked_userRolemapping_array.forEach(async function name(user) {
-    const resp = await webconsolejs["common/api/services/workspace_api"].deleteWorkspaceUserRoleMapping(currentClickedWorkspaceId, user.username);
-  })
-  location.reload()
+  for (const user of checked_userRolemapping_array) {
+    await webconsolejs["common/api/services/workspace_api"].removeWorkspaceUserRoleMapping(
+      currentClickedWorkspaceId,
+      user.role_id,
+      user.id,
+    );
+  }
+  await setWokrspaceUserTableData(currentClickedWorkspaceId);
 }
 
 // tableaction area end

--- a/front/templates/pages/operations/manage/workspaces.html
+++ b/front/templates/pages/operations/manage/workspaces.html
@@ -397,6 +397,28 @@
                                         <div class="card-header">
                                             <h3 class="card-title">Share Members / status</h3>
                                             <div class="card-actions btn-actions">
+                                                <!-- Add button -->
+                                                <a class="btn-action" type="button" onclick="webconsolejs['pages/operation/workspace/workspaces'].addUserModalInit()">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-plus"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 5l0 14" /><path d="M5 12l14 0" /></svg>
+                                                </a>
+                                                <!-- Action -->
+                                                <div class="dropdown">
+                                                    <a href="#" class="btn-action" data-bs-toggle="dropdown">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-chevron-down">
+                                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                                            <path d="M6 9l6 6l6 -6" />
+                                                        </svg>
+                                                    </a>
+                                                    <div class="dropdown-menu dropdown-menu-end dropdown-menu-demo dropdown-menu-arrow">
+                                                        <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#commonDefaultModal" onclick="webconsolejs['partials/layout/modal'].commonModal(this,'Unassign Members', 'Would you like to unassign selected members from this workspace?', 'pages/operation/workspace/workspaces.deassignUser')">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="icon dropdown-item-icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                                                <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                                                                <path d="M13 12v.01"></path><path d="M3 21h18"></path><path d="M5 21v-16a2 2 0 0 1 2 -2h7.5"></path><path d="M14 7l7 7"></path><path d="M14 14l7 -7"></path>
+                                                            </svg>
+                                                            Unassign Members
+                                                        </a>
+                                                    </div>
+                                                </div>
                                                 <!-- filter -->
                                                 <a class="btn-action" type="button" data-bs-toggle="collapse" data-bs-target="#members-filterbody" aria-expanded="false">
                                                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-filter">


### PR DESCRIPTION
## Summary

- `assignWorkspaceRole` / `removeWorkspaceRole` 엔드포인트로 변경 (기존 `CreateWorkspaceUserRoleMappingByName` / `DeleteWorkspaceUserRoleMapping` → IAM 레지스트리에 미존재)
- 사용자 ID를 `String()`으로 변환하여 IAM 400 오류("잘못된 사용자 ID 형식입니다") 해결
- `deassignUser`: `forEach(async) + location.reload()` → `for...of + await + setWokrspaceUserTableData()` 로 수정 (비동기 버그 해결)
- 사용자 선택자: `option.value = username` → `option.value = userId` 로 수정 (숫자 ID 전달)
- Members 탭에 Add User(`+`) 버튼 및 "Unassign Members" 드롭다운 추가

## Test plan

- [ ] workspace Members 탭에서 사용자 추가(+) 버튼 클릭 → 모달에서 사용자/역할 선택 → Assign 확인
- [ ] 할당된 사용자 체크박스 선택 → "Unassign Members" 클릭 → 목록에서 제거 확인
- [ ] SETUP-FLOW-05a E2E 테스트 통과 확인 (`npx playwright test setup-flow-05a`)