### PR TITLE
feat(mci): Infra Template 관리 화면 및 template 기반 MCI 생성 기능 추가

### DIFF
--- a/front/assets/js/common/api/services/infratemplate_api.js
+++ b/front/assets/js/common/api/services/infratemplate_api.js
@@ -51,14 +51,15 @@ export async function deleteAll(ns) {
 }
 
 // 저장된 template 형상 그대로 MCI 생성 (name/description override만 전달)
-export async function deployFromTemplate(ns, templateId, applyReq, option) {
+// options는 commonAPIPost의 loader 옵션 ({ loaderType, progressLabel } 등)
+export async function deployFromTemplate(ns, templateId, applyReq, option, options) {
   const controller = '/api/mc-infra-manager/PostInfraDynamicFromTemplate';
   const params = {
     pathParams: { nsId: ns, templateId },
     request: applyReq
   };
   if (option) params.queryParams = { option };
-  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, params);
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, params, undefined, options);
   return response;
 }
 

--- a/front/assets/js/common/api/services/infratemplate_api.js
+++ b/front/assets/js/common/api/services/infratemplate_api.js
@@ -1,0 +1,74 @@
+// Infra Dynamic Template API 서비스 (mc-infra-manager → cb-tumblebug)
+
+export async function list(ns, filterKeyword) {
+  const controller = '/api/mc-infra-manager/GetAllInfraDynamicTemplate';
+  const params = { pathParams: { nsId: ns } };
+  if (filterKeyword) params.queryParams = { filterKeyword };
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, params);
+  return response?.data?.responseData;
+}
+
+export async function get(ns, templateId) {
+  const controller = '/api/mc-infra-manager/GetInfraDynamicTemplate';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId: ns, templateId }
+  });
+  return response?.data?.responseData;
+}
+
+export async function create(ns, body) {
+  const controller = '/api/mc-infra-manager/PostInfraDynamicTemplate';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId: ns },
+    request: body
+  });
+  return response?.data?.responseData;
+}
+
+export async function update(ns, templateId, body) {
+  const controller = '/api/mc-infra-manager/PutInfraDynamicTemplate';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId: ns, templateId },
+    request: body
+  });
+  return response?.data?.responseData;
+}
+
+export async function del(ns, templateId) {
+  const controller = '/api/mc-infra-manager/DeleteInfraDynamicTemplate';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId: ns, templateId }
+  });
+  return response?.data;
+}
+
+export async function deleteAll(ns) {
+  const controller = '/api/mc-infra-manager/DeleteAllInfraDynamicTemplate';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId: ns }
+  });
+  return response?.data;
+}
+
+// 저장된 template 형상 그대로 MCI 생성 (name/description override만 전달)
+export async function deployFromTemplate(ns, templateId, applyReq, option) {
+  const controller = '/api/mc-infra-manager/PostInfraDynamicFromTemplate';
+  const params = {
+    pathParams: { nsId: ns, templateId },
+    request: applyReq
+  };
+  if (option) params.queryParams = { option };
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, params);
+  return response;
+}
+
+// 기존 MCI에서 InfraDynamicReq 형상 추출 (configCopy)
+// 응답은 InfraDynamicReq 객체 그대로 반환됨 (swagger의 "[DEFAULT]" 래핑은 실응답에 없음)
+export async function getInfraReqFromInfra(ns, infraId) {
+  const controller = '/api/mc-infra-manager/GetInfraReqFromInfra';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId: ns, infraId }
+  });
+  const data = response?.data?.responseData;
+  return data?.['[DEFAULT]'] ?? data;
+}

--- a/front/assets/js/pages/operation/manage/mci.js
+++ b/front/assets/js/pages/operation/manage/mci.js
@@ -3631,3 +3631,42 @@ function clearLabelFilter() {
     mciListTable.setData(Object.values(window.totalMciListObj));
   }
 }
+// ─── MCI를 Infra Template으로 저장 ────────────────────────────────────────
+
+export function openSaveAsTemplateModal() {
+  if (window.currentMciId == undefined || window.currentMciId == "") {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Validation', 'Please select an MCI first')
+    return;
+  }
+  document.getElementById('save-template-name').value = `${window.currentMciId}-template`;
+  document.getElementById('save-template-desc').value = '';
+  new bootstrap.Modal(document.getElementById('save-as-template-modal')).show();
+}
+
+export async function executeSaveAsTemplate() {
+  const mciId = window.currentMciId;
+  const nsId = window.currentNsId;
+  if (mciId == undefined || mciId == "") {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Validation', 'Please select an MCI first')
+    return;
+  }
+  const name = document.getElementById('save-template-name').value.trim();
+  if (!name) {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Validation', 'Template name is required')
+    return;
+  }
+  const description = document.getElementById('save-template-desc').value.trim();
+
+  executeWithToast(
+    async () => {
+      const infraDynamicReq = await webconsolejs["common/api/services/infratemplate_api"].getInfraReqFromInfra(nsId, mciId);
+      const body = { name, infraDynamicReq };
+      if (description) body.description = description;
+      return webconsolejs["common/api/services/infratemplate_api"].create(nsId, body);
+    },
+    "Template saved",
+    "Failed to save template"
+  ).then(() => {
+    bootstrap.Modal.getInstance(document.getElementById('save-as-template-modal'))?.hide();
+  }).catch(() => {});
+}

