### PR TITLE
[feat]: Add proactive access token refresh before JWT expiry

### DIFF
--- a/front/assets/js/common/cookie/authcookie.js
+++ b/front/assets/js/common/cookie/authcookie.js
@@ -1,135 +1,261 @@
+const DEFAULT_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const MIN_SCHEDULE_DELAY_MS = 30 * 1000;
+const DEFAULT_ACCESS_TTL_MS = 25 * 60 * 1000;
+
+let proactiveRefreshTimer = null;
+let refreshInFlight = null;
+let nextProactiveRefreshAt = null;
+
+function getRefreshBufferMs() {
+  if (typeof window !== 'undefined' && window.__MCWC_TOKEN_REFRESH_BUFFER_MS > 0) {
+    return window.__MCWC_TOKEN_REFRESH_BUFFER_MS;
+  }
+  return DEFAULT_REFRESH_BUFFER_MS;
+}
+
+function isValidJWT(token) {
+  if (!token || typeof token !== 'string') {
+    return false;
+  }
+
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return false;
+  }
+
+  return Boolean(parts[0] && parts[1] && parts[2]);
+}
+
+function getCookie(name) {
+  const cookies = document.cookie.split(';');
+
+  for (let cookie of cookies) {
+    const [key, value] = cookie.trim().split('=');
+    if (key === name) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function decodeJwtPayload(token) {
+  if (!isValidJWT(token)) {
+    return null;
+  }
+
+  try {
+    const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+    return JSON.parse(atob(padded));
+  } catch (error) {
+    console.error('Failed to decode JWT payload:', error);
+    return null;
+  }
+}
+
+function getAccessTokenFromCookie() {
+  return getCookie('Authorization');
+}
+
+function getRefreshTokenFromCookie() {
+  return getCookie('RefreshToken');
+}
+
+function syncSessionTokens() {
+  if (!webconsolejs || !webconsolejs['common/storage/sessionstorage']) {
+    return;
+  }
+
+  webconsolejs['common/storage/sessionstorage'].setSessionCurrentUserToken();
+  webconsolejs['common/storage/sessionstorage'].setSessionCurrentUserRefreshToken();
+}
+
 export async function updateCookieAccessToken(accessToken) {
-    let now = new Date();
-    now.setTime(now.getTime() + (24 * 60 * 60 * 1000)); // 1day
-    document.cookie = `Authorization=${accessToken}; path=/; expires=${now.toUTCString()};`;
+  let now = new Date();
+  now.setTime(now.getTime() + (24 * 60 * 60 * 1000));
+  document.cookie = `Authorization=${accessToken}; path=/; expires=${now.toUTCString()};`;
 }
 
 export async function updateCookieRefreshToken(refreshToken) {
-    let now = new Date();
-    now.setTime(now.getTime() + (24 * 60 * 60 * 1000)); // 1day
-    document.cookie = `RefreshToken=${refreshToken}; path=/; expires=${now.toUTCString()};`;
+  let now = new Date();
+  now.setTime(now.getTime() + (24 * 60 * 60 * 1000));
+  document.cookie = `RefreshToken=${refreshToken}; path=/; expires=${now.toUTCString()};`;
 }
 
-export async function refreshCookieAccessToken(){
-   var controller = "/api/auth/refresh"; 
-   
-   // JWT 토큰 형식 검증 함수
-   function isValidJWT(token) {
-       if (!token || typeof token !== 'string') {
-           return false;
-       }
-       
-       // JWT는 3개의 부분으로 구성되어야 함 (header.payload.signature)
-       const parts = token.split('.');
-       if (parts.length !== 3) {
-           console.error("Invalid JWT format: token should have 3 parts, got", parts.length);
-           return false;
-       }
-       
-       // 각 부분이 비어있지 않아야 함
-       if (!parts[0] || !parts[1] || !parts[2]) {
-           console.error("Invalid JWT format: one or more parts are empty");
-           return false;
-       }
-       
-       return true;
-   }
-   
-   // 쿠키에서 리프레시 토큰 가져오기
-   function getRefreshTokenFromCookie() {
-       const cookies = document.cookie.split(';');
-       
-       for (let cookie of cookies) {
-           const [name, value] = cookie.trim().split('=');
-           if (name === 'RefreshToken') {
-               return value;
-           }
-       }
-       
-       return null;
-   }
+function computeProactiveRefreshDelayMs(accessToken) {
+  const payload = decodeJwtPayload(accessToken);
+  const bufferMs = getRefreshBufferMs();
+  const nowMs = Date.now();
 
-   const refreshToken = getRefreshTokenFromCookie();
-   if (!refreshToken) {
-       return false;
-   }
+  if (payload && payload.exp) {
+    const refreshAtMs = (payload.exp * 1000) - bufferMs;
+    return Math.max(refreshAtMs - nowMs, MIN_SCHEDULE_DELAY_MS);
+  }
 
-   // 토큰 형식 검증
-   if (!isValidJWT(refreshToken)) {
-       // 잘못된 토큰이면 쿠키에서 제거
-       document.cookie = "RefreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
-       return false;
-   }
+  return Math.max(DEFAULT_ACCESS_TTL_MS - bufferMs, MIN_SCHEDULE_DELAY_MS);
+}
 
-   // 요청 데이터 준비 - CommonRequest.Request 형태로 감싸기
-   var data = {
-       "request": {
-           "refresh_token": refreshToken
-       }
-   }
+export function stopProactiveTokenRefresh() {
+  if (proactiveRefreshTimer) {
+    clearTimeout(proactiveRefreshTimer);
+    proactiveRefreshTimer = null;
+  }
+  nextProactiveRefreshAt = null;
+}
 
-    try {
-        
-        const response = await webconsolejs["common/api/http"].commonAPIPostWithoutRetry(controller, data)
-        
-        // 응답이 에러인지 확인
-        if (response.error || response.response) {
-            console.error("ERROR: Response contains error:", response.error || response.response);
-            return false;
-        }
-        
-        // 응답 데이터 구조 확인
-        if (!response.data) {
-            console.error("ERROR: Response data is missing");
-            return false;
-        }
+async function runProactiveTokenRefresh() {
+  if (refreshInFlight) {
+    return refreshInFlight;
+  }
 
-        const accessToken = response.data.access_token;
-        if (!accessToken || accessToken === "") {
-            console.error("ERROR: Access token is missing or empty in response");
-            return false;
-        }
-        
-        // 새로운 액세스 토큰도 JWT 형식 검증
-        if (!isValidJWT(accessToken)) {
-            console.error("ERROR: Invalid access token format received:", accessToken);
-            return false;
-        }
-        
-        // 토큰 업데이트
-        updateCookieAccessToken(accessToken)
-        
-        // refresh_token도 함께 업데이트 (있는 경우)
-        if (response.data.refresh_token) {
-            const newRefreshToken = response.data.refresh_token;
-            if (isValidJWT(newRefreshToken)) {
-                updateCookieRefreshToken(newRefreshToken)
-            } else {
-                console.error("ERROR: Invalid new refresh token format:", newRefreshToken);
-            }
-        } else {
-            console.log("No new refresh token in response");
-        }
-        
-        return true;
-        
-    } catch (error) {
-        console.error("ERROR during token refresh:", error);
-        return false;
+  refreshInFlight = (async () => {
+    const ok = await refreshCookieAccessToken();
+    if (!ok) {
+      console.warn('[authcookie] proactive refresh failed');
+      stopProactiveTokenRefresh();
+      if (webconsolejs && webconsolejs['common/util']) {
+        webconsolejs['common/util'].showToast(
+          'Session has expired. Please login again.',
+          'error',
+        );
+      }
+      window.location = '/auth/login';
+      return false;
     }
+
+    console.log('[authcookie] proactive refresh succeeded');
+    scheduleProactiveTokenRefresh();
+    return true;
+  })();
+
+  try {
+    return await refreshInFlight;
+  } finally {
+    refreshInFlight = null;
+  }
 }
-// export async function refreshCookieAccessToken() {
-//     const response = await webconsolejs["common/api/http"].commonAPIPostWithoutRetry("/api/auth/refresh")
-    
-    
-//     try {
-//         if (response.data.responseData.access_token === undefined || response.data.responseData.access_token === "") {
-//             return false
-//         } else {
-//             updateCookieAccessToken(response.data.responseData.access_token)
-//             return true
-//         }
-//     } catch (error) {
-//         return false
-//     }
-// }
+
+export function scheduleProactiveTokenRefresh() {
+  stopProactiveTokenRefresh();
+
+  const accessToken = getAccessTokenFromCookie();
+  const refreshToken = getRefreshTokenFromCookie();
+
+  if (!accessToken || !refreshToken) {
+    return;
+  }
+
+  if (!isValidJWT(accessToken) || !isValidJWT(refreshToken)) {
+    return;
+  }
+
+  const delayMs = computeProactiveRefreshDelayMs(accessToken);
+  nextProactiveRefreshAt = Date.now() + delayMs;
+
+  proactiveRefreshTimer = setTimeout(() => {
+    runProactiveTokenRefresh();
+  }, delayMs);
+
+  console.log(
+    `[authcookie] proactive refresh scheduled in ${Math.round(delayMs / 1000)}s`,
+  );
+}
+
+export function startProactiveTokenRefresh() {
+  const accessToken = getAccessTokenFromCookie();
+  if (!accessToken) {
+    return;
+  }
+
+  const payload = decodeJwtPayload(accessToken);
+  const bufferMs = getRefreshBufferMs();
+  const expiresSoon = payload && payload.exp
+    ? (payload.exp * 1000) - Date.now() <= bufferMs
+    : false;
+
+  if (expiresSoon) {
+    runProactiveTokenRefresh();
+    return;
+  }
+
+  scheduleProactiveTokenRefresh();
+}
+
+export function isProactiveTokenRefreshActive() {
+  return proactiveRefreshTimer !== null;
+}
+
+export function getNextProactiveRefreshAt() {
+  return nextProactiveRefreshAt;
+}
+
+export async function runProactiveTokenRefreshNow() {
+  return runProactiveTokenRefresh();
+}
+
+export async function refreshCookieAccessToken() {
+  const controller = '/api/auth/refresh';
+  const refreshToken = getRefreshTokenFromCookie();
+
+  if (!refreshToken) {
+    return false;
+  }
+
+  if (!isValidJWT(refreshToken)) {
+    document.cookie = 'RefreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    return false;
+  }
+
+  const data = {
+    request: {
+      refresh_token: refreshToken,
+    },
+  };
+
+  try {
+    const response = await webconsolejs['common/api/http'].commonAPIPostWithoutRetry(
+      controller,
+      data,
+    );
+
+    if (response.error || response.response) {
+      console.error('ERROR: Response contains error:', response.error || response.response);
+      return false;
+    }
+
+    if (!response.data) {
+      console.error('ERROR: Response data is missing');
+      return false;
+    }
+
+    const accessToken = response.data.access_token;
+    if (!accessToken || accessToken === '') {
+      console.error('ERROR: Access token is missing or empty in response');
+      return false;
+    }
+
+    if (!isValidJWT(accessToken)) {
+      console.error('ERROR: Invalid access token format received:', accessToken);
+      return false;
+    }
+
+    await updateCookieAccessToken(accessToken);
+
+    if (response.data.refresh_token) {
+      const newRefreshToken = response.data.refresh_token;
+      if (isValidJWT(newRefreshToken)) {
+        await updateCookieRefreshToken(newRefreshToken);
+      } else {
+        console.error('ERROR: Invalid new refresh token format:', newRefreshToken);
+      }
+    }
+
+    syncSessionTokens();
+    scheduleProactiveTokenRefresh();
+    return true;
+  } catch (error) {
+    console.error('ERROR during token refresh:', error);
+    return false;
+  }
+}

--- a/front/assets/js/pages/auth/login.js
+++ b/front/assets/js/pages/auth/login.js
@@ -20,6 +20,7 @@ document.getElementById("loginbtn").addEventListener('click',async function () {
             await webconsolejs["common/cookie/authcookie"].updateCookieAccessToken(response.data.access_token);
             await webconsolejs["common/storage/sessionstorage"].setSessionCurrentUserToken();
             await webconsolejs["common/storage/sessionstorage"].setSessionCurrentUserRefreshToken();
+            webconsolejs["common/cookie/authcookie"].startProactiveTokenRefresh();
         } catch (error) {
             console.error("Error saving tokens:", error);
             alert("Token save failed: " + error.message);

--- a/front/assets/js/partials/layout/navbar.js
+++ b/front/assets/js/partials/layout/navbar.js
@@ -10,6 +10,7 @@ let projectListselectBox = document.getElementById("select-current-project");
 let workspaceRefreshBtn = document.getElementById("refresh-user-ws-prj")// ws prj refresh 버튼
 
 document.addEventListener('DOMContentLoaded', async function () {
+    webconsolejs['common/cookie/authcookie'].startProactiveTokenRefresh();
     await workspaceProjectInit() // workspace select box, project select box 초기화 from local storage
     if (workspaceListselectBox.value === ""){
         workspaceListselectBox.classList.add('is-invalid');
@@ -149,6 +150,7 @@ export async function workspaceProjectInit() {
 
 
 document.getElementById("logoutbtn").addEventListener('click', async function () {
+    webconsolejs['common/cookie/authcookie'].stopProactiveTokenRefresh();
     destroyAccessToken()
     sessionStorage.clear();
     window.location = "/auth/logout"


### PR DESCRIPTION
## Summary
- JWT `exp` 기준 만료 5분 전에 access token을 자동 갱신하도록 스케줄러 추가
- 로그인 성공 및 인증 페이지(navbar) 로드 시 스케줄러 시작, 로그아웃 시 중지
- refresh 성공 시 쿠키와 sessionStorage를 함께 갱신 (iframe 플러그인 토큰 동기화)
- 기존 401 반응형 refresh 성공 후에도 다음 선제 refresh 시각 재예약

## Test plan
 30분 유휴 후 PMK → MCI 이동, GetAllInfra 200 확인