### PR TITLE
fix: align PMK NodeGroup dynamic request with K8s NodeGroup schema

### DIFF
--- a/front/assets/js/common/api/services/pmk_api.js
+++ b/front/assets/js/common/api/services/pmk_api.js
@@ -265,30 +265,36 @@ export async function vmDynamic(pmkId, nsId, Express_Server_Config_Arr) {
 
   var obj = {}
   obj = Express_Server_Config_Arr[0]
+
+  var desiredNodeSize = parseInt(obj.desiredNodeSize || obj.subGroupSize) || 1
+
+  // K8sNodeGroupDynamicReq: specId/imageId 필수, 노드 수는 desired/min/maxNodeSize 체계
   const data = {
     pathParams: {
       nsId: nsId,
-      pmkId: pmkId,
+      k8sClusterId: pmkId,
     },
     request: {
-      "commonImage": obj.commonImage,
-      "commonSpec": obj.commonSpec,
-      "connectionName": obj.connectionName,
-      "description": obj.description,
-      // "label": "",
       "name": obj.name,
-      "subGroupSize": obj.subGroupSize,
-      "rootDiskSize": obj.rootDiskSize,
-      "rootDiskType": obj.rootDiskType,
+      "description": obj.description,
+      "specId": obj.specId || obj.commonSpec,
+      "imageId": obj.imageId || obj.commonImage,
+      "desiredNodeSize": desiredNodeSize,
+      "minNodeSize": parseInt(obj.minNodeSize) || desiredNodeSize,
+      "maxNodeSize": parseInt(obj.maxNodeSize) || desiredNodeSize,
+      "onAutoScaling": obj.onAutoScaling || "false",
+      "rootDiskSize": parseInt(obj.rootDiskSize) || 0,
+      "rootDiskType": obj.rootDiskType || "",
     }
   }
 
-
-  var controller = "/api/" + "PostPmkVmDynamic";
+  var controller = "/api/" + "mc-infra-manager/" + "PostK8sNodeGroupDynamic";
   const response = await webconsolejs["common/api/http"].commonAPIPost(
     controller,
     data
   )
+
+  return response
 }
 
 // export async function pmkRecommendVm(data) {


### PR DESCRIPTION
## 변경 요약
- `pmk_api.js` `vmDynamic()`을 cb-tumblebug K8s NodeGroup 동적 생성 스키마(`K8sNodeGroupDynamicReq`)에 맞게 재작성
- 존재하지 않는 operationId(`PostPmkVmDynamic`) → `mc-infra-manager/PostK8sNodeGroupDynamic`으로 정정
- `subGroupSize`/`commonSpec`/`commonImage` → `desiredNodeSize`(+min/max)/`specId`/`imageId`, pathParams `pmkId` → `k8sClusterId`

## 테스트 결과
| Gate | 결과 |
|---|---|
| frontend go vet / go test | PASS |
| frontend bundle (webpack production build) | PASS |
| secret scan (develop 대비 diff) | PASS |
| deps audit | SKIP — 의존성 변경 없음 |

- UI 제출 경로는 기존 `createNode()`(`Postk8snodegroup`) 그대로 유지 — 화면 동작 변경 없음 (재작성 함수는 현재 export만, 호출부 없음)

## Breaking Change
- [x] 없음

## 체크리스트
- [x] gate 전체 통과 (변경 모듈)
- [x] 머지 타겟이 develop
- [x] 관련 문서 업데이트 (해당 시)