--- a/front/assets/js/pages/operations/manage/workloads/infratemplates.js
+++ b/front/assets/js/pages/operations/manage/workloads/infratemplates.js
@@ -1,0 +1,341 @@
+import { TabulatorFull as Tabulator } from "tabulator-tables";
+
+const AppState = {
+  resources: { list: [], selected: null },
+  ui: { viewMode: false },
+  tables: { resourceTable: null },
+  ns: ''
+};
+
+// project 변경 시 목록 재조회
+$('#select-current-project').on('change', async function () {
+  if (this.value === '') return;
+  const project = { Id: this.value, Name: this.options[this.selectedIndex].text, NsId: this.options[this.selectedIndex].text };
+  webconsolejs['common/api/services/workspace_api'].setCurrentProject(project);
+  AppState.ns = project.NsId;
+  hideDetail();
+  await loadList();
+  await loadInfraList();
+});
+
+async function loadList() {
+  const ns = AppState.ns;
+  if (!ns) return;
+  try {
+    const data = await webconsolejs['common/api/services/infratemplate_api'].list(ns);
+    const items = data?.templates || [];
+    AppState.resources.list = items;
+    if (AppState.tables.resourceTable) {
+      AppState.tables.resourceTable.replaceData(items);
+    } else {
+      initTable(items);
+    }
+  } catch (e) {
+    if (e?.response?.status !== 404) console.error('Failed to load infra templates', e);
+    AppState.resources.list = [];
+    if (AppState.tables.resourceTable) AppState.tables.resourceTable.replaceData([]);
+    else initTable([]);
+  }
+}
+
+function nodeGroupSummary(infraDynamicReq) {
+  const groups = infraDynamicReq?.nodeGroups || [];
+  const total = groups.reduce((sum, g) => sum + (Number(g.nodeGroupSize) || 0), 0);
+  return `${groups.length} group(s) / ${total} node(s)`;
+}
+
+function initTable(data) {
+  AppState.tables.resourceTable = new Tabulator('#template-table', {
+    data: data,
+    layout: 'fitColumns',
+    placeholder: 'No infra templates found.',
+    columns: [
+      { title: 'Name', field: 'name', sorter: 'string' },
+      { title: 'Description', field: 'description', sorter: 'string' },
+      {
+        title: 'NodeGroups', field: 'infraDynamicReq', headerSort: false,
+        formatter: function (cell) {
+          return nodeGroupSummary(cell.getValue());
+        }
+      },
+      {
+        title: 'Source', field: 'source', sorter: 'string', width: 100,
+        formatter: function (cell) {
+          const v = cell.getValue();
+          return v ? '<span class="badge bg-blue-lt">' + v + '</span>' : '-';
+        }
+      },
+      { title: 'Created', field: 'createdAt', sorter: 'string', width: 180 },
+      { title: 'Updated', field: 'updatedAt', sorter: 'string', width: 180 }
+    ]
+  });
+
+  AppState.tables.resourceTable.on('rowClick', function (e, row) {
+    const rowData = row.getData();
+    AppState.resources.selected = rowData;
+    renderDetail(rowData);
+    showDetail();
+  });
+}
+
+function renderDetail(data) {
+  document.getElementById('detail-name').textContent = data.name || '-';
+  document.getElementById('detail-id').textContent = data.id || '-';
+  document.getElementById('detail-description').textContent = data.description || '-';
+  document.getElementById('detail-source').textContent = data.source || '-';
+  document.getElementById('detail-resourceType').textContent = data.resourceType || '-';
+  document.getElementById('detail-createdAt').textContent = data.createdAt || '-';
+  document.getElementById('detail-updatedAt').textContent = data.updatedAt || '-';
+
+  const req = data.infraDynamicReq || {};
+
+  const tbody = document.getElementById('detail-nodegroup-rows');
+  tbody.innerHTML = '';
+  const groups = req.nodeGroups || [];
+  if (groups.length === 0) {
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = 7;
+    td.className = 'text-muted';
+    td.textContent = '-';
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+  } else {
+    groups.forEach(g => {
+      const tr = document.createElement('tr');
+      const rootDisk = [g.rootDiskType, g.rootDiskSize].filter(v => v !== undefined && v !== '' && v !== 0).join(' / ');
+      [g.name, g.specId, g.imageId, g.nodeGroupSize, g.connectionName, rootDisk, g.zone].forEach(val => {
+        const td = document.createElement('td');
+        td.textContent = (val === undefined || val === null || val === '') ? '-' : String(val);
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+    });
+  }
+
+  const commands = req.postCommand?.command || [];
+  document.getElementById('detail-postCommand').textContent = commands.length ? commands.join('\n') : '-';
+
+  document.getElementById('detail-raw-json').textContent = JSON.stringify(req, null, 2);
+}
+
+function showDetail() {
+  const el = document.getElementById('view-mode-cards');
+  if (el) el.classList.add('show');
+  AppState.ui.viewMode = true;
+}
+
+window.hideDetail = function () {
+  const el = document.getElementById('view-mode-cards');
+  if (el) el.classList.remove('show');
+  AppState.ui.viewMode = false;
+  AppState.resources.selected = null;
+};
+
+// ─── MCI List (From-MCI mode) ──────────────────────────────────────────
+
+async function loadInfraList() {
+  const ns = AppState.ns;
+  if (!ns) return;
+  try {
+    const resp = await webconsolejs['common/api/http'].commonAPIPost('/api/mc-infra-manager/GetAllInfra', {
+      pathParams: { nsId: ns },
+      queryParams: { option: 'id' }
+    });
+    const ids = resp?.data?.responseData?.output || [];
+    const sel = document.getElementById('create-mci-select');
+    if (!sel) return;
+    while (sel.options.length > 1) sel.remove(1);
+    ids.forEach(id => {
+      const opt = document.createElement('option');
+      opt.value = id;
+      opt.textContent = id;
+      sel.appendChild(opt);
+    });
+  } catch (e) {
+    console.error('Failed to load MCI list', e);
+  }
+}
+
+// ─── Create / Edit Modal ───────────────────────────────────────────────
+
+window.onCreateModeChange = function (mode) {
+  document.getElementById('create-frommci-fields').style.display = mode === 'mci' ? '' : 'none';
+};
+
+window.extractFromMci = async function () {
+  const ns = AppState.ns;
+  const infraId = document.getElementById('create-mci-select').value;
+  if (!ns) { webconsolejs['common/util'].showToast('Please select a project first.', 'error'); return; }
+  if (!infraId) { webconsolejs['common/util'].showToast('Please select an MCI.', 'error'); return; }
+  try {
+    const req = await webconsolejs['common/api/services/infratemplate_api'].getInfraReqFromInfra(ns, infraId);
+    document.getElementById('create-json').value = JSON.stringify(req, null, 2);
+  } catch (e) {
+    webconsolejs['common/util'].showToast('Failed to extract: ' + (e?.response?.data?.message || e.message), 'error');
+  }
+};
+
+function parseJsonInput(elementId) {
+  const raw = document.getElementById(elementId).value.trim();
+  if (!raw) throw new Error('Infra Request JSON is empty');
+  return JSON.parse(raw);
+}
+
+window.submitCreate = async function () {
+  const ns = AppState.ns;
+  if (!ns) { webconsolejs['common/util'].showToast('Please select a project first.', 'error'); return; }
+  const name = document.getElementById('create-name').value.trim();
+  if (!name) { webconsolejs['common/util'].showToast('Name is required.', 'error'); return; }
+  let infraDynamicReq;
+  try {
+    infraDynamicReq = parseJsonInput('create-json');
+  } catch (e) {
+    webconsolejs['common/util'].showToast('Invalid JSON: ' + e.message, 'error');
+    return;
+  }
+  const body = { name, infraDynamicReq };
+  const description = document.getElementById('create-description').value.trim();
+  if (description) body.description = description;
+  try {
+    await webconsolejs['common/api/services/infratemplate_api'].create(ns, body);
+    bootstrap.Modal.getInstance(document.getElementById('create-modal'))?.hide();
+    await loadList();
+    webconsolejs['common/util'].showToast('Template created.', 'success');
+  } catch (e) {
+    webconsolejs['common/util'].showToast('Failed to create: ' + (e?.response?.data?.message || e.message), 'error');
+  }
+};
+
+window.openEditModal = function () {
+  const item = AppState.resources.selected;
+  if (!item) return;
+  document.getElementById('edit-name').value = item.name || '';
+  document.getElementById('edit-description').value = item.description || '';
+  document.getElementById('edit-json').value = JSON.stringify(item.infraDynamicReq || {}, null, 2);
+  new bootstrap.Modal(document.getElementById('edit-modal')).show();
+};
+
+window.submitEdit = async function () {
+  const ns = AppState.ns;
+  const templateId = AppState.resources.selected?.id;
+  if (!ns || !templateId) return;
+  const name = document.getElementById('edit-name').value.trim();
+  if (!name) { webconsolejs['common/util'].showToast('Name is required.', 'error'); return; }
+  let infraDynamicReq;
+  try {
+    infraDynamicReq = parseJsonInput('edit-json');
+  } catch (e) {
+    webconsolejs['common/util'].showToast('Invalid JSON: ' + e.message, 'error');
+    return;
+  }
+  const body = { name, infraDynamicReq };
+  const description = document.getElementById('edit-description').value.trim();
+  if (description) body.description = description;
+  try {
+    await webconsolejs['common/api/services/infratemplate_api'].update(ns, templateId, body);
+    bootstrap.Modal.getInstance(document.getElementById('edit-modal'))?.hide();
+    await loadList();
+    webconsolejs['common/util'].showToast('Template updated.', 'success');
+  } catch (e) {
+    webconsolejs['common/util'].showToast('Failed to update: ' + (e?.response?.data?.message || e.message), 'error');
+  }
+};
+
+// ─── Delete ────────────────────────────────────────────────────────────
+
+window.confirmDelete = function () {
+  const item = AppState.resources.selected;
+  if (!item) return;
+  webconsolejs['partials/layout/modal'].commonConfirmModal(
+    'commonDefaultModal',
+    'Delete Template',
+    'Delete template "' + item.name + '"?',
+    'pages/operations/manage/workloads/infratemplates.executeDelete'
+  );
+};
+
+export async function executeDelete() {
+  const templateId = AppState.resources.selected?.id;
+  if (!templateId) return;
+  try {
+    await webconsolejs['common/api/services/infratemplate_api'].del(AppState.ns, templateId);
+    hideDetail();
+    await loadList();
+    webconsolejs['common/util'].showToast('Template deleted.', 'success');
+  } catch (e) {
+    webconsolejs['common/util'].showToast('Failed to delete: ' + (e?.response?.data?.message || e.message), 'error');
+  }
+}
+
+window.confirmDeleteAll = function () {
+  webconsolejs['partials/layout/modal'].commonConfirmModal(
+    'commonDefaultModal',
+    'Delete All Templates',
+    'Delete ALL infra templates in this namespace?',
+    'pages/operations/manage/workloads/infratemplates.executeDeleteAll'
+  );
+};
+
+export async function executeDeleteAll() {
+  try {
+    await webconsolejs['common/api/services/infratemplate_api'].deleteAll(AppState.ns);
+    hideDetail();
+    await loadList();
+    webconsolejs['common/util'].showToast('All templates deleted.', 'success');
+  } catch (e) {
+    webconsolejs['common/util'].showToast('Failed to delete: ' + (e?.response?.data?.message || e.message), 'error');
+  }
+}
+
+// ─── Filter ────────────────────────────────────────────────────────────
+
+function initFilter() {
+  const fieldEl = document.getElementById('filter-field');
+  const typeEl = document.getElementById('filter-type');
+  const valueEl = document.getElementById('filter-value');
+  if (!fieldEl || !typeEl || !valueEl) return;
+
+  function updateFilter() {
+    const filterVal = fieldEl.value;
+    const typeVal = typeEl.value;
+    if (filterVal && AppState.tables.resourceTable) {
+      AppState.tables.resourceTable.setFilter(filterVal, typeVal, valueEl.value);
+    }
+  }
+
+  fieldEl.addEventListener('change', updateFilter);
+  typeEl.addEventListener('change', updateFilter);
+  valueEl.addEventListener('keyup', updateFilter);
+  document.getElementById('filter-clear').addEventListener('click', function () {
+    fieldEl.value = '';
+    typeEl.value = 'like';
+    valueEl.value = '';
+    if (AppState.tables.resourceTable) AppState.tables.resourceTable.clearFilter();
+  });
+}
+
+// ─── Init ──────────────────────────────────────────────────────────────
+
+document.addEventListener('DOMContentLoaded', async function () {
+  const btnList = document.getElementById('page-header-btn-list');
+  if (btnList) {
+    btnList.innerHTML = `
+      <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#create-modal">Add Template</button>`;
+  }
+
+  const selectedWorkspaceProject = await webconsolejs['partials/layout/navbar'].workspaceProjectInit();
+  webconsolejs['partials/layout/modal'].checkWorkspaceSelection(selectedWorkspaceProject);
+
+  if (selectedWorkspaceProject.workspaceId !== '' && selectedWorkspaceProject.projectId === '') {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Project Selection Check', 'Please select a project first');
+  }
+
+  AppState.ns = selectedWorkspaceProject.nsId;
+  initFilter();
+
+  if (selectedWorkspaceProject.projectId !== '') {
+    await loadList();
+    await loadInfraList();
+  }
+});

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -1192,7 +1192,7 @@ function initTemplateDeploySelect() {
 		}
 		const mciName = ($("#mci_name").val() || "").trim();
 		if (!mciName) {
-			alert("Please input MCI Name first");
+			webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Please input MCI Name first");
 			this.value = "express";
 			mciDeployAlgorithmPrev = "express";
 			return;
@@ -1205,7 +1205,7 @@ export async function openTemplateSelectModal() {
 	var selectedWorkspaceProject = await webconsolejs["partials/layout/navbar"].workspaceProjectInit();
 	var nsId = selectedWorkspaceProject.nsId;
 	if (!nsId) {
-		alert("Please select a project first");
+		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Please select a project first");
 		revertDeployAlgorithmSelect();
 		return;
 	}
@@ -1266,7 +1266,7 @@ export async function openTemplateSelectModal() {
 export async function deployFromSelectedTemplate() {
 	const selected = templateSelectTable ? templateSelectTable.getSelectedData() : [];
 	if (selected.length === 0) {
-		alert("Please select a template");
+		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Please select a template");
 		return;
 	}
 	const template = selected[0];
@@ -1278,7 +1278,7 @@ export async function deployFromSelectedTemplate() {
 	var mciDesc = $("#mci_desc").val();
 
 	if (!mciName) {
-		alert("MCI Name is required");
+		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "MCI Name is required");
 		return;
 	}
 
@@ -1289,9 +1289,10 @@ export async function deployFromSelectedTemplate() {
 		await webconsolejs["common/api/services/infratemplate_api"].deployFromTemplate(nsId, template.id, applyReq);
 		templateDeploySucceeded = true;
 		bootstrap.Modal.getInstance(document.getElementById("infra-template-select-modal"))?.hide();
-		alert("MCI creation request completed.");
-		window.location.href = "/webconsole/operations/manage/workloads/mciworkloads";
+		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.SUCCESS, "MCI creation request completed.");
+		// Toast가 보이도록 잠시 후 이동
+		setTimeout(() => { window.location.href = "/webconsole/operations/manage/workloads/mciworkloads"; }, 1500);
 	} catch (e) {
-		alert("Failed to deploy from template: " + (e?.response?.data?.message || e.message));
+		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Failed to deploy from template: " + (e?.response?.data?.message || e.message));
 	}
 }

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -1122,6 +1122,7 @@ export function clearExpressForm() {
 let templateSelectTable = null;
 let mciDeployAlgorithmPrev = "express";
 let templateDeploySucceeded = false;
+let templateDeployInFlight = false;
 
 function revertDeployAlgorithmSelect() {
 	const sel = document.getElementById("mci_deploy_algorithm");
@@ -1264,6 +1265,8 @@ export async function openTemplateSelectModal() {
 }
 
 export async function deployFromSelectedTemplate() {
+	if (templateDeployInFlight) return; // 요청 진행 중 중복 호출 방지
+
 	const selected = templateSelectTable ? templateSelectTable.getSelectedData() : [];
 	if (selected.length === 0) {
 		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Please select a template");
@@ -1285,14 +1288,31 @@ export async function deployFromSelectedTemplate() {
 	const applyReq = { name: mciName };
 	if (mciDesc) applyReq.description = mciDesc;
 
+	const deployBtn = document.getElementById("btn-deploy-from-template");
+	templateDeployInFlight = true;
+	if (deployBtn) deployBtn.disabled = true;
+
 	try {
-		await webconsolejs["common/api/services/infratemplate_api"].deployFromTemplate(nsId, template.id, applyReq);
+		const response = await webconsolejs["common/api/services/infratemplate_api"].deployFromTemplate(
+			nsId, template.id, applyReq, undefined,
+			{ loaderType: "toast", progressLabel: "Deploying MCI from template..." }
+		);
+		// commonAPIPost는 HTTP 오류 시 throw하지 않고 error 객체를 반환하므로 status로 성공 판정
+		if (response?.status !== 200) {
+			// 오류 toast는 commonAPIPost가 이미 표시. 모달을 유지해 재시도 가능하게 함
+			templateDeployInFlight = false;
+			if (deployBtn) deployBtn.disabled = false;
+			return;
+		}
 		templateDeploySucceeded = true;
 		bootstrap.Modal.getInstance(document.getElementById("infra-template-select-modal"))?.hide();
 		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.SUCCESS, "MCI creation request completed.");
 		// Toast가 보이도록 잠시 후 이동
 		setTimeout(() => { window.location.href = "/webconsole/operations/manage/workloads/mciworkloads"; }, 1500);
 	} catch (e) {
-		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Failed to deploy from template: " + (e?.response?.data?.message || e.message));
+		// HTTP 오류는 위에서 처리되므로 여기는 예기치 못한 예외만 도달
+		templateDeployInFlight = false;
+		if (deployBtn) deployBtn.disabled = false;
+		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Failed to deploy from template: " + (e?.message || e));
 	}
 }

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -1128,6 +1128,59 @@ function revertDeployAlgorithmSelect() {
 	if (sel && sel.value === "template") sel.value = mciDeployAlgorithmPrev;
 }
 
+// 템플릿 미리보기 초기화 (선택 없음 → 안내문구 표시)
+function resetTemplateSelectDetail() {
+	const hint = document.getElementById("template-select-detail-hint");
+	const content = document.getElementById("template-select-detail-content");
+	if (hint) hint.classList.remove("d-none");
+	if (content) content.classList.add("d-none");
+}
+
+// 선택한 템플릿 내용을 읽기 전용으로 렌더링
+function renderTemplateSelectDetail(template) {
+	const hint = document.getElementById("template-select-detail-hint");
+	const content = document.getElementById("template-select-detail-content");
+	if (!content) return;
+	if (hint) hint.classList.add("d-none");
+	content.classList.remove("d-none");
+
+	const req = template.infraDynamicReq || {};
+	document.getElementById("template-select-detail-desc").textContent = template.description || "-";
+
+	const tbody = document.getElementById("template-select-nodegroup-rows");
+	tbody.innerHTML = "";
+	const groups = req.nodeGroups || [];
+	if (groups.length === 0) {
+		const tr = document.createElement("tr");
+		const td = document.createElement("td");
+		td.colSpan = 7;
+		td.className = "text-muted";
+		td.textContent = "-";
+		tr.appendChild(td);
+		tbody.appendChild(tr);
+	} else {
+		groups.forEach(g => {
+			const tr = document.createElement("tr");
+			const rootDisk = [g.rootDiskType, g.rootDiskSize].filter(v => v !== undefined && v !== "" && v !== 0).join(" / ");
+			[g.name, g.specId, g.imageId, g.nodeGroupSize, g.connectionName, rootDisk, g.zone].forEach(val => {
+				const td = document.createElement("td");
+				td.textContent = (val === undefined || val === null || val === "") ? "-" : String(val);
+				tr.appendChild(td);
+			});
+			tbody.appendChild(tr);
+		});
+	}
+
+	const block = document.getElementById("template-select-postcommand-block");
+	const commands = req.postCommand?.command || [];
+	if (commands.length > 0) {
+		block.classList.remove("d-none");
+		document.getElementById("template-select-postcommand").textContent = commands.join("\n");
+	} else {
+		block.classList.add("d-none");
+	}
+}
+
 function initTemplateDeploySelect() {
 	const sel = document.getElementById("mci_deploy_algorithm");
 	if (!sel) return;
@@ -1167,6 +1220,7 @@ export async function openTemplateSelectModal() {
 
 	if (templateSelectTable) {
 		templateSelectTable.replaceData(templates);
+		templateSelectTable.deselectRow();
 	} else {
 		templateSelectTable = new Tabulator("#template-select-table", {
 			data: templates,
@@ -1187,6 +1241,12 @@ export async function openTemplateSelectModal() {
 				{ title: "Created", field: "createdAt", sorter: "string", width: 180 }
 			]
 		});
+
+		// 선택 변경 시 템플릿 미리보기 갱신
+		templateSelectTable.on("rowSelectionChanged", function (data) {
+			if (data.length > 0) renderTemplateSelectDetail(data[0]);
+			else resetTemplateSelectDetail();
+		});
 	}
 
 	const modalEl = document.getElementById("infra-template-select-modal");
@@ -1199,6 +1259,7 @@ export async function openTemplateSelectModal() {
 	modalEl.addEventListener("hidden.bs.modal", function () {
 		if (!templateDeploySucceeded) revertDeployAlgorithmSelect();
 	}, { once: true });
+	resetTemplateSelectDetail();
 	new bootstrap.Modal(modalEl).show();
 }
 

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -29,6 +29,8 @@ export function initMciCreate() {
 	
 	// 이미지 선택 콜백 함수 설정
 	webconsolejs["partials/operation/manage/imagerecommendation"].setImageSelectionCallback(webconsolejs["partials/operation/manage/mcicreate"].callbackImageRecommendation);
+
+	initTemplateDeploySelect(); // Deployment Algorithm의 Template 선택 처리
 }
 
 // callback PopupData
@@ -1118,12 +1120,40 @@ export function clearExpressForm() {
 // ─── Infra Template으로 MCI 배포 ─────────────────────────────────────────
 
 let templateSelectTable = null;
+let mciDeployAlgorithmPrev = "express";
+let templateDeploySucceeded = false;
+
+function revertDeployAlgorithmSelect() {
+	const sel = document.getElementById("mci_deploy_algorithm");
+	if (sel && sel.value === "template") sel.value = mciDeployAlgorithmPrev;
+}
+
+function initTemplateDeploySelect() {
+	const sel = document.getElementById("mci_deploy_algorithm");
+	if (!sel) return;
+	mciDeployAlgorithmPrev = sel.value;
+	sel.addEventListener("change", async function () {
+		if (this.value !== "template") {
+			mciDeployAlgorithmPrev = this.value;
+			return;
+		}
+		const mciName = ($("#mci_name").val() || "").trim();
+		if (!mciName) {
+			alert("Please input MCI Name first");
+			this.value = "express";
+			mciDeployAlgorithmPrev = "express";
+			return;
+		}
+		await openTemplateSelectModal();
+	});
+}
 
 export async function openTemplateSelectModal() {
 	var selectedWorkspaceProject = await webconsolejs["partials/layout/navbar"].workspaceProjectInit();
 	var nsId = selectedWorkspaceProject.nsId;
 	if (!nsId) {
 		alert("Please select a project first");
+		revertDeployAlgorithmSelect();
 		return;
 	}
 
@@ -1163,6 +1193,12 @@ export async function openTemplateSelectModal() {
 	modalEl.addEventListener("shown.bs.modal", function () {
 		if (templateSelectTable) templateSelectTable.redraw(true);
 	}, { once: true });
+	// 배포 없이 닫히면 Deployment Algorithm을 이전 값으로 되돌린다
+	// (displayNewServerForm이 select 값으로 분기하므로 'template'으로 남겨두지 않음)
+	templateDeploySucceeded = false;
+	modalEl.addEventListener("hidden.bs.modal", function () {
+		if (!templateDeploySucceeded) revertDeployAlgorithmSelect();
+	}, { once: true });
 	new bootstrap.Modal(modalEl).show();
 }
 
@@ -1190,6 +1226,7 @@ export async function deployFromSelectedTemplate() {
 
 	try {
 		await webconsolejs["common/api/services/infratemplate_api"].deployFromTemplate(nsId, template.id, applyReq);
+		templateDeploySucceeded = true;
 		bootstrap.Modal.getInstance(document.getElementById("infra-template-select-modal"))?.hide();
 		alert("MCI creation request completed.");
 		window.location.href = "/webconsole/operations/manage/workloads/mciworkloads";

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -1114,3 +1114,86 @@ export function clearExpressForm() {
 	// 5. 폼은 그대로 유지 (토글하지 않음)
 }
 
+
+// ─── Infra Template으로 MCI 배포 ─────────────────────────────────────────
+
+let templateSelectTable = null;
+
+export async function openTemplateSelectModal() {
+	var selectedWorkspaceProject = await webconsolejs["partials/layout/navbar"].workspaceProjectInit();
+	var nsId = selectedWorkspaceProject.nsId;
+	if (!nsId) {
+		alert("Please select a project first");
+		return;
+	}
+
+	let templates = [];
+	try {
+		const data = await webconsolejs["common/api/services/infratemplate_api"].list(nsId);
+		templates = data?.templates || [];
+	} catch (e) {
+		if (e?.response?.status !== 404) console.error("Failed to load infra templates", e);
+	}
+
+	if (templateSelectTable) {
+		templateSelectTable.replaceData(templates);
+	} else {
+		templateSelectTable = new Tabulator("#template-select-table", {
+			data: templates,
+			layout: "fitColumns",
+			placeholder: "No infra templates found.",
+			selectableRows: 1,
+			columns: [
+				{ title: "Name", field: "name", sorter: "string" },
+				{ title: "Description", field: "description", sorter: "string" },
+				{
+					title: "NodeGroups", field: "infraDynamicReq", headerSort: false,
+					formatter: function (cell) {
+						const groups = cell.getValue()?.nodeGroups || [];
+						const total = groups.reduce((sum, g) => sum + (Number(g.nodeGroupSize) || 0), 0);
+						return `${groups.length} group(s) / ${total} node(s)`;
+					}
+				},
+				{ title: "Created", field: "createdAt", sorter: "string", width: 180 }
+			]
+		});
+	}
+
+	const modalEl = document.getElementById("infra-template-select-modal");
+	modalEl.addEventListener("shown.bs.modal", function () {
+		if (templateSelectTable) templateSelectTable.redraw(true);
+	}, { once: true });
+	new bootstrap.Modal(modalEl).show();
+}
+
+export async function deployFromSelectedTemplate() {
+	const selected = templateSelectTable ? templateSelectTable.getSelectedData() : [];
+	if (selected.length === 0) {
+		alert("Please select a template");
+		return;
+	}
+	const template = selected[0];
+
+	var selectedWorkspaceProject = await webconsolejs["partials/layout/navbar"].workspaceProjectInit();
+	var nsId = selectedWorkspaceProject.nsId;
+
+	var mciName = ($("#mci_name").val() || "").trim();
+	var mciDesc = $("#mci_desc").val();
+
+	if (!mciName) {
+		alert("MCI Name is required");
+		return;
+	}
+
+	const applyReq = { name: mciName };
+	if (mciDesc) applyReq.description = mciDesc;
+
+	try {
+		await webconsolejs["common/api/services/infratemplate_api"].deployFromTemplate(nsId, template.id, applyReq);
+		bootstrap.Modal.getInstance(document.getElementById("infra-template-select-modal"))?.hide();
+		alert("MCI creation request completed.");
+		window.location.href = "/webconsole/operations/manage/workloads/mciworkloads";
+	} catch (e) {
+		alert("Failed to deploy from template: " + (e?.response?.data?.message || e.message));
+	}
+}

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -1293,24 +1293,16 @@ export async function deployFromSelectedTemplate() {
 	if (deployBtn) deployBtn.disabled = true;
 
 	try {
-		const response = await webconsolejs["common/api/services/infratemplate_api"].deployFromTemplate(
-			nsId, template.id, applyReq, undefined,
-			{ loaderType: "toast", progressLabel: "Deploying MCI from template..." }
-		);
-		// commonAPIPost는 HTTP 오류 시 throw하지 않고 error 객체를 반환하므로 status로 성공 판정
-		if (response?.status !== 200) {
-			// 오류 toast는 commonAPIPost가 이미 표시. 모달을 유지해 재시도 가능하게 함
-			templateDeployInFlight = false;
-			if (deployBtn) deployBtn.disabled = false;
-			return;
-		}
+		// mciDynamic과 동일한 비동기 방식 — 생성 요청만 보내고 결과를 기다리지 않는다
+		webconsolejs["common/api/services/infratemplate_api"]
+			.deployFromTemplate(nsId, template.id, applyReq, undefined, { loaderType: "none" })
+			.catch(() => {});
 		templateDeploySucceeded = true;
 		bootstrap.Modal.getInstance(document.getElementById("infra-template-select-modal"))?.hide();
 		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.SUCCESS, "MCI creation request completed.");
 		// Toast가 보이도록 잠시 후 이동
 		setTimeout(() => { window.location.href = "/webconsole/operations/manage/workloads/mciworkloads"; }, 1500);
 	} catch (e) {
-		// HTTP 오류는 위에서 처리되므로 여기는 예기치 못한 예외만 도달
 		templateDeployInFlight = false;
 		if (deployBtn) deployBtn.disabled = false;
 		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Failed to deploy from template: " + (e?.message || e));

--- a/front/templates/pages/operations/manage/workloads/infratemplates.html
+++ b/front/templates/pages/operations/manage/workloads/infratemplates.html
@@ -1,0 +1,260 @@
+<div class="page-body">
+  <div class="container-xl">
+
+    <!-- Template List -->
+    <div class="row row-cards">
+      <div class="col-12">
+        <div class="card">
+          <div class="card-header">
+            <h3 class="card-title">Infra Template List</h3>
+            <div class="card-options ms-auto d-flex gap-2">
+              <a class="btn-action" type="button" data-bs-toggle="collapse" data-bs-target="#filter-body" aria-expanded="false">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                  <path d="M5.5 5h13a1 1 0 0 1 .5 1.5L14 12L14 19L10 16L10 12L5 6.5a1 1 0 0 1 .5 -1.5"></path>
+                </svg>
+              </a>
+              <a class="btn-action" onclick="confirmDeleteAll()">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon text-danger" width="24" height="24" viewBox="0 0 24 24"
+                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                  <path d="M4 7l16 0"></path>
+                  <path d="M10 11l0 6"></path>
+                  <path d="M14 11l0 6"></path>
+                  <path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12"></path>
+                  <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+          <div class="collapse" id="filter-body">
+            <div class="card-body border-bottom py-3">
+              <div class="row g-2 align-items-end">
+                <div class="col-auto">
+                  <label class="form-label mb-1">Field</label>
+                  <select id="filter-field" class="form-select form-select-sm">
+                    <option value="">-- select --</option>
+                    <option value="name">name</option>
+                    <option value="description">description</option>
+                    <option value="source">source</option>
+                  </select>
+                </div>
+                <div class="col-auto">
+                  <label class="form-label mb-1">Type</label>
+                  <select id="filter-type" class="form-select form-select-sm">
+                    <option value="like">like</option>
+                    <option value="=">=</option>
+                    <option value="!=">!=</option>
+                  </select>
+                </div>
+                <div class="col">
+                  <label class="form-label mb-1">Value</label>
+                  <input type="text" id="filter-value" class="form-control form-control-sm" placeholder="filter...">
+                </div>
+                <div class="col-auto">
+                  <button id="filter-clear" class="btn btn-sm btn-outline-secondary">Clear</button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="card-body p-0">
+            <div id="template-table"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Detail Panel -->
+    <div id="view-mode-cards" class="collapse">
+      <div class="row row-cards mt-2">
+        <div class="col-12">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">Template Info — <span id="detail-name" class="text-primary"></span></h3>
+              <div class="card-options">
+                <button class="btn btn-sm btn-outline-secondary me-1" onclick="openEditModal()">Edit</button>
+                <button class="btn btn-sm btn-outline-danger me-1" onclick="confirmDelete()">Delete</button>
+                <a href="#" class="card-options-remove" onclick="hideDetail()">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                    stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                    <path d="M18 6l-12 12"></path>
+                    <path d="M6 6l12 12"></path>
+                  </svg>
+                </a>
+              </div>
+            </div>
+            <div class="card-body">
+              <div class="datagrid">
+                <div class="datagrid-item">
+                  <div class="datagrid-title">ID</div>
+                  <div class="datagrid-content" id="detail-id">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Description</div>
+                  <div class="datagrid-content" id="detail-description">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Source</div>
+                  <div class="datagrid-content" id="detail-source">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Resource Type</div>
+                  <div class="datagrid-content" id="detail-resourceType">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Created At</div>
+                  <div class="datagrid-content" id="detail-createdAt">-</div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Updated At</div>
+                  <div class="datagrid-content" id="detail-updatedAt">-</div>
+                </div>
+              </div>
+
+              <!-- NodeGroups -->
+              <div class="mt-3">
+                <h4>NodeGroups</h4>
+                <div class="table-responsive">
+                  <table class="table table-vcenter table-sm">
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Spec ID</th>
+                        <th>Image ID</th>
+                        <th>Size</th>
+                        <th>Connection</th>
+                        <th>Root Disk</th>
+                        <th>Zone</th>
+                      </tr>
+                    </thead>
+                    <tbody id="detail-nodegroup-rows"></tbody>
+                  </table>
+                </div>
+              </div>
+
+              <!-- Post Command -->
+              <div class="mt-3">
+                <div class="datagrid">
+                  <div class="datagrid-item">
+                    <div class="datagrid-title">Post Command</div>
+                    <div class="datagrid-content" id="detail-postCommand" style="white-space:pre-wrap">-</div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Raw JSON -->
+              <div class="mt-3">
+                <h4>Infra Request (JSON)</h4>
+                <pre id="detail-raw-json" class="bg-dark text-white p-3 rounded" style="max-height:300px;overflow:auto"></pre>
+              </div>
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<!-- Create Modal -->
+<div class="modal modal-blur fade" id="create-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Add Infra Template</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label required">Name</label>
+          <input type="text" id="create-name" class="form-control" placeholder="my-infra-template">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Description</label>
+          <input type="text" id="create-description" class="form-control" placeholder="Optional description">
+        </div>
+        <div class="mb-3">
+          <label class="form-label required">Mode</label>
+          <div class="d-flex gap-3">
+            <label class="form-check">
+              <input class="form-check-input" type="radio" name="create-mode" id="create-mode-mci" value="mci" checked onchange="onCreateModeChange('mci')">
+              <span class="form-check-label">From existing MCI</span>
+            </label>
+            <label class="form-check">
+              <input class="form-check-input" type="radio" name="create-mode" id="create-mode-json" value="json" onchange="onCreateModeChange('json')">
+              <span class="form-check-label">JSON</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- From-MCI Fields -->
+        <div id="create-frommci-fields">
+          <div class="mb-3">
+            <label class="form-label">Source MCI</label>
+            <div class="row g-2">
+              <div class="col">
+                <select id="create-mci-select" class="form-select">
+                  <option value="">-- select MCI --</option>
+                </select>
+              </div>
+              <div class="col-auto">
+                <button type="button" class="btn btn-outline-primary" onclick="extractFromMci()">Extract</button>
+              </div>
+            </div>
+            <small class="text-muted">Extract fills the request below as a preview. You can edit it before creating.</small>
+          </div>
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label required">Infra Request (JSON)</label>
+          <textarea id="create-json" class="form-control font-monospace" rows="10"
+            placeholder='{
+  "name": "my-infra",
+  "nodeGroups": [
+    { "specId": "aws+ap-northeast-2+t3.small", "imageId": "ubuntu22.04", "name": "g1", "nodeGroupSize": 1 }
+  ]
+}'></textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" onclick="submitCreate()">Create</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Edit Modal -->
+<div class="modal modal-blur fade" id="edit-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Edit Infra Template</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label required">Name</label>
+          <input type="text" id="edit-name" class="form-control">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Description</label>
+          <input type="text" id="edit-description" class="form-control">
+        </div>
+        <div class="mb-3">
+          <label class="form-label required">Infra Request (JSON)</label>
+          <textarea id="edit-json" class="form-control font-monospace" rows="12"></textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" onclick="submitEdit()">Save</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+{{ javascriptTag("common/api/services/infratemplate_api.js") | raw }} {{ javascriptTag("pages/operations/manage/workloads/infratemplates.js") | raw }}

--- a/front/templates/pages/operations/manage/workloads/mciworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/mciworkloads.html
@@ -617,15 +617,6 @@
           <div class="card">
             <div class="card-header">
               <h3 class="card-title">Create MCI</h3>
-              <div class="card-options ms-auto">
-                <button
-                  type="button"
-                  class="btn btn-sm btn-outline-primary"
-                  onclick="webconsolejs['partials/operation/manage/mcicreate'].openTemplateSelectModal()"
-                >
-                  From Template
-                </button>
-              </div>
             </div>
 
             <div class="card-body">
@@ -661,6 +652,7 @@
                   <option value="express" selected>Express</option>
                   <option value="simple">Simple</option>
                   <option value="expert">Expert</option>
+                  <option value="template">Template</option>
                 </select>
               </div>
 

--- a/front/templates/pages/operations/manage/workloads/mciworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/mciworkloads.html
@@ -300,6 +300,35 @@
                       </svg>
                       Delete
                     </a>
+                    <a
+                      class="dropdown-item"
+                      onclick="webconsolejs['pages/operation/manage/mci'].openSaveAsTemplateModal()"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        class="icon dropdown-item-icon"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        stroke-width="2"
+                        stroke="currentColor"
+                        fill="none"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <path
+                          stroke="none"
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        ></path>
+                        <path
+                          d="M6 4h10l4 4v10a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2"
+                        ></path>
+                        <path d="M12 14m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"></path>
+                        <path d="M14 4l0 4l-6 0l0 -4"></path>
+                      </svg>
+                      Save as Template
+                    </a>
                     <a class="dropdown-item" href="#">
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -588,6 +617,15 @@
           <div class="card">
             <div class="card-header">
               <h3 class="card-title">Create MCI</h3>
+              <div class="card-options ms-auto">
+                <button
+                  type="button"
+                  class="btn btn-sm btn-outline-primary"
+                  onclick="webconsolejs['partials/operation/manage/mcicreate'].openTemplateSelectModal()"
+                >
+                  From Template
+                </button>
+              </div>
             </div>
 
             <div class="card-body">
@@ -1663,6 +1701,67 @@
   </div>
 </div>
 
+<!-- Infra Template 선택 팝업 -->
+<div class="modal modal-blur fade" id="infra-template-select-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Deploy from Infra Template</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="text-muted mb-2">
+          MCI Name/Description below override the template values; current MCI Name / Description inputs of the
+          Create MCI form are used.
+        </p>
+        <div id="template-select-table"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button
+          type="button"
+          class="btn btn-primary"
+          onclick="webconsolejs['partials/operation/manage/mcicreate'].deployFromSelectedTemplate()"
+        >
+          Deploy from Template
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- MCI를 Infra Template으로 저장 팝업 -->
+<div class="modal modal-blur fade" id="save-as-template-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Save as Infra Template</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label required">Template Name</label>
+          <input type="text" id="save-template-name" class="form-control" placeholder="my-infra-template">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Description</label>
+          <input type="text" id="save-template-desc" class="form-control" placeholder="Optional description">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button
+          type="button"
+          class="btn btn-primary"
+          onclick="webconsolejs['pages/operation/manage/mci'].executeSaveAsTemplate()"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- pageloader-->
 {{ partial("partials/layout/pageloader.html") | raw }}
 {{ javascriptTag("pages/operation/manage/mci.js") | raw }}
@@ -1670,3 +1769,4 @@
 {{ javascriptTag("common/api/services/vmimage_api.js") | raw }}
 {{ javascriptTag("common/api/services/import_api.js") | raw }}
 {{ javascriptTag("pages/operation/manage/importvm.js") | raw }}
+{{ javascriptTag("common/api/services/infratemplate_api.js") | raw }}

--- a/front/templates/pages/operations/manage/workloads/mciworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/mciworkloads.html
@@ -1746,6 +1746,7 @@
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
         <button
           type="button"
+          id="btn-deploy-from-template"
           class="btn btn-primary"
           onclick="webconsolejs['partials/operation/manage/mcicreate'].deployFromSelectedTemplate()"
         >

--- a/front/templates/pages/operations/manage/workloads/mciworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/mciworkloads.html
@@ -1695,7 +1695,7 @@
 
 <!-- Infra Template 선택 팝업 -->
 <div class="modal modal-blur fade" id="infra-template-select-modal" tabindex="-1" role="dialog" aria-hidden="true">
-  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+  <div class="modal-dialog modal-xl modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Deploy from Infra Template</h5>
@@ -1707,6 +1707,40 @@
           Create MCI form are used.
         </p>
         <div id="template-select-table"></div>
+
+        <!-- 선택한 템플릿 미리보기 (읽기 전용) -->
+        <div id="template-select-detail" class="mt-3">
+          <p id="template-select-detail-hint" class="text-muted mb-0">
+            Select a template to preview its configuration.
+          </p>
+          <div id="template-select-detail-content" class="d-none">
+            <div class="mb-2">
+              <span class="text-muted">Description:</span>
+              <span id="template-select-detail-desc">-</span>
+            </div>
+            <h4 class="mb-1">NodeGroups</h4>
+            <div class="table-responsive" style="overflow-x:auto">
+              <table class="table table-vcenter table-sm">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Spec ID</th>
+                    <th>Image ID</th>
+                    <th>Size</th>
+                    <th>Connection</th>
+                    <th>Root Disk</th>
+                    <th>Zone</th>
+                  </tr>
+                </thead>
+                <tbody id="template-select-nodegroup-rows"></tbody>
+              </table>
+            </div>
+            <div id="template-select-postcommand-block" class="d-none">
+              <h4 class="mb-1">Post Command</h4>
+              <pre id="template-select-postcommand" class="bg-dark text-white p-2 rounded mb-0" style="max-height:120px;overflow:auto"></pre>
+            </div>
+          </div>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>


### PR DESCRIPTION
## Summary
- **Infra Template 관리 화면 신규** — `/webconsole/operations/manage/workloads/infratemplates`
  - 목록(Name/Description/NodeGroups 요약/Source/Created/Updated) + 필터, 상세(메타 + NodeGroups 구성 표 + Post Command + raw JSON)
  - 생성 2모드: ① 기존 MCI에서 형상 추출(configCopy) 미리보기 ② `infraDynamicReq` JSON 직접 입력 — 잘못된 JSON은 토스트로 차단
  - 수정(name/description + JSON 편집), 삭제(단건/전체)
- **MCI 생성 화면 From Template 배포** — Deployment Algorithm select의 `Template` 옵션 선택(MCI Name 선검증) → template 선택 모달 → MCI 이름/설명 override만 입력 후 저장 형상 그대로 provisioning (`PostInfraDynamicFromTemplate`)
- **MCI 목록 Save as Template** — 선택한 MCI의 형상을 추출(`GetInfraReqFromInfra`)하여 template으로 저장
- **백엔드 변경 없음** — `conf/api.yaml`(mc-infra-manager v0.12.9)에 기등록된 operationId 8종 사용, generic proxy 경유

## 변경 파일
- `front/assets/js/common/api/services/infratemplate_api.js` — 신규 API 계층 (list/get/create/update/del/deleteAll/deployFromTemplate/getInfraReqFromInfra)
- `front/templates/pages/operations/manage/workloads/infratemplates.html` — 신규 관리 화면 (networktemplates 패턴)
- `front/assets/js/pages/operations/manage/workloads/infratemplates.js` — 신규 관리 화면 로직
- `front/templates/pages/operations/manage/workloads/mciworkloads.html` — From Template 버튼·선택 모달, Save as Template 드롭다운·모달
- `front/assets/js/partials/operation/manage/mcicreate.js` — export 2개 추가 (기존 함수 무수정)
- `front/assets/js/pages/operation/manage/mci.js` — export 2개 추가 (기존 함수 무수정)

## Gate 결과
| Gate | 결과 |
|---|---|
| feature:backend | SKIP (변경 없음) |
| feature:frontend.vet | PASS |
| feature:frontend.test | PASS |
| feature:frontend-bundle | PASS |
| security:secrets | PASS |
| security:deps | SKIP (의존성 변경 없음) |
| cost | PASS (인프라 변경 없음) |

## 테스트
- Playwright 실브라우저 (worktree 서버, 실로그인, 실변경 API 전부 route-mock) — **7 passed** (`mcmp-e2e/mc-web-console/specs/web-tech-009-infra-template.spec.ts`)
  - 목록 렌더 + 상세(nodeGroups/raw JSON), 빈 목록(`templates:null`) placeholder
  - 생성 payload 검증(`nodeGroupSize` number 타입 유지) + 잘못된 JSON 토스트
  - 수정/삭제 `pathParams.templateId` 도달, From-MCI 추출→생성 체이닝
  - Save as Template configCopy→create 체이닝, From Template 배포 payload + 검증 alert + redirect
- 라이브 tumblebug(v0.12.9) 사전 실증: template API 실존, configCopy 응답은 InfraDynamicReq 그대로(스웨거 `[DEFAULT]` 래핑 없음 — 방어 코드 포함), 빈 목록 `templates:null`

## 참고
- 후속 분리: template→생성 폼 프리필, PostInfraNode/ScaleOut·SG/vNet from template 연동, IAM 사이드바 메뉴 등록(현재 URL 직접 접근)


## 업데이트 (2026-07-14)
- 진입 UI 변경: 헤더 버튼 → **Deployment Algorithm select `Template` 옵션** (Express/Simple/Expert와 동일 계층). 모달 오픈 전 MCI Name 선검증, 취소 시 select 원복
- [Deploy]와 [Deploy from Template]은 서로 다른 API·독립 경로 (`PostInfraDynamicReview`→`PostInfraDynamic` vs `PostInfraDynamicFromTemplate`) — TC-12로 기존 경로 미호출 자동 검증
- Playwright 재실행 **8 passed** (TC-11-③ 모달 취소 원복 포함) + gate 전체 PASS

## 업데이트 2 (2026-07-14)
- Template 배포 모달에 **선택 template 상세 미리보기(readonly)** 추가 — Description + NodeGroups 표(Spec ID/Image ID/Size/Connection/Root Disk/Zone) + Post Command. 미선택 시 안내 문구, 재오픈 시 초기화. 모달 폭 modal-xl로 확대
- Playwright 재실행 **8 passed** (TC-13 상세 렌더 검증 포함) + gate 전체 PASS

## 업데이트 3 (2026-07-14)
- Template 배포 흐름의 결과/검증 메시지를 `alert()` → **공통 Toast 컴포넌트**(`common/utils/toast`)로 교체 — 검증 실패 ERROR / 배포 성공 SUCCESS 토스트 후 1.5초 지연 redirect / 배포 실패 ERROR
- Playwright 재실행 **8 passed** (토스트 기반 검증으로 전환) + gate 전체 PASS

## 업데이트 4 (2026-07-14) — 라이브 배포 결함 수정
- 실배포 검증에서 발견: `commonAPIPost`가 HTTP 오류를 throw하지 않고 error 객체를 반환 → 실패에도 성공 경로 진행. `response.status === 200` 명시 검증으로 수정 (실패 시 모달 유지, redirect 없음)
- 동기 long-running 배포(~35초) 대기 중 재클릭 → 중복 요청 400("already exists") 발생하던 문제: in-flight 가드 + Deploy 버튼 disable + progress toast로 차단
- Playwright 재실행 **9 passed** (TC-14 실패 처리 / TC-15 중복 클릭 방지 추가) + gate 전체 PASS

## 업데이트 5 (2026-07-14) — 비동기 처리 전환
- [Deploy from Template]을 VM Deploy(`mciDynamic`)와 동일한 **fire-and-forget**으로 전환 — 요청 발사 후 즉시 완료 토스트 → 목록 이동 (응답 미대기). tumblebug는 클라이언트 연결 종료 후에도 생성을 계속함(라이브 실증)
- Playwright 재실행 **9 passed** — TC-14 재정의(5초 지연 mock에서 응답 도착 전 토스트·redirect 발생 assert로 비동기성 증명) + gate 전체 PASS
