### PR TITLE
fix(pmk): Node Recommendation 모달 id 중복 해소 (image-search → cluster-spec-search)

### DIFF
--- a/front/assets/js/partials/operation/manage/clusterrecommendation.js
+++ b/front/assets/js/partials/operation/manage/clusterrecommendation.js
@@ -15,7 +15,7 @@ export function initClusterRecommendation(callbackfunction) {
 	}
 
 	// 팝업 열릴 때마다 provider 체크박스 초기화 (All 체크, 나머지 해제)
-	const modalEl = document.getElementById('image-search');
+	const modalEl = document.getElementById('cluster-spec-search');
 	if (modalEl) {
 		modalEl.addEventListener('shown.bs.modal', function () {
 			document.querySelectorAll('.spec-provider-check-cluster').forEach(cb => cb.checked = false);

--- a/front/templates/partials/operation/manage/_clusterrecommendation.html
+++ b/front/templates/partials/operation/manage/_clusterrecommendation.html
@@ -1,7 +1,7 @@
-<!-- add node : image-search : node recommendation -->
+<!-- add node : cluster-spec-search : node recommendation -->
 <div
   class="modal modal-blur fade"
-  id="image-search"
+  id="cluster-spec-search"
   tabindex="-1"
   style="display: none"
   aria-hidden="true"


### PR DESCRIPTION
## Summary
- pmkworkloads 화면에 `id="image-search"`를 가진 모달이 두 개 존재하던 문제 수정 — `_clusterrecommendation.html`(PMK 클러스터/노드 스펙 추천, title "Node Recommendation")과 `_imagerecommendation.html`(실제 이미지 추천, title "Image Recommendation")이 동일 id를 사용
- `getElementById`/`querySelector`는 첫 매칭 요소만 반환하므로 잠재적 오작동 위험 — 향후 두 모달 중 하나에 트리거가 추가되면 오작동 가능한 잠재 결함이었음 (현재는 `_clusterrecommendation.html` 모달을 여는 UI 트리거가 없어 실사용자 영향은 없음)
- `_clusterrecommendation.html` 쪽만 `id="cluster-spec-search"`로 분리, `_imagerecommendation.html`(정당한 소유자)은 무변경
