### PR TITLE
fix: deploy 시 expert mode 등 버그 수정

### DIFF
--- a/front/assets/js/common/api/services/cspimport_api.js
+++ b/front/assets/js/common/api/services/cspimport_api.js
@@ -127,7 +127,7 @@ export async function deregisterSshKey(nsId, sshKeyId) {
 
 /** VM(MCI) 등록 해제 */
 export async function deregisterMciVm(nsId, mciId, vmId) {
-  return call('DeregisterMciVm', { pathParams: { nsId, mciId, vmId } });
+  return call('DeregisterInfraNode', { pathParams: { nsId, infraId: mciId, nodeId: vmId } });
 }
 
 // ── Schedule ─────────────────────────────────────────────────────────────────

--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -183,7 +183,7 @@ export function vmDelete(mciId, nsId, vmId) {
     pathParams: {
       nsId: nsId,
       infraId: mciId,
-      vmId: vmId
+      nodeId: vmId
     },
     queryParams: {
       "option": "force"
@@ -725,7 +725,10 @@ export async function postScaleOutSubGroup(nsId, mciId, subgroupId, numVMsToAdd)
     pathParams: {
       nsId: nsId,
       infraId: mciId,
-      subgroupId: subgroupId
+      nodegroupId: subgroupId
+    },
+    queryParams: {
+      async: "true"
     },
     Request: {
       "numVMsToAdd": numVMsToAdd,
@@ -733,13 +736,9 @@ export async function postScaleOutSubGroup(nsId, mciId, subgroupId, numVMsToAdd)
   };
 
   var controller = "/api/" + "mc-infra-manager/" + "PostInfraNodeGroupScaleOut";
-  const response = await webconsolejs["common/api/http"].commonAPIPost(
-    controller,
-    data
-  )
-
-  alert("Creation request completed");
-  window.location = "/webconsole/operations/manage/workloads/mciworkloads"
+  webconsolejs["common/api/http"].commonAPIPost(controller, data)
+    .catch(err => console.error("ScaleOut background error:", err));
+  return { status: "requested" }
 
 }
 

--- a/front/assets/js/common/api/services/pmk_api.js
+++ b/front/assets/js/common/api/services/pmk_api.js
@@ -243,7 +243,7 @@ export async function getAvailableK8sClusterVersion(providerName, regionName) {
     }
   }
 
-  var controller = "/api/" + "mc-infra-manager/" + "Getavailablek8sclusterversion";
+  var controller = "/api/" + "mc-infra-manager/" + "GetAvailableK8sVersion";
   const response = await webconsolejs["common/api/http"].commonAPIPost(
     controller,
     data
@@ -479,7 +479,7 @@ export async function getAvailablek8sClusterNodeImage(providerName, regionName) 
     },
   };
 
