### PR TITLE
fix(mci): Spec Recommendation 테이블 Region 잘림·가로 스크롤·표시 항목 보완

### DIFF
--- a/front/assets/js/partials/operation/manage/clusterrecommendation.js
+++ b/front/assets/js/partials/operation/manage/clusterrecommendation.js
@@ -25,8 +25,20 @@ export function initClusterRecommendation(callbackfunction) {
 	}
 }
 
+// 값이 없거나 0/-1인 숫자 필드는 "-"로 표시
+function dashIfEmpty(cell) {
+	var v = cell.getValue();
+	if (v === undefined || v === null || v === "" || v === 0 || v === -1) {
+		return "-";
+	}
+	return v;
+}
+
 function initRecommendSpecTable() {
-	var tableObjParams = {};
+	// MCI용(serverrecommendation.js)과 동일 — fitColumns는 가로 스크롤이 생기지 않아 fitData로 전환
+	var tableObjParams = {
+		layout: "fitData",
+	};
 
 	var columns = [
 		{
@@ -45,12 +57,6 @@ function initRecommendSpecTable() {
 			visible: false
 		},
 		{
-			title: "EVALUATIONSCORE",
-			field: "evaluationScore10",
-			headerSort: false,
-			visible: false
-		},
-		{
 			title: "PROVIDER",
 			field: "providerName",
 			vertAlign: "middle",
@@ -62,7 +68,8 @@ function initRecommendSpecTable() {
 		{
 			title: "REGION",
 			field: "regionName",
-			vertAlign: "middle"
+			vertAlign: "middle",
+			minWidth: 140,
 		},
 		{
 			title: "PRICE",
@@ -84,6 +91,73 @@ function initRecommendSpecTable() {
 			hozAlign: "center",
 			headerHozAlign: "center",
 			maxWidth: 135,
+		},
+		{
+			title: "ARCHITECTURE",
+			field: "architecture",
+			vertAlign: "middle",
+			hozAlign: "center",
+			formatter: dashIfEmpty,
+		},
+		{
+			title: "DISK (GB)",
+			field: "diskSizeGB",
+			vertAlign: "middle",
+			hozAlign: "center",
+			formatter: dashIfEmpty,
+		},
+		{
+			title: "ROOT DISK",
+			field: "rootDiskType",
+			vertAlign: "middle",
+			hozAlign: "center",
+			formatter: function (cell) {
+				var row = cell.getRow().getData();
+				var type = row.rootDiskType;
+				var size = row.rootDiskSize;
+				if (!type && (!size || size <= 0)) {
+					return "-";
+				}
+				if (size && size > 0) {
+					return (type ? type + " " : "") + size + " GB";
+				}
+				return type;
+			},
+		},
+		{
+			title: "NET BW (Gbps)",
+			field: "netBwGbps",
+			vertAlign: "middle",
+			hozAlign: "center",
+			formatter: dashIfEmpty,
+		},
+		{
+			title: "GPU",
+			field: "acceleratorModel",
+			vertAlign: "middle",
+			hozAlign: "center",
+			formatter: function (cell) {
+				var row = cell.getRow().getData();
+				var model = row.acceleratorModel;
+				if (!model || model === "NA" || row.acceleratorType === "") {
+					return "-";
+				}
+				var count = row.acceleratorCount;
+				return count && count > 1 ? model + " x" + count : model;
+			},
+		},
+		{
+			title: "GPU MEM (GB)",
+			field: "acceleratorMemoryGB",
+			vertAlign: "middle",
+			hozAlign: "center",
+			formatter: dashIfEmpty,
+		},
+		{
+			title: "SCORE",
+			field: "evaluationScore10",
+			vertAlign: "middle",
+			hozAlign: "center",
 		}
 	];
 

--- a/front/assets/js/partials/operation/manage/pmk_serverrecommendation.js
+++ b/front/assets/js/partials/operation/manage/pmk_serverrecommendation.js
@@ -30,8 +30,20 @@ export function initServerRecommendationPmk(callbackfunction) {
 	}
 }
 
+// 값이 없거나 0/-1인 숫자 필드는 "-"로 표시
+function dashIfEmpty(cell) {
+	var v = cell.getValue();
+	if (v === undefined || v === null || v === "" || v === 0 || v === -1) {
+		return "-";
+	}
+	return v;
+}
+
 function initRecommendSpecTablePmk() {
-	var tableObjParams = {}; // MCI용과 동일하게 빈 객체 사용
+	// MCI용(serverrecommendation.js)과 동일 — fitColumns는 가로 스크롤이 생기지 않아 fitData로 전환
+	var tableObjParams = {
+		layout: "fitData",
+	};
 
 	var columns = [
 		{
@@ -50,12 +62,6 @@ function initRecommendSpecTablePmk() {
 			visible: false
 		},
 		{
-			title: "EVALUATIONSCORE",
-			field: "evaluationScore10",
-			headerSort: false,
-			visible: false
-		},
-		{
 			title: "PROVIDER",
 			field: "providerName",
 			vertAlign: "middle",
@@ -67,7 +73,8 @@ function initRecommendSpecTablePmk() {
 	{
 		title: "REGION",
 		field: "regionName",
-		vertAlign: "middle"
+		vertAlign: "middle",
+		minWidth: 140,
 	},
 	{
 		title: "SPEC NAME",
@@ -98,6 +105,73 @@ function initRecommendSpecTablePmk() {
 		hozAlign: "center",
 		headerHozAlign: "center",
 		maxWidth: 80,
+	},
+	{
+		title: "ARCHITECTURE",
+		field: "architecture",
+		vertAlign: "middle",
+		hozAlign: "center",
+		formatter: dashIfEmpty,
+	},
+	{
+		title: "DISK (GB)",
+		field: "diskSizeGB",
+		vertAlign: "middle",
+		hozAlign: "center",
+		formatter: dashIfEmpty,
+	},
+	{
+		title: "ROOT DISK",
+		field: "rootDiskType",
+		vertAlign: "middle",
+		hozAlign: "center",
+		formatter: function (cell) {
+			var row = cell.getRow().getData();
+			var type = row.rootDiskType;
+			var size = row.rootDiskSize;
+			if (!type && (!size || size <= 0)) {
+				return "-";
+			}
+			if (size && size > 0) {
+				return (type ? type + " " : "") + size + " GB";
+			}
+			return type;
+		},
+	},
+	{
+		title: "NET BW (Gbps)",
+		field: "netBwGbps",
+		vertAlign: "middle",
+		hozAlign: "center",
+		formatter: dashIfEmpty,
+	},
+	{
+		title: "GPU",
+		field: "acceleratorModel",
+		vertAlign: "middle",
+		hozAlign: "center",
+		formatter: function (cell) {
+			var row = cell.getRow().getData();
+			var model = row.acceleratorModel;
+			if (!model || model === "NA" || row.acceleratorType === "") {
+				return "-";
+			}
+			var count = row.acceleratorCount;
+			return count && count > 1 ? model + " x" + count : model;
+		},
+	},
+	{
+		title: "GPU MEM (GB)",
+		field: "acceleratorMemoryGB",
+		vertAlign: "middle",
+		hozAlign: "center",
+		formatter: dashIfEmpty,
+	},
+	{
+		title: "SCORE",
+		field: "evaluationScore10",
+		vertAlign: "middle",
+		hozAlign: "center",
 	}
 	];
 

--- a/front/assets/js/partials/operation/manage/serverrecommendation.js
+++ b/front/assets/js/partials/operation/manage/serverrecommendation.js
@@ -25,8 +25,20 @@ export function initServerRecommendation(callbackfunction) {
 	}
 }
 
+// 값이 없거나 0/-1인 숫자 필드는 "-"로 표시
+function dashIfEmpty(cell) {
+	var v = cell.getValue();
+	if (v === undefined || v === null || v === "" || v === 0 || v === -1) {
+		return "-";
+	}
+	return v;
+}
+
 function initRecommendSpecTable() {
-	var tableObjParams = {};
+	// fitColumns는 전체 칼럼을 컨테이너 폭에 압축해 가로 스크롤이 생기지 않음 → fitData로 전환
+	var tableObjParams = {
+		layout: "fitData",
+	};
 
 	var columns = [
 		{
@@ -45,12 +57,6 @@ function initRecommendSpecTable() {
 			visible: false
 		},
 		{
-			title: "EVALUATIONSCORE",
-			field: "evaluationScore10",
-			headerSort: false,
-			visible: false
-		},
-		{
 			title: "PROVIDER",
 			field: "providerName",
 			vertAlign: "middle",
@@ -62,7 +68,8 @@ function initRecommendSpecTable() {
 	{
 		title: "REGION",
 		field: "regionName",
-		vertAlign: "middle"
+		vertAlign: "middle",
+		minWidth: 140,
 	},
 	{
 		title: "SPEC NAME",
@@ -93,6 +100,73 @@ function initRecommendSpecTable() {
 		hozAlign: "center",
 		headerHozAlign: "center",
 		maxWidth: 80,
+	},
+	{
+		title: "ARCHITECTURE",
+		field: "architecture",
+		vertAlign: "middle",
+		hozAlign: "center",
+		formatter: dashIfEmpty,
+	},
+	{
+		title: "DISK (GB)",
+		field: "diskSizeGB",
+		vertAlign: "middle",
+		hozAlign: "center",
+		formatter: dashIfEmpty,
+	},
+	{
+		title: "ROOT DISK",
+		field: "rootDiskType",
+		vertAlign: "middle",
+		hozAlign: "center",
+		formatter: function (cell) {
+			var row = cell.getRow().getData();
+			var type = row.rootDiskType;
+			var size = row.rootDiskSize;
+			if (!type && (!size || size <= 0)) {
+				return "-";
+			}
+			if (size && size > 0) {
+				return (type ? type + " " : "") + size + " GB";
+			}
+			return type;
+		},
+	},
+	{
+		title: "NET BW (Gbps)",
+		field: "netBwGbps",
+		vertAlign: "middle",
+		hozAlign: "center",
+		formatter: dashIfEmpty,
+	},
+	{
+		title: "GPU",
+		field: "acceleratorModel",
+		vertAlign: "middle",
+		hozAlign: "center",
+		formatter: function (cell) {
+			var row = cell.getRow().getData();
+			var model = row.acceleratorModel;
+			if (!model || model === "NA" || row.acceleratorType === "") {
+				return "-";
+			}
+			var count = row.acceleratorCount;
+			return count && count > 1 ? model + " x" + count : model;
+		},
+	},
+	{
+		title: "GPU MEM (GB)",
+		field: "acceleratorMemoryGB",
+		vertAlign: "middle",
+		hozAlign: "center",
+		formatter: dashIfEmpty,
+	},
+	{
+		title: "SCORE",
+		field: "evaluationScore10",
+		vertAlign: "middle",
+		hozAlign: "center",
 	}
 	];
 


### PR DESCRIPTION
## Summary
- Spec Recommendation(자원추천) 조회 결과 테이블에서 Region 칼럼이 좁아 `asia-northeast2` 수준 리전명이 잘려 보이는 문제 수정 — REGION `minWidth: 140`
- Tabulator 기본 `layout: "fitColumns"`(전체 칼럼을 컨테이너 폭에 압축, 가로 스크롤 불가)을 `fitData`로 전환하여 테이블 가로 스크롤 지원
- API 응답에 이미 포함된 스펙 상세 필드를 칼럼으로 추가: ARCHITECTURE / DISK (GB) / ROOT DISK / NET BW (Gbps) / GPU / GPU MEM (GB) / SCORE(기존 hidden 칼럼 노출 전환) — 값 없는 필드는 "-" 표시, API 변경 없음
- **PMK 화면의 동일 구조 스펙 추천 팝업 2종(클러스터 생성·NodeGroup 추가)에도 같은 처리 확대 적용** — 두 팝업 모두 동일한 RecommendSpec 응답 사용

## 변경 파일
- `front/assets/js/partials/operation/manage/serverrecommendation.js` — MCI Spec Recommendation
- `front/assets/js/partials/operation/manage/clusterrecommendation.js` — PMK 클러스터 생성 스펙 추천
- `front/assets/js/partials/operation/manage/pmk_serverrecommendation.js` — PMK NodeGroup 스펙 추천
