### PR TITLE
fix(pmk): Expert Creation Node Group Spec 팝업 Provider 미전달 버그 수정

### DIFF
--- a/front/assets/js/partials/operation/manage/pmk_serverrecommendation.js
+++ b/front/assets/js/partials/operation/manage/pmk_serverrecommendation.js
@@ -18,7 +18,9 @@ export function initServerRecommendationPmk(callbackfunction) {
 	const modalEl = document.getElementById('spec-search-pmk');
 	if (modalEl) {
 		modalEl.addEventListener('shown.bs.modal', function () {
-			const provider = document.getElementById('cluster_provider_dynamic')?.value || '';
+			const provider = document.getElementById('cluster_provider_dynamic')?.value
+				|| document.getElementById('cluster_provider')?.value
+				|| '';
 			const badge = document.getElementById('spec-provider-badge-pmk');
 			const hidden = document.getElementById('spec-provider-value-pmk');
 			if (badge) badge.textContent = provider;


### PR DESCRIPTION
## Summary

- Expert Creation 모드에서 Node Group의 Spec Recommendation 팝업을 열 때 Cloud Provider 체크박스가 표시되지 않는 버그 수정

## Root Cause

`pmk_serverrecommendation.js`의 `shown.bs.modal` 핸들러에서 provider를 `#cluster_provider_dynamic`(Dynamic 모드 필드)만 읽음. Expert Creation 모드의 provider 필드는 `#cluster_provider`이므로 빈 값이 전달되어 필터 미적용.

## Fix

`#cluster_provider_dynamic` 조회 실패 시 `#cluster_provider`를 fallback으로 읽도록 수정.