### PR TITLE
fix(pmk): Expert Creation Node Group Spec 팝업 Provider filter 표시 수정

### DIFF
--- a/front/assets/js/partials/operation/manage/pmk_serverrecommendation.js
+++ b/front/assets/js/partials/operation/manage/pmk_serverrecommendation.js
@@ -18,7 +18,9 @@ export function initServerRecommendationPmk(callbackfunction) {
 	const modalEl = document.getElementById('spec-search-pmk');
 	if (modalEl) {
 		modalEl.addEventListener('shown.bs.modal', function () {
-			const provider = document.getElementById('cluster_provider_dynamic')?.value || '';
+			const provider = document.getElementById('cluster_provider_dynamic')?.value
+				|| document.getElementById('cluster_provider')?.value
+				|| '';
 			const badge = document.getElementById('spec-provider-badge-pmk');
 			const hidden = document.getElementById('spec-provider-value-pmk');
 			if (badge) badge.textContent = provider;


### PR DESCRIPTION
## Summary

- Expert Creation 모드에서 Node Group의 Spec Recommendation 팝업을 열 때 Cloud Provider 체크박스가 표시