-  var controller = "/api/" + "mc-infra-manager/" + "Getavailablek8sclusternodeimage";
+  var controller = "/api/" + "mc-infra-manager/" + "GetAvailableK8sNodeImage";
   const response = webconsolejs["common/api/http"].commonAPIPost(
     controller,
     data

--- a/front/assets/js/pages/operation/manage/mci.js
+++ b/front/assets/js/pages/operation/manage/mci.js
@@ -751,7 +751,7 @@ function displayServerStatusList(mciID, vmList) {
 // subGroup 단위로 묶음
 function groupBySubGroup(vmList) {
   const grouped = vmList.reduce((acc, vm) => {
-    const key = vm.subGroupId;
+    const key = vm.nodeGroupId;
     if (!acc[key]) acc[key] = [];
     acc[key].push(vm);
     return acc;
@@ -1034,7 +1034,7 @@ export async function vmDetailInfo(vmId) {
   try {
     var response = await webconsolejs["common/api/services/mci_api"].getMciVm(window.currentNsId, currentMciId, vmId);
     var aVm = response.responseData
-    var subGroupId = aVm.subGroupId
+    var subGroupId = aVm.nodeGroupId
     var cspVMID = aVm.uid
     var responseVmId = response.id;
     // 전체를 관리하는 obj 갱신

--- a/front/assets/js/pages/operation/manage/mci.js
+++ b/front/assets/js/pages/operation/manage/mci.js
@@ -570,8 +570,12 @@ function updateMciLabelsTab(mciData) {
 
 // mci 삭제
 export function deleteMci() {
+  const deletingMciId = window.currentMciId;
+  window.currentMciId = "";
+  webconsolejs["partials/layout/navigatePages"].deactiveElement(document.getElementById("mci_info"));
+  mciListTable.deselectRow();
   executeWithToast(
-    () => webconsolejs["common/api/services/mci_api"].mciDelete(window.currentMciId, window.currentNsId),
+    () => webconsolejs["common/api/services/mci_api"].mciDelete(deletingMciId, window.currentNsId),
     "MCI deleted successfully",
     "MCI deletion failed"
   ).then(() => {
@@ -581,8 +585,10 @@ export function deleteMci() {
 
 // vm 삭제
 export function deleteVm() {
+  const deletingVmId = currentVmId;
+  resetDefaultTabSelections();
   executeWithToast(
-    () => webconsolejs["common/api/services/mci_api"].vmDelete(window.currentMciId, window.currentNsId, currentVmId),
+    () => webconsolejs["common/api/services/mci_api"].vmDelete(window.currentMciId, window.currentNsId, deletingVmId),
     "VM deleted successfully",
     "VM deletion failed"
   ).then(() => {
@@ -2156,39 +2162,15 @@ function providerFormatterString(data) {
     btnOk.className = 'btn btn-primary btn-sm ms-3';
     btnOk.textContent = 'Apply';
     btnOk.addEventListener('click', () => {
-      var numVMsToAdd = inputBox.value
+      var numVMsToAdd = parseInt(inputBox.value, 10)
       
       // 로딩 프로그레스 토스트 표시
       webconsolejs["common/utils/toast"].showProgressToast("ScaleOut", "processing");
       
-      // API 호출
-      var response = webconsolejs["common/api/services/mci_api"].postScaleOutSubGroup(window.currentNsId, currentMciId, currentSubGroupId, numVMsToAdd)
-        .then(async response => {
-
-          var mciData = await webconsolejs["common/api/services/mci_api"].getMci(window.currentNsId, currentMciId);
-          refreshRowData(currentMciId, mciData.responseData);
-          const groupTabLink = document.querySelector('a[href="#tabs-mci-group"]');
-          if (groupTabLink) bootstrap.Tab.getOrCreateInstance(groupTabLink).show();
-
-          // 4) 해당 서브그룹 체크 & Scale 폼 열기
-          //    (displayServerGroupStatusList 내부에서 checkbox, currentGroupedVmList 세팅됨)
-          // displayServerGroupStatusList(currentMciId, mciData.responseData);
-          const chk = document.querySelector(`#checkbox_vmGroup_${currentSubGroupId}`);
-          if (chk) {
-            chk.checked = true;
-            // collapse 토글
-            bsCollapse.show();
-            toggleBtn.setAttribute('aria-expanded', 'true');
-          }
-          
-          // API 성공 시 토스트 제거
-          webconsolejs["common/utils/toast"].hideProgressToast();
-        })
-        .catch(error => {
-          console.error('ScaleOut API call failed:', error);
-          // API 실패 시 토스트 제거
-          webconsolejs["common/utils/toast"].hideProgressToast();
-        });
+      // API 호출 (fire-and-forget: tumblebug ScaleOut은 VM 생성 완료까지 수분 소요)
+      webconsolejs["common/api/services/mci_api"].postScaleOutSubGroup(window.currentNsId, currentMciId, currentSubGroupId, numVMsToAdd);
+      webconsolejs["common/utils/toast"].hideProgressToast();
+      alert(`ScaleOut 요청이 접수되었습니다.\nVM 생성이 완료되면 Group 탭을 새로고침하세요.`);
 
     });
     li.appendChild(btnOk);

--- a/front/assets/js/partials/operation/manage/clustercreate.js
+++ b/front/assets/js/partials/operation/manage/clustercreate.js
@@ -336,7 +336,7 @@ async function updateConfigurationFilltering() {
 		$("#cluster_cloudconnection").empty();
 		$("#cluster_cloudconnection").append(html);
 
-		checkAvailableK8sClusterVersion(selectedProvider, selectedRegion);
+		checkAvailableK8sClusterVersion(selectedProvider, regionName);
 	}
 
 }


### PR DESCRIPTION
## Summary

- MCI Group 탭에서 SubGroup이 `undefined`로 표시되는 버그 수정 (`subGroupId` → `nodeGroupId`)
- mc-infra-manager v0.12 API 경로변수/operationId 불일치로 인한 500 오류 수정
- MCI/VM 삭제 후 삭제된 리소스 재조회로 인한 오류 수정

## Changes

| 파일 | 내용 |
|------|------|
| `mci.js` | `groupBySubGroup`, `vmDetailInfo`에서 `subGroupId` → `nodeGroupId`; ScaleOut `numVMsToAdd` parseInt 처리; 삭제 전 선택 상태 즉시 초기화 |
| `mci_api.js` | `vmDelete` pathParam `vmId`→`nodeId`; `postScaleOutSubGroup` pathParam `subgroupId`→`nodegroupId`, async fire-and-forget 전환 |
| `cspimport_api.js` | `DeregisterMciVm` → `DeregisterInfraNode`, pathParam 맞춤 |
| `pmk_api.js` | `Getavailablek8sclusterversion` → `GetAvailableK8sVersion`; `Getavailablek8sclusternodeimage` → `GetAvailableK8sNodeImage` |
| `clustercreate.js` | K8s 버전 조회 시 regionName에서 `[CSP]` 프리픽스 제거 후 전달 |

## Test plan

- [ ] MCI Group 탭 SubGroup 정상 표시 확인
- [ ] ScaleOut 요청 정상 동작 (비동기 fire-and-forget)
- [ ] VM 삭제 정상 동작 (GetInfraNode 500 오류 없음)
- [ ] MCI 삭제 후 Info 패널 즉시 숨김, GetInfra 재조회 없음
- [ ] PMK K8s 버전 목록 정상 조회