### PR TITLE
fix(pmk): PostK8sCluster 400 오류 수정 및 AutoScaling Off 시 min/max 비활성화

### DIFF
--- a/front/assets/js/common/api/services/pmk_api.js
+++ b/front/assets/js/common/api/services/pmk_api.js
@@ -95,7 +95,7 @@ export async function CreateCluster(clusterName, selectedConnection, clusterVers
         maxNodeSize: parseInt(group.maxNodeSize, 10) || 0,
         minNodeSize: parseInt(group.minNodeSize, 10) || 0,
         name: group.name,
-        onAutoScaling: group.onAutoScaling === true || group.onAutoScaling === 'true',
+        onAutoScaling: String(group.onAutoScaling),
         rootDiskType: group.rootDiskType,
         specId: group.specId,
         sshKeyId: group.sshKeyId

--- a/front/assets/js/common/api/services/pmk_api.js
+++ b/front/assets/js/common/api/services/pmk_api.js
@@ -88,25 +88,31 @@ export async function CreateCluster(clusterName, selectedConnection, clusterVers
 
   // NodeGroupList가 있으면 추가 (조건부로 추가)
   if (Create_Cluster_Config_Arr[0].k8sNodeGroupList && Create_Cluster_Config_Arr[0].k8sNodeGroupList.length > 0) {
-    obj['k8sNodeGroupList'] = Create_Cluster_Config_Arr[0].k8sNodeGroupList.map(group => ({
-      desiredNodeSize: group.desiredNodeSize,
-      imageId: group.imageId,
-      maxNodeSize: group.maxNodeSize,
-      minNodeSize: group.minNodeSize,
-      name: group.name,
-      onAutoScaling: group.onAutoScaling,
-      rootDiskSize: group.rootDiskSize,
-      rootDiskType: group.rootDiskType,
-      specId: group.specId,
-      sshKeyId: group.sshKeyId
-    }));
+    obj['k8sNodeGroupList'] = Create_Cluster_Config_Arr[0].k8sNodeGroupList.map(group => {
+      const ng = {
+        desiredNodeSize: parseInt(group.desiredNodeSize, 10) || 0,
+        imageId: group.imageId,
+        maxNodeSize: parseInt(group.maxNodeSize, 10) || 0,
+        minNodeSize: parseInt(group.minNodeSize, 10) || 0,
+        name: group.name,
+        onAutoScaling: group.onAutoScaling === true || group.onAutoScaling === 'true',
+        rootDiskType: group.rootDiskType,
+        specId: group.specId,
+        sshKeyId: group.sshKeyId
+      };
+      const rootDiskSize = parseInt(group.rootDiskSize, 10);
+      if (!isNaN(rootDiskSize) && rootDiskSize > 0) {
+        ng.rootDiskSize = rootDiskSize;
+      }
+      return ng;
+    });
   }
 
   const data = {
     pathParams: {
       "nsId": selectedNsId
     },
-    Request: {
+    request: {
       "connectionName": obj['connectionName'],
       "name": obj['name'],
       "description": obj['description'],

--- a/front/assets/js/pages/operation/manage/pmk.js
+++ b/front/assets/js/pages/operation/manage/pmk.js
@@ -1699,6 +1699,19 @@ export async function deployPmkDynamic() {
                 webconsolejs['common/util'].showToast('Please input NodeGroup name', 'warning');
                 return;
             }
+            // AutoScaling On일 때만 min/max 포함
+            const autoScalingVal = $("#nodegroup_autoscaling_dynamic").val();
+            createData.onAutoScaling = autoScalingVal || "false";
+            if (autoScalingVal === "true") {
+                const minNodeSize = $("#nodegroup_minnodesize_dynamic").val();
+                const maxNodeSize = $("#nodegroup_maxnodesize_dynamic").val();
+                if (!minNodeSize || !maxNodeSize) {
+                    webconsolejs['common/util'].showToast('Min/Max Node Size is required when AutoScaling is On', 'warning');
+                    return;
+                }
+                createData.minNodeSize = parseInt(minNodeSize, 10);
+                createData.maxNodeSize = parseInt(maxNodeSize, 10);
+            }
         }
 
         // available k8sversion 조회        
@@ -1952,6 +1965,16 @@ function setupDesiredNodeSizeButtons() {
     // 기존 이벤트 핸들러 제거
     $(document).off('click', '#nodegroup_configuration_dynamic .input-number-decrement');
     $(document).off('click', '#nodegroup_configuration_dynamic .input-number-increment');
+    $(document).off('change', '#nodegroup_autoscaling_dynamic');
+
+    // AutoScaling 변경 시 min/max 활성화 제어
+    $(document).on('change', '#nodegroup_autoscaling_dynamic', function () {
+        if ($(this).val() === 'true') {
+            $('#nodegroup_minnodesize_dynamic, #nodegroup_maxnodesize_dynamic').prop('disabled', false);
+        } else {
+            $('#nodegroup_minnodesize_dynamic, #nodegroup_maxnodesize_dynamic').val('').prop('disabled', true);
+        }
+    });
 
     // 새로운 이벤트 핸들러 등록
     $(document).on('click', '#nodegroup_configuration_dynamic .input-number-decrement', function (e) {

--- a/front/assets/js/partials/operation/manage/clustercreate.js
+++ b/front/assets/js/partials/operation/manage/clustercreate.js
@@ -18,6 +18,7 @@ function setupDesiredNodeSizeButtons() {
 	// 기존 이벤트 핸들러 제거 (중복 방지)
 	$(document).off('click', '#nodegroup_configuration .input-number-decrement');
 	$(document).off('click', '#nodegroup_configuration .input-number-increment');
+	$(document).off('change', '#node_autoscaling');
 	$(document).off('change', '#node_minnodesize');
 	$(document).off('change', '#node_maxnodesize');
 
@@ -48,6 +49,16 @@ function setupDesiredNodeSizeButtons() {
 		// maxNodeSize 이하로 유지
 		if (currentValue < maxNodeSize) {
 			input.val(currentValue + 1);
+		}
+	});
+
+	// AutoScaling 변경 시 min/max 활성화 제어
+	$(document).on('change', '#node_autoscaling', function () {
+		const val = $(this).val();
+		if (val === 'true') {
+			$('#node_minnodesize, #node_maxnodesize').prop('disabled', false);
+		} else {
+			$('#node_minnodesize, #node_maxnodesize').val('').prop('disabled', true);
 		}
 	});
 
@@ -810,15 +821,18 @@ export async function createCluster() {
 // }
 export function clusterFormDone_btn() {
 	// 1. 필수 필드 검증
+	const isAutoScalingOn = $('#node_autoscaling').val() === 'true';
 	var requiredFields = [
 		{ id: '#node_name', message: 'NodeGroup name is required' },
 		{ id: '#node_specid', message: 'Spec is required' },
 		{ id: '#node_imageid', message: 'Image is required' },
-		{ id: '#node_minnodesize', message: 'Min Node Size is required' },
-		{ id: '#node_maxnodesize', message: 'Max Node Size is required' },
 		{ id: '#node_sshkey', message: 'SSH Key is required' },
 		{ id: '#node_autoscaling', message: 'AutoScaling option is required' }
 	];
+	if (isAutoScalingOn) {
+		requiredFields.push({ id: '#node_minnodesize', message: 'Min Node Size is required' });
+		requiredFields.push({ id: '#node_maxnodesize', message: 'Max Node Size is required' });
+	}
 	
 	for (var field of requiredFields) {
 		if (!$(field.id).val() || $(field.id).val().trim() === '') {
@@ -876,8 +890,6 @@ export function clusterFormDone_btn() {
     var nodeGroupData = {
         "desiredNodeSize": desiredNodeSize || "",
         "imageId": imageId || "",
-        "maxNodeSize": maxNodeSize || "",
-        "minNodeSize": minNodeSize || "",
         "name": nodeGroupName,
         "onAutoScaling": onAutoScaling || "false",
         "rootDiskSize": rootDiskSize || "",
@@ -885,6 +897,11 @@ export function clusterFormDone_btn() {
         "specId": specId || "",
         "sshKeyId": sshKeyId || ""
     };
+    // AutoScaling On일 때만 min/max 포함
+    if (onAutoScaling === "true") {
+        nodeGroupData["maxNodeSize"] = maxNodeSize || "";
+        nodeGroupData["minNodeSize"] = minNodeSize || "";
+    }
 
     if (nodeGroupName) {
         cluster_form["k8sNodeGroupList"] = [nodeGroupData];
@@ -1062,12 +1079,18 @@ export function view_ngForm(cnt){
 		$("#node_specid").val(nodeGroupData.specId || "");
 		$("#node_commonSpecId").val(nodeGroupData.specId || "");
 		$("#node_imageid").val(nodeGroupData.imageId || "");
-		$("#node_minnodesize").val(nodeGroupData.minNodeSize || "");
-		$("#node_maxnodesize").val(nodeGroupData.maxNodeSize || "");
+		const editAutoScalingOn = (nodeGroupData.onAutoScaling || "false") === "true";
+		$("#node_autoscaling").val(nodeGroupData.onAutoScaling || "false");
+		if (editAutoScalingOn) {
+			$('#node_minnodesize, #node_maxnodesize').prop('disabled', false);
+			$("#node_minnodesize").val(nodeGroupData.minNodeSize || "");
+			$("#node_maxnodesize").val(nodeGroupData.maxNodeSize || "");
+		} else {
+			$('#node_minnodesize, #node_maxnodesize').val('').prop('disabled', true);
+		}
 		$("#node_sshkey").val(nodeGroupData.sshKeyId || "");
 		$("#node_rootdisk").val(nodeGroupData.rootDiskType || "");
 		$("#node_rootdisksize").val(nodeGroupData.rootDiskSize || "");
-		$("#node_autoscaling").val(nodeGroupData.onAutoScaling || "false");
 		$("#node_desirednodesize").val(nodeGroupData.desiredNodeSize || "1");
 		
 		// Hidden 필드에도 설정

--- a/front/templates/pages/operations/manage/workloads/pmkworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/pmkworkloads.html
@@ -580,6 +580,7 @@
                         class="form-select"
                         name="nodegroup-minnodesize-dynamic"
                         id="nodegroup_minnodesize_dynamic"
+                        disabled
                       >
                         <option value="">Min</option>
                         <option value="1">1</option>
@@ -594,6 +595,7 @@
                         class="form-select"
                         name="nodegroup-maxnodesize-dynamic"
                         id="nodegroup_maxnodesize_dynamic"
+                        disabled
                       >
                         <option value="">Max</option>
                         <option value="1">1</option>

--- a/front/templates/partials/operation/manage/_clustercreate.html
+++ b/front/templates/partials/operation/manage/_clustercreate.html
@@ -152,6 +152,7 @@
                       class="form-select"
                       name="node-minnodesize"
                       id="node_minnodesize"
+                      disabled
                     >
                       <option value="">Min</option>
                       <option value="1">1</option>
@@ -166,6 +167,7 @@
                       class="form-select"
                       name="node_maxnodesize"
                       id="node_maxnodesize"
+                      disabled
                     >
                       <option value="">Max</option>
                       <option value="1">1</option>


### PR DESCRIPTION
## Summary

- `k8sNodeGroupList` 필드 타입 오류로 인한 PostK8sCluster 400 수정 (`desiredNodeSize`/`maxNodeSize`/`minNodeSize` string → int, `onAutoScaling` string 유지)
- AutoScaling Off 시 `minNodeSize`/`maxNodeSize`를 UI에서 비활성화하고 전송 시 제외 (NCP 500 방지)
- Expert Creation 폼 및 Dynamic 폼 모두 적용

## Changes

- `pmk_api.js`: nodeGroup 필드 타입 변환 (parseInt) 및 request 키 소문자 수정
- `clustercreate.js`: AutoScaling change 이벤트 추가, nodeGroupData 구성 시 Off이면 min/max 제외, validation 조건부 처리
- `_clustercreate.html`: node_minnodesize / node_maxnodesize 초기 disabled
- `pmk.js`: Dynamic 폼 AutoScaling change 이벤트 추가, deployPmkDynamic에서 On일 때만 min/max 전송
- `pmkworkloads.html`: nodegroup_minnodesize_dynamic / nodegroup_maxnodesize_dynamic 초기 disabled