### PR TITLE
feat: consume IAM menu resource fields for viewType routing

### DIFF
--- a/front/actions/pageController.go
+++ b/front/actions/pageController.go
@@ -13,23 +13,32 @@ import (
 // ex) "/webconsole/configuration/workspace/manage" 롤 경로를 주고
 // templates/pages 아래에 /configuration/workspace/manage 에 html 파일을 만들면 됨.
 func PageController(c echo.Context) error {
-	// Echo의 /* 와일드카드는 전체 경로를 포함하므로 파라미터에서 추출
 	path := c.Request().URL.Path
-	renderHtmlPath := "pages" + strings.TrimSuffix(strings.TrimPrefix(path, "/webconsole"), "/")
+	trimmed := strings.TrimSuffix(strings.TrimPrefix(path, "/webconsole"), "/")
+
+	// WEB-FIX-002: /webconsole/_view/{menuId} → generic iframe shell
+	if strings.HasPrefix(trimmed, "/_view/") {
+		menuID := strings.Trim(strings.TrimPrefix(trimmed, "/_view/"), "/")
+		if menuID == "" || strings.Contains(menuID, "/") {
+			return c.HTML(http.StatusNotFound, "<html><body><h1>404 Not Found</h1></body></html>")
+		}
+		return RenderHTML(c, http.StatusOK, "pages/operation/generic.iframe.html", map[string]interface{}{
+			"MenuId": menuID,
+		})
+	}
+
+	renderHtmlPath := "pages" + trimmed
 	suffix := ".html"
-	iframefix := ".iframe"
+	iframeSuffix := ".iframe"
 
 	_, err := templates.FS().Open(renderHtmlPath + suffix)
 	if err != nil {
-		_, err := templates.FS().Open(renderHtmlPath + iframefix + suffix)
+		_, err := templates.FS().Open(renderHtmlPath + iframeSuffix + suffix)
 		if err != nil {
 			return c.HTML(http.StatusNotFound, "<html><body><h1>404 Not Found</h1></body></html>")
-		} else {
-			// iFrame 템플릿 렌더링
-			return RenderHTML(c, http.StatusOK, renderHtmlPath+iframefix+suffix, nil)
 		}
+		return RenderHTML(c, http.StatusOK, renderHtmlPath+iframeSuffix+suffix, nil)
 	}
 
-	// 일반 템플릿 렌더링
 	return RenderHTML(c, http.StatusOK, renderHtmlPath+suffix, nil)
 }

--- a/front/assets/js/pages/operation/plugins/costoptimizer.iframe.js
+++ b/front/assets/js/pages/operation/plugins/costoptimizer.iframe.js
@@ -1,53 +1,25 @@
-function getCostOptimizerData() {
-  const currentWorkspace = webconsolejs['common/api/services/workspace_api'].getCurrentWorkspace();
-  const currentProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
-  const accessToken = webconsolejs['common/storage/sessionstorage'].getSessionCurrentUserToken();
-
-  return {
-    accessToken: accessToken,
-    workspaceInfo: {
-      id: currentWorkspace.Id,
-      name: currentWorkspace.Name,
-    },
-    projectInfo: {
-      id: currentProject.Id,
-      ns_id: currentProject.NsId,
-      name: currentProject.Name,
-    },
-    requestOperationId: '',
-  };
-}
-
-async function loadCostOptimizer() {
-  const currentWorkspace = webconsolejs['common/api/services/workspace_api'].getCurrentWorkspace();
-  const currentProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
-  const targetDiv = document.getElementById('costIframe');
-
-  if (!currentWorkspace || !currentWorkspace.Id || !currentProject || !currentProject.Id) {
-    targetDiv.innerHTML =
-      '<div class="alert alert-warning m-3">Please select a Workspace and Project.</div>';
-    return;
-  }
-
-  const host = await webconsolejs['common/iframe/iframe'].GetApiHosts('mc-cost-optimizer-fe');
-  if (!host) {
-    targetDiv.innerHTML =
-      '<div class="alert alert-warning m-3">mc-cost-optimizer-fe service URL not found.<br>' +
-      'Please register the mc-cost-optimizer-fe URL in Settings &gt; Environment &gt; Cloud SPs &gt; Cloud Overview.</div>';
-    return;
-  }
-
-  const data = getCostOptimizerData();
-  targetDiv.innerHTML = '';
-  webconsolejs['common/iframe/iframe'].addIframe('costIframe', host, data);
-}
-
-$('#select-current-project').on('change', async function () {
-  const project = { Id: this.value, Name: this.options[this.selectedIndex].text, NsId: this.options[this.selectedIndex].text };
-  webconsolejs['common/api/services/workspace_api'].setCurrentProject(project);
-  await loadCostOptimizer();
+/**
+ * Thin wrapper → genericMenuLoader (WEB-FIX-002)
+ * Legacy convention URL 유지용 폴백 메타 포함
+ */
+document.addEventListener('DOMContentLoaded', async function () {
+  const loader = webconsolejs['pages/operation/plugins/genericMenuLoader'];
+  await loader.loadByMenuId('costanalysis', 'costIframe', {
+    frameworkService: 'mc-cost-optimizer-fe',
+    path: '/',
+  });
 });
 
-document.addEventListener('DOMContentLoaded', async function () {
-  await loadCostOptimizer();
+$('#select-current-project').on('change', async function () {
+  const project = {
+    Id: this.value,
+    Name: this.options[this.selectedIndex].text,
+    NsId: this.options[this.selectedIndex].text,
+  };
+  webconsolejs['common/api/services/workspace_api'].setCurrentProject(project);
+  const loader = webconsolejs['pages/operation/plugins/genericMenuLoader'];
+  await loader.loadByMenuId('costanalysis', 'costIframe', {
+    frameworkService: 'mc-cost-optimizer-fe',
+    path: '/',
+  });
 });

--- a/front/assets/js/pages/operation/plugins/datamanager.iframe.js
+++ b/front/assets/js/pages/operation/plugins/datamanager.iframe.js
@@ -1,53 +1,21 @@
-function getDataManagerData() {
-  const currentWorkspace = webconsolejs['common/api/services/workspace_api'].getCurrentWorkspace();
-  const currentProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
-  const accessToken = webconsolejs['common/storage/sessionstorage'].getSessionCurrentUserToken();
-
-  return {
-    accessToken: accessToken,
-    workspaceInfo: {
-      id: currentWorkspace.Id,
-      name: currentWorkspace.Name,
-    },
-    projectInfo: {
-      id: currentProject.Id,
-      ns_id: currentProject.NsId,
-      name: currentProject.Name,
-    },
-    requestOperationId: '',
-  };
-}
-
-async function loadDataManager() {
-  const currentWorkspace = webconsolejs['common/api/services/workspace_api'].getCurrentWorkspace();
-  const currentProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
-  const targetDiv = document.getElementById('targetIframe');
-
-  if (!currentWorkspace || !currentWorkspace.Id || !currentProject || !currentProject.Id) {
-    targetDiv.innerHTML =
-      '<div class="alert alert-warning m-3">Please select a Workspace and Project.</div>';
-    return;
-  }
-
-  const host = await webconsolejs['common/iframe/iframe'].GetApiHosts('mc-data-manager-fe');
-  if (!host) {
-    targetDiv.innerHTML =
-      '<div class="alert alert-warning m-3">mc-data-manager-fe service URL not found.<br>' +
-      'Please register the mc-data-manager-fe URL in Settings &gt; Environment.</div>';
-    return;
-  }
-
-  const data = getDataManagerData();
-  targetDiv.innerHTML = '';
-  webconsolejs['common/iframe/iframe'].addIframe('targetIframe', host, data);
-}
-
-$('#select-current-project').on('change', async function () {
-  const project = { Id: this.value, Name: this.options[this.selectedIndex].text, NsId: this.options[this.selectedIndex].text };
-  webconsolejs['common/api/services/workspace_api'].setCurrentProject(project);
-  await loadDataManager();
+document.addEventListener('DOMContentLoaded', async function () {
+  const loader = webconsolejs['pages/operation/plugins/genericMenuLoader'];
+  await loader.loadByMenuId('datamigrations', 'targetIframe', {
+    frameworkService: 'mc-data-manager-fe',
+    path: '/',
+  });
 });
 
-document.addEventListener('DOMContentLoaded', async function () {
-  await loadDataManager();
+$('#select-current-project').on('change', async function () {
+  const project = {
+    Id: this.value,
+    Name: this.options[this.selectedIndex].text,
+    NsId: this.options[this.selectedIndex].text,
+  };
+  webconsolejs['common/api/services/workspace_api'].setCurrentProject(project);
+  const loader = webconsolejs['pages/operation/plugins/genericMenuLoader'];
+  await loader.loadByMenuId('datamigrations', 'targetIframe', {
+    frameworkService: 'mc-data-manager-fe',
+    path: '/',
+  });
 });

--- a/front/assets/js/pages/operation/plugins/genericMenuLoader.js
+++ b/front/assets/js/pages/operation/plugins/genericMenuLoader.js
@@ -1,0 +1,150 @@
+/**
+ * WEB-FIX-002: generic iframe loader
+ * menuId → IAM 메뉴 메타(frameworkService/path) + getapihosts → iframe src
+ */
+
+function getCommonIframePostData() {
+  const currentWorkspace = webconsolejs['common/api/services/workspace_api'].getCurrentWorkspace();
+  const currentProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
+  const accessToken = webconsolejs['common/storage/sessionstorage'].getSessionCurrentUserToken();
+
+  return {
+    accessToken: accessToken,
+    workspaceInfo: {
+      id: currentWorkspace?.Id,
+      name: currentWorkspace?.Name,
+    },
+    projectInfo: {
+      id: currentProject?.Id,
+      ns_id: currentProject?.NsId,
+      name: currentProject?.Name,
+    },
+    requestOperationId: '',
+  };
+}
+
+function findMenuInTree(nodes, menuId) {
+  if (!Array.isArray(nodes)) return null;
+  for (const node of nodes) {
+    if (node.id === menuId) return node;
+    const nested = node.menus || node.children;
+    if (nested && nested.length) {
+      const found = findMenuInTree(nested, menuId);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function normalizePath(path) {
+  if (path == null || path === '') return '/';
+  return path.startsWith('/') ? path : '/' + path;
+}
+
+/** getapihosts BaseURL + menu path (BaseURL trailing / 와 path 조합) */
+export function joinFrameworkUrl(baseUrl, path) {
+  const p = normalizePath(path);
+  if (!baseUrl) return p;
+  try {
+    const u = new URL(baseUrl);
+    if (p === '/') {
+      return baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
+    }
+    // BaseURL pathname 이 / 만이면 origin + path
+    const basePath = u.pathname === '/' ? '' : u.pathname.replace(/\/$/, '');
+    return u.origin + basePath + p;
+  } catch {
+    const base = baseUrl.replace(/\/$/, '');
+    return p === '/' ? base + '/' : base + p;
+  }
+}
+
+/**
+ * @param {string} menuId
+ * @param {string} targetDivId
+ * @param {object} [opts]
+ * @param {string} [opts.frameworkService] menu 메타 없을 때 폴백
+ * @param {string} [opts.path]
+ * @param {string} [opts.apiFrameworkService] swcatalogs 용 apiBaseUrl
+ */
+export async function loadByMenuId(menuId, targetDivId, opts = {}) {
+  const targetDiv = document.getElementById(targetDivId);
+  if (!targetDiv) {
+    console.error('[genericMenuLoader] target div not found:', targetDivId);
+    return;
+  }
+
+  const currentWorkspace = webconsolejs['common/api/services/workspace_api'].getCurrentWorkspace();
+  const currentProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
+  if (!currentWorkspace?.Id || !currentProject?.Id) {
+    targetDiv.innerHTML =
+      '<div class="alert alert-warning m-3">Please select a Workspace and Project.</div>';
+    return;
+  }
+
+  const tree = webconsolejs['common/storage/localstorage'].getMenuLocalStorage() || [];
+  const menu = findMenuInTree(tree, menuId) || {};
+  const frameworkService =
+    menu.frameworkService || opts.frameworkService || '';
+  const path = menu.path != null && menu.path !== '' ? menu.path : (opts.path ?? '/');
+
+  if (!frameworkService) {
+    targetDiv.innerHTML =
+      '<div class="alert alert-warning m-3">Menu resource metadata missing (frameworkService).<br>' +
+      'menuId=' + menuId + '</div>';
+    return;
+  }
+
+  const host = await webconsolejs['common/iframe/iframe'].GetApiHosts(frameworkService);
+  if (!host) {
+    targetDiv.innerHTML =
+      '<div class="alert alert-warning m-3">' + frameworkService +
+      ' service URL not found.<br>Please register it in Settings &gt; Environment.</div>';
+    return;
+  }
+
+  const data = getCommonIframePostData();
+  const apiFw = opts.apiFrameworkService ||
+    (frameworkService === 'mc-application-manager-fe' ? 'mc-application-manager' : null);
+  if (apiFw) {
+    const apiHost = await webconsolejs['common/iframe/iframe'].GetApiHosts(apiFw);
+    if (apiHost) data.apiBaseUrl = apiHost;
+  }
+
+  const src = joinFrameworkUrl(host, path);
+  targetDiv.innerHTML = '';
+  webconsolejs['common/iframe/iframe'].addIframe(targetDivId, src, data);
+}
+
+export function resolveMenuIdFromLocation() {
+  const parts = window.location.pathname.split('/').filter(Boolean);
+  const idx = parts.indexOf('_view');
+  if (idx >= 0 && parts[idx + 1]) return parts[idx + 1];
+  const el = document.getElementById('genericMenuIframe');
+  return el?.dataset?.menuId || null;
+}
+
+async function bootGenericView() {
+  const menuId = resolveMenuIdFromLocation();
+  if (!menuId) return;
+  await loadByMenuId(menuId, 'genericMenuIframe');
+}
+
+$('#select-current-project').on('change', async function () {
+  const project = {
+    Id: this.value,
+    Name: this.options[this.selectedIndex].text,
+    NsId: this.options[this.selectedIndex].text,
+  };
+  webconsolejs['common/api/services/workspace_api'].setCurrentProject(project);
+  const menuId = resolveMenuIdFromLocation();
+  if (menuId && document.getElementById('genericMenuIframe')) {
+    await loadByMenuId(menuId, 'genericMenuIframe');
+  }
+});
+
+document.addEventListener('DOMContentLoaded', async function () {
+  if (document.getElementById('genericMenuIframe')) {
+    await bootGenericView();
+  }
+});

--- a/front/assets/js/pages/operation/plugins/observability.iframe.js
+++ b/front/assets/js/pages/operation/plugins/observability.iframe.js
@@ -1,59 +1,21 @@
-function getObservabilityData() {
-  const currentWorkspace = webconsolejs['common/api/services/workspace_api'].getCurrentWorkspace();
-  const currentProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
-  const accessToken = webconsolejs['common/storage/sessionstorage'].getSessionCurrentUserToken();
-
-  return {
-    accessToken: accessToken,
-    workspaceInfo: {
-      id: currentWorkspace.Id,
-      name: currentWorkspace.Name,
-    },
-    projectInfo: {
-      id: currentProject.Id,
-      ns_id: currentProject.NsId,
-      name: currentProject.Name,
-    },
-    requestOperationId: '',
-  };
-}
-
-async function loadObservability() {
-  const currentWorkspace = webconsolejs['common/api/services/workspace_api'].getCurrentWorkspace();
-  const currentProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
-  const targetDiv = document.getElementById('targetIframe-observability');
-  const bannerDiv = document.getElementById('observability-cert-banner');
-
-  if (!currentWorkspace || !currentWorkspace.Id || !currentProject || !currentProject.Id) {
-    bannerDiv.innerHTML = '';
-    targetDiv.innerHTML =
-      '<div class="alert alert-warning m-3">Please select a Workspace and Project.</div>';
-    return;
-  }
-
-  const host = await webconsolejs['common/iframe/iframe'].GetApiHosts('mc-observability-fe');
-  if (!host) {
-    bannerDiv.innerHTML = '';
-    targetDiv.innerHTML =
-      '<div class="alert alert-warning m-3">mc-observability-fe service URL not found.<br>' +
-      'Please register the mc-observability-fe URL in Settings &gt; Environment.</div>';
-    return;
-  }
-
-  const data = getObservabilityData();
-  const iframeSrc = host;
-
-  bannerDiv.innerHTML = '';
-  targetDiv.innerHTML = '';
-  webconsolejs['common/iframe/iframe'].addIframe('targetIframe-observability', iframeSrc, data);
-}
-
-$('#select-current-project').on('change', async function () {
-  const project = { Id: this.value, Name: this.options[this.selectedIndex].text, NsId: this.options[this.selectedIndex].text };
-  webconsolejs['common/api/services/workspace_api'].setCurrentProject(project);
-  await loadObservability();
+document.addEventListener('DOMContentLoaded', async function () {
+  const loader = webconsolejs['pages/operation/plugins/genericMenuLoader'];
+  await loader.loadByMenuId('observability', 'targetIframe-observability', {
+    frameworkService: 'mc-observability-fe',
+    path: '/',
+  });
 });
 
-document.addEventListener('DOMContentLoaded', async function () {
-  await loadObservability();
+$('#select-current-project').on('change', async function () {
+  const project = {
+    Id: this.value,
+    Name: this.options[this.selectedIndex].text,
+    NsId: this.options[this.selectedIndex].text,
+  };
+  webconsolejs['common/api/services/workspace_api'].setCurrentProject(project);
+  const loader = webconsolejs['pages/operation/plugins/genericMenuLoader'];
+  await loader.loadByMenuId('observability', 'targetIframe-observability', {
+    frameworkService: 'mc-observability-fe',
+    path: '/',
+  });
 });

--- a/front/assets/js/pages/operation/plugins/softwaremanager.iframe.js
+++ b/front/assets/js/pages/operation/plugins/softwaremanager.iframe.js
@@ -1,59 +1,23 @@
-function getSoftwareManagerData() {
-  const currentWorkspace = webconsolejs['common/api/services/workspace_api'].getCurrentWorkspace();
-  const currentProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
-  const accessToken = webconsolejs['common/storage/sessionstorage'].getSessionCurrentUserToken();
-
-  return {
-    accessToken: accessToken,
-    workspaceInfo: {
-      id: currentWorkspace.Id,
-      name: currentWorkspace.Name,
-    },
-    projectInfo: {
-      id: currentProject.Id,
-      ns_id: currentProject.NsId,
-      name: currentProject.Name,
-    },
-    requestOperationId: '',
-  };
-}
-
-async function loadSoftwareManager() {
-  const currentWorkspace = webconsolejs['common/api/services/workspace_api'].getCurrentWorkspace();
-  const currentProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
-  const targetDiv = document.getElementById('targetIframe-sofrwareCatalog');
-
-  if (!currentWorkspace || !currentWorkspace.Id || !currentProject || !currentProject.Id) {
-    targetDiv.innerHTML =
-      '<div class="alert alert-warning m-3">Please select a Workspace and Project.</div>';
-    return;
-  }
-
-  const host = await webconsolejs['common/iframe/iframe'].GetApiHosts('mc-application-manager-fe');
-  if (!host) {
-    targetDiv.innerHTML =
-      '<div class="alert alert-warning m-3">mc-application-manager-fe service URL not found.<br>' +
-      'Please register the mc-application-manager-fe URL in Settings &gt; Environment.</div>';
-    return;
-  }
-
-  const data = getSoftwareManagerData();
-
-  const apiHost = await webconsolejs['common/iframe/iframe'].GetApiHosts('mc-application-manager');
-  if (apiHost) {
-    data.apiBaseUrl = apiHost;
-  }
-
-  targetDiv.innerHTML = '';
-  webconsolejs['common/iframe/iframe'].addIframe('targetIframe-sofrwareCatalog', host + '/web/softwareCatalog', data);
-}
-
-$('#select-current-project').on('change', async function () {
-  const project = { Id: this.value, Name: this.options[this.selectedIndex].text, NsId: this.options[this.selectedIndex].text };
-  webconsolejs['common/api/services/workspace_api'].setCurrentProject(project);
-  await loadSoftwareManager();
+document.addEventListener('DOMContentLoaded', async function () {
+  const loader = webconsolejs['pages/operation/plugins/genericMenuLoader'];
+  await loader.loadByMenuId('swcatalogs', 'targetIframe-sofrwareCatalog', {
+    frameworkService: 'mc-application-manager-fe',
+    path: '/web/softwareCatalog',
+    apiFrameworkService: 'mc-application-manager',
+  });
 });
 
-document.addEventListener('DOMContentLoaded', async function () {
-  await loadSoftwareManager();
+$('#select-current-project').on('change', async function () {
+  const project = {
+    Id: this.value,
+    Name: this.options[this.selectedIndex].text,
+    NsId: this.options[this.selectedIndex].text,
+  };
+  webconsolejs['common/api/services/workspace_api'].setCurrentProject(project);
+  const loader = webconsolejs['pages/operation/plugins/genericMenuLoader'];
+  await loader.loadByMenuId('swcatalogs', 'targetIframe-sofrwareCatalog', {
+    frameworkService: 'mc-application-manager-fe',
+    path: '/web/softwareCatalog',
+    apiFrameworkService: 'mc-application-manager',
+  });
 });

--- a/front/assets/js/pages/operation/plugins/workflowmanager.iframe.js
+++ b/front/assets/js/pages/operation/plugins/workflowmanager.iframe.js
@@ -1,53 +1,21 @@
-function getWorkflowManagerData() {
-  const currentWorkspace = webconsolejs['common/api/services/workspace_api'].getCurrentWorkspace();
-  const currentProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
-  const accessToken = webconsolejs['common/storage/sessionstorage'].getSessionCurrentUserToken();
-
-  return {
-    accessToken: accessToken,
-    workspaceInfo: {
-      id: currentWorkspace.Id,
-      name: currentWorkspace.Name,
-    },
-    projectInfo: {
-      id: currentProject.Id,
-      ns_id: currentProject.NsId,
-      name: currentProject.Name,
-    },
-    requestOperationId: '',
-  };
-}
-
-async function loadWorkflowManager() {
-  const currentWorkspace = webconsolejs['common/api/services/workspace_api'].getCurrentWorkspace();
-  const currentProject = webconsolejs['common/api/services/workspace_api'].getCurrentProject();
-  const targetDiv = document.getElementById('targetIframe');
-
-  if (!currentWorkspace || !currentWorkspace.Id || !currentProject || !currentProject.Id) {
-    targetDiv.innerHTML =
-      '<div class="alert alert-warning m-3">Please select a Workspace and Project.</div>';
-    return;
-  }
-
-  const host = await webconsolejs['common/iframe/iframe'].GetApiHosts('mc-workflow-manager-fe');
-  if (!host) {
-    targetDiv.innerHTML =
-      '<div class="alert alert-warning m-3">mc-workflow-manager-fe service URL not found.<br>' +
-      'Please register the mc-workflow-manager-fe URL in Settings &gt; Environment.</div>';
-    return;
-  }
-
-  const data = getWorkflowManagerData();
-  targetDiv.innerHTML = '';
-  webconsolejs['common/iframe/iframe'].addIframe('targetIframe', host + '/web/workflow/list', data);
-}
-
-$('#select-current-project').on('change', async function () {
-  const project = { Id: this.value, Name: this.options[this.selectedIndex].text, NsId: this.options[this.selectedIndex].text };
-  webconsolejs['common/api/services/workspace_api'].setCurrentProject(project);
-  await loadWorkflowManager();
+document.addEventListener('DOMContentLoaded', async function () {
+  const loader = webconsolejs['pages/operation/plugins/genericMenuLoader'];
+  await loader.loadByMenuId('workflows', 'targetIframe', {
+    frameworkService: 'mc-workflow-manager-fe',
+    path: '/web/workflow/list',
+  });
 });
 
-document.addEventListener('DOMContentLoaded', async function () {
-  await loadWorkflowManager();
+$('#select-current-project').on('change', async function () {
+  const project = {
+    Id: this.value,
+    Name: this.options[this.selectedIndex].text,
+    NsId: this.options[this.selectedIndex].text,
+  };
+  webconsolejs['common/api/services/workspace_api'].setCurrentProject(project);
+  const loader = webconsolejs['pages/operation/plugins/genericMenuLoader'];
+  await loader.loadByMenuId('workflows', 'targetIframe', {
+    frameworkService: 'mc-workflow-manager-fe',
+    path: '/web/workflow/list',
+  });
 });

--- a/front/assets/js/pages/settings/accountnaccess/organizations/menus.js
+++ b/front/assets/js/pages/settings/accountnaccess/organizations/menus.js
@@ -156,6 +156,12 @@ const UIManager = {
         document.getElementById('detail-menu-isaction').textContent = menu.isAction ? 'Yes' : 'No';
         document.getElementById('detail-menu-priority').textContent = menu.priority != null ? menu.priority : '-';
         document.getElementById('detail-menu-menunumber').textContent = menu.menuNumber != null ? menu.menuNumber : '-';
+        const vt = document.getElementById('detail-menu-viewtype');
+        const fw = document.getElementById('detail-menu-frameworkservice');
+        const ph = document.getElementById('detail-menu-path');
+        if (vt) vt.textContent = menu.viewType || 'local';
+        if (fw) fw.textContent = menu.frameworkService || '-';
+        if (ph) ph.textContent = menu.path != null && menu.path !== '' ? menu.path : '-';
 
         const panel = document.getElementById('menu-detail-panel');
         if (panel.classList.contains('d-none')) {
@@ -226,6 +232,12 @@ const ModalManager = {
         document.getElementById('create-menu-isaction').checked = false;
         document.getElementById('create-menu-priority').value = '2';
         document.getElementById('create-menu-menunumber').value = '';
+        const cv = document.getElementById('create-menu-viewtype');
+        if (cv) cv.value = 'local';
+        const cf = document.getElementById('create-menu-frameworkservice');
+        if (cf) cf.value = '';
+        const cp = document.getElementById('create-menu-path');
+        if (cp) cp.value = '';
 
         // ParentID select 채우기
         UIManager.populateParentSelect('create-menu-parentid', parentId || '');
@@ -245,6 +257,12 @@ const ModalManager = {
         document.getElementById('edit-menu-isaction').checked = !!menu.isAction;
         document.getElementById('edit-menu-priority').value = menu.priority != null ? menu.priority : '';
         document.getElementById('edit-menu-menunumber').value = menu.menuNumber != null ? menu.menuNumber : '';
+        const ev = document.getElementById('edit-menu-viewtype');
+        if (ev) ev.value = menu.viewType || 'local';
+        const ef = document.getElementById('edit-menu-frameworkservice');
+        if (ef) ef.value = menu.frameworkService || '';
+        const ep = document.getElementById('edit-menu-path');
+        if (ep) ep.value = menu.path != null ? menu.path : '';
 
         UIManager.populateParentSelect('edit-menu-parentid', menu.parentId || '');
 
@@ -290,6 +308,13 @@ window.saveCreateMenu = async function () {
     }
 
     const parentId = document.getElementById('create-menu-parentid').value;
+    const viewType = document.getElementById('create-menu-viewtype')?.value || 'local';
+    const frameworkService = document.getElementById('create-menu-frameworkservice')?.value.trim() || '';
+    const path = document.getElementById('create-menu-path')?.value.trim() || '';
+    if ((viewType === 'iframe' || viewType === 'popup') && !frameworkService) {
+        alert('frameworkService is required for iframe/popup viewType.');
+        return;
+    }
     const data = {
         id: id,
         displayName: displayName,
@@ -298,6 +323,9 @@ window.saveCreateMenu = async function () {
         isAction: document.getElementById('create-menu-isaction').checked,
         priority: String(parseInt(document.getElementById('create-menu-priority').value) || 2),
         menuNumber: String(parseInt(document.getElementById('create-menu-menunumber').value) || 0),
+        viewType: viewType,
+        frameworkService: frameworkService,
+        path: path,
         roleIds: UIManager.getCheckedRoleIds('create-menu-roles')
     };
 
@@ -325,6 +353,13 @@ window.saveEditMenu = async function () {
         return;
     }
 
+    const viewType = document.getElementById('edit-menu-viewtype')?.value || 'local';
+    const frameworkService = document.getElementById('edit-menu-frameworkservice')?.value.trim() || '';
+    const path = document.getElementById('edit-menu-path')?.value.trim() || '';
+    if ((viewType === 'iframe' || viewType === 'popup') && !frameworkService) {
+        alert('frameworkService is required for iframe/popup viewType.');
+        return;
+    }
     const data = {
         displayName: displayName,
         parentId: document.getElementById('edit-menu-parentid').value,
@@ -332,6 +367,9 @@ window.saveEditMenu = async function () {
         isAction: document.getElementById('edit-menu-isaction').checked,
         priority: String(parseInt(document.getElementById('edit-menu-priority').value) || 2),
         menuNumber: String(parseInt(document.getElementById('edit-menu-menunumber').value) || 0),
+        viewType: viewType,
+        frameworkService: frameworkService,
+        path: path,
         roleIds: UIManager.getCheckedRoleIds('edit-menu-roles')
     };
 

--- a/front/assets/js/partials/layout/sidebar.js
+++ b/front/assets/js/partials/layout/sidebar.js
@@ -1,81 +1,140 @@
 document.addEventListener("DOMContentLoaded", function () {
     updatemenu();
-    document.querySelectorAll('div[name^="sidebar_"]').forEach(function(item) {
-        item.addEventListener('click', function(e) {
-            const hrefStr = this.getAttribute('href')
-            if( hrefStr && "#navbar-extra" !== hrefStr) {
-                window.location = hrefStr
-                return
-            }
-            // Bootstrap이 두 번 로드되어 toggle이 즉시 취소되는 문제 방지:
-            // document까지 이벤트 전파를 막고 수동으로 show/hide 처리
-            if (this.classList.contains('dropdown-toggle')) {
-                e.stopPropagation()
-                const menu = this.nextElementSibling
-                if (menu && menu.classList.contains('dropdown-menu')) {
-                    menu.classList.toggle('show')
-                    this.classList.toggle('show')
-                    this.setAttribute('aria-expanded', this.classList.contains('show'))
-                }
-            }
-        });
-    });
+    bindSidebarClicks();
     setActiveMenu();
 
     document.addEventListener("refresh-sidebar", function () {
         updatemenu();
+        bindSidebarClicks();
     });
-
 });
 
-function updatemenu(){
-    var  menuData = webconsolejs["common/storage/localstorage"].getMenuLocalStorage()
+function bindSidebarClicks() {
+    document.querySelectorAll('a[name^="sidebar_"], div[name^="sidebar_"]').forEach(function (item) {
+        item.addEventListener('click', async function (e) {
+            const viewType = this.getAttribute('data-viewtype');
+            if (viewType === 'popup') {
+                e.preventDefault();
+                e.stopPropagation();
+                await openPopupMenu(this);
+                return;
+            }
+            const hrefStr = this.getAttribute('href');
+            if (hrefStr && hrefStr !== '#navbar-extra' && hrefStr !== '#' && !hrefStr.startsWith('#popup')) {
+                window.location = hrefStr;
+                return;
+            }
+            if (this.classList.contains('dropdown-toggle')) {
+                e.stopPropagation();
+                const menu = this.nextElementSibling;
+                if (menu && menu.classList.contains('dropdown-menu')) {
+                    menu.classList.toggle('show');
+                    this.classList.toggle('show');
+                    this.setAttribute('aria-expanded', this.classList.contains('show'));
+                }
+            }
+        });
+    });
+}
+
+async function openPopupMenu(el) {
+    const framework = el.getAttribute('data-framework') || '';
+    const path = el.getAttribute('data-path') || '/';
+    if (!framework) {
+        alert('Menu resource: frameworkService is required for popup viewType');
+        return;
+    }
+    const host = await webconsolejs['common/iframe/iframe'].GetApiHosts(framework);
+    if (!host) {
+        alert(framework + ' service URL not found.');
+        return;
+    }
+    const loader = webconsolejs['pages/operation/plugins/genericMenuLoader'];
+    const url = loader && loader.joinFrameworkUrl
+        ? loader.joinFrameworkUrl(host, path)
+        : host.replace(/\/$/, '') + (path.startsWith('/') ? path : '/' + path);
+    window.open(url, '_blank');
+}
+
+function updatemenu() {
+    var menuData = webconsolejs['common/storage/localstorage'].getMenuLocalStorage();
     const menuHTML = generateMenuHTML(menuData);
-    document.getElementById("sidebar-menu-inner").innerHTML = menuHTML;
+    document.getElementById('sidebar-menu-inner').innerHTML = menuHTML;
+}
+
+/** WEB-FIX-002: viewType 기반 href / data attrs */
+function resolveMenuHref(title, category, menu, parentMenu) {
+    const viewType = (menu.viewType || 'local').toLowerCase();
+    const convention = parentMenu
+        ? `/webconsole/${title.id}/${category.id}/${parentMenu.id}/${menu.id}`
+        : `/webconsole/${title.id}/${category.id}/${menu.id}`;
+
+    if (viewType === 'iframe') {
+        return { href: `/webconsole/_view/${menu.id}`, viewType, framework: menu.frameworkService || '', path: menu.path || '/' };
+    }
+    if (viewType === 'popup') {
+        return { href: '#', viewType, framework: menu.frameworkService || '', path: menu.path || '/' };
+    }
+    // local
+    if (menu.path) {
+        const p = menu.path.startsWith('/') ? menu.path : '/' + menu.path;
+        return { href: '/webconsole' + p, viewType: 'local', framework: '', path: menu.path };
+    }
+    return { href: convention, viewType: 'local', framework: '', path: '' };
+}
+
+function actionAttrs(resolved, nameAttr, idAttr) {
+    if (!resolved) return '';
+    const idPart = idAttr ? ` id="${idAttr}"` : '';
+    const data =
+        ` data-viewtype="${resolved.viewType}"` +
+        (resolved.framework ? ` data-framework="${resolved.framework}"` : '') +
+        (resolved.path != null ? ` data-path="${resolved.path}"` : '');
+    return `href="${resolved.href}" name="${nameAttr}"${idPart}${data}`;
 }
 
 function generateMenuHTML(menus) {
     let html = '';
-    let debugMenu = document.getElementById("sidebar-menu-inner").innerHTML ; // 디버그 용도
-    menus.forEach(title => {
-        html += ` <li class="nav-item">`
-        html += ` <div class="hr-text fs-3">${title.displayName}</div>`
-        html += ` </li>`
-        title.menus.forEach(category => {
-            html += ` <li class="nav-item">`
-            html += ` <span class="nav-link hr-text-color" id="sidebar_${category.id}">${category.displayName}</span>`
-            html += ` </li>`
+    if (!menus || !menus.length) return html;
+    menus.forEach((title) => {
+        html += ` <li class="nav-item">`;
+        html += ` <div class="hr-text fs-3">${title.displayName}</div>`;
+        html += ` </li>`;
+        (title.menus || []).forEach((category) => {
+            html += ` <li class="nav-item">`;
+            html += ` <span class="nav-link hr-text-color" id="sidebar_${category.id}">${category.displayName}</span>`;
+            html += ` </li>`;
             if (category.menus && category.menus.length > 0) {
-                category.menus.forEach(menu => {
-                    if (!menu.menus || menu.menus.length === 0){
-                        html +=`<li class="nav-item">`
-                        html +=`<a class="nav-link" ${stringToBool(menu.isAction) ? `href="/webconsole/${title.id}/${category.id}/${menu.id}"` : ""}" name="sidebar_${menu.id}">`
-                        html +=`<span class="nav-link-icon d-md-none d-lg-inline-block">${iconsArr[menu.id] ? iconsArr[menu.id] : iconsArr["undefined"] }</span>`; // svg
-                        html +=`<span class="nav-link-title">${menu.displayName}</span>`
-                        html +=`</a>`
-                        html +=`</li>`
-                    }else {
+                category.menus.forEach((menu) => {
+                    if (!menu.menus || menu.menus.length === 0) {
+                        const resolved = stringToBool(menu.isAction)
+                            ? resolveMenuHref(title, category, menu, null)
+                            : null;
+                        html += `<li class="nav-item">`;
+                        html += `<a class="nav-link" ${resolved ? actionAttrs(resolved, 'sidebar_' + menu.id) : `name="sidebar_${menu.id}"`}>`;
+                        html += `<span class="nav-link-icon d-md-none d-lg-inline-block">${iconsArr[menu.id] ? iconsArr[menu.id] : iconsArr['undefined']}</span>`;
+                        html += `<span class="nav-link-title">${menu.displayName}</span>`;
+                        html += `</a>`;
+                        html += `</li>`;
+                    } else {
                         html += `<li class="nav-item box-link dropdown" name="sidebar_${menu.id}">`;
-                        html += `<div class="nav-link dropdown-toggle" name="sidebar_${menu.id}" href="${stringToBool(menu.isAction) ? `/webconsole/${title.id}/${category.id}/${menu.id}` : "#navbar-extra"}" role="button" aria-expanded="false">`;
-                        html += `<span class="nav-link-icon d-md-none d-lg-inline-block">${iconsArr[menu.id] ? iconsArr[menu.id] : iconsArr["undefined"] }</span>`; // svg
+                        const parentHref = stringToBool(menu.isAction)
+                            ? resolveMenuHref(title, category, menu, null).href
+                            : '#navbar-extra';
+                        html += `<div class="nav-link dropdown-toggle" name="sidebar_${menu.id}" href="${parentHref}" role="button" aria-expanded="false">`;
+                        html += `<span class="nav-link-icon d-md-none d-lg-inline-block">${iconsArr[menu.id] ? iconsArr[menu.id] : iconsArr['undefined']}</span>`;
                         html += `<span class="nav-link-title">${menu.displayName}</span>`;
                         html += `</div>`;
                     }
                     if (menu.menus && menu.menus.length > 0) {
                         html += `<div class="dropdown-menu" name="sidebar_${menu.id}"><div class="dropdown-menu-columns">`;
-                        menu.menus.forEach(subMenu => {
-                            if (stringToBool(subMenu.isAction)){
-                                html += `<div class="dropdown-menu-column">`;
-                                html += `<a class="dropdown-item" href="/webconsole/${title.id}/${category.id}/${menu.id}/${subMenu.id}" id="sidebar_${menu.id}_${subMenu.id}">`;
-                                html += `${subMenu.displayName}</a>`;
-                                html += `</div>`;
-                            }else {
-                                html += `<div class="dropdown-menu-column">`;
-                                html += `<a class="dropdown-item disabled" href="/webconsole/${title.id}/${category.id}/${menu.id}/${subMenu.id}" id="sidebar_${menu.id}_${subMenu.id}">`;
-                                html += `${subMenu.displayName}</a>`;
-                                html += `</div>`;
-                            }
-
+                        menu.menus.forEach((subMenu) => {
+                            const resolved = resolveMenuHref(title, category, subMenu, menu);
+                            const disabled = stringToBool(subMenu.isAction) ? '' : ' disabled';
+                            html += `<div class="dropdown-menu-column">`;
+                            html += `<a class="dropdown-item${disabled}" ${actionAttrs(resolved, 'sidebar_' + menu.id, 'sidebar_' + menu.id + '_' + subMenu.id)}>`;
+                            html += `${subMenu.displayName}</a>`;
+                            html += `</div>`;
                         });
                         html += `</div></div>`;
                     }
@@ -84,116 +143,100 @@ function generateMenuHTML(menus) {
             }
         });
     });
-    // return html+debugMenu;
     return html;
 }
 
-
-
-
 function setActiveMenu() {
-    // try {
-        const path = window.location.pathname.split('/');
-        const depth3 = path[3] ? `sidebar_${path[3]}` : null;
-        const depth4 = path[4] ? `sidebar_${path[4]}` : null;
-        const depth5 = path[5] ? `sidebar_${path[4]}_${path[5]}` : null;
-        if (depth4) {
-            const elements = document.querySelectorAll(`[name="${depth4}"]`);
-            elements.forEach(i => {
-                if (!i.classList.contains('show')) i.classList.add('show');
-                if (!i.classList.contains('active')) i.classList.add('active');
-            });
+    const path = window.location.pathname.split('/');
+    // /webconsole/_view/{menuId}
+    if (path[2] === '_view' && path[3]) {
+        const name = `sidebar_${path[3]}`;
+        document.querySelectorAll(`[name="${name}"]`).forEach((i) => {
+            i.classList.add('show', 'active');
+        });
+        return;
+    }
+    const depth3 = path[3] ? `sidebar_${path[3]}` : null;
+    const depth4 = path[4] ? `sidebar_${path[4]}` : null;
+    const depth5 = path[5] ? `sidebar_${path[4]}_${path[5]}` : null;
+    if (depth4) {
+        document.querySelectorAll(`[name="${depth4}"]`).forEach((i) => {
+            if (!i.classList.contains('show')) i.classList.add('show');
+            if (!i.classList.contains('active')) i.classList.add('active');
+        });
+    }
+    if (depth5) {
+        const element = document.getElementById(depth5);
+        if (element && !element.classList.contains('active')) {
+            element.classList.add('active');
         }
-        if (depth5) {
-            const element = document.getElementById(depth5);
-            if (element && !element.classList.contains('active')) {
-                element.classList.add('active');
+    }
+    if (depth4 && depth5) {
+        var pretitle = document.getElementById('page-pretitle');
+        var title = document.getElementById('page-title');
+        if (pretitle && title) {
+            const navLinkTitle = document.querySelector(`[name="${depth4}"].dropdown-toggle`);
+            if (navLinkTitle) {
+                const innerText = navLinkTitle.querySelector('.nav-link-title').innerText;
+                pretitle.innerHTML = innerText;
+            }
+            const depth5Element = document.getElementById(depth5);
+            if (depth5Element) {
+                title.innerHTML = depth5Element.innerHTML;
             }
         }
-        if (depth4&&depth5) {
-            var pretitle = document.getElementById("page-pretitle");
-            var title = document.getElementById("page-title");
-            if (pretitle && title) {
-                const navLinkTitle = document.querySelector(`[name="${depth4}"].dropdown-toggle`);
-                if (navLinkTitle) {
-                    const innerText = navLinkTitle.querySelector('.nav-link-title').innerText;
-                    pretitle.innerHTML = innerText 
-                }
-                const depth5Element = document.getElementById(depth5);
-                if (depth5Element) {
-                    title.innerHTML = depth5Element.innerHTML;
-                }
-            }
-        } else if (depth3&&depth4) {
-            var pretitle = document.getElementById("page-pretitle");
-            var title = document.getElementById("page-title");
-            if (pretitle && title) {
-                pretitle.innerHTML = document.getElementById(depth3).innerHTML
-                const navLinkTitle = document.querySelector(`[name="${depth4}"].dropdown-toggle`);
-                if (navLinkTitle) {
-                    const innerText = navLinkTitle.querySelector('.nav-link-title').innerText;
-                    title.innerHTML = innerText 
-                }else {
-                    const navLinkTitle2 = document.querySelector(`[name="${depth4}"].nav-link`);
-                    if (navLinkTitle2) {
-                        const innerText = navLinkTitle2.querySelector('.nav-link-title').innerText;
-                        title.innerHTML = innerText 
-                    }
+    } else if (depth3 && depth4) {
+        var pretitle2 = document.getElementById('page-pretitle');
+        var title2 = document.getElementById('page-title');
+        if (pretitle2 && title2) {
+            const d3 = document.getElementById(depth3);
+            if (d3) pretitle2.innerHTML = d3.innerHTML;
+            const navLinkTitle = document.querySelector(`[name="${depth4}"].dropdown-toggle`);
+            if (navLinkTitle) {
+                title2.innerHTML = navLinkTitle.querySelector('.nav-link-title').innerText;
+            } else {
+                const navLinkTitle2 = document.querySelector(`[name="${depth4}"].nav-link`);
+                if (navLinkTitle2) {
+                    title2.innerHTML = navLinkTitle2.querySelector('.nav-link-title').innerText;
                 }
             }
         }
-        
-    // } catch (error) {
-    //     console.log('An error occurred in setActiveMenu:', error.message);
-    // }
+    }
 }
 
 function stringToBool(value) {
-    // boolean 타입인 경우
-    if (typeof value === 'boolean') {
-        return value;
-    }
-    // 문자열인 경우
-    if (typeof value === 'string') {
-        return value.toLowerCase() === 'true';
-    }
-    // 기타 타입은 false로 처리
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'string') return value.toLowerCase() === 'true';
     return false;
 }
 
 const iconsArr = {
-
-    "workloads" : `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+    workloads: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
         fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
         stroke-linejoin="round"
         class="icon icon-tabler icons-tabler-outline icon-tabler-layout-dashboard">
         <path stroke="none" d="M0 0h24v24H0z" fill="none" />
         <path d="M5 4h4a1 1 0 0 1 1 1v6a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-6a1 1 0 0 1 1 -1" />
         <path d="M5 16h4a1 1 0 0 1 1 1v2a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-2a1 1 0 0 1 1 -1" />
-        <path
-            d="M15 12h4a1 1 0 0 1 1 1v6a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-6a1 1 0 0 1 1 -1" />
+        <path d="M15 12h4a1 1 0 0 1 1 1v6a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-6a1 1 0 0 1 1 -1" />
         <path d="M15 4h4a1 1 0 0 1 1 1v2a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-2a1 1 0 0 1 1 -1" />
         </svg>`,
-
-    "undefined" : `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+    undefined: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
         fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
         stroke-linejoin="round"
         class="icon icon-tabler icons-tabler-outline icon-tabler-layout-dashboard">
         <path stroke="none" d="M0 0h24v24H0z" fill="none" />
         <path d="M5 4h4a1 1 0 0 1 1 1v6a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-6a1 1 0 0 1 1 -1" />
         <path d="M5 16h4a1 1 0 0 1 1 1v2a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-2a1 1 0 0 1 1 -1" />
-        <path
-            d="M15 12h4a1 1 0 0 1 1 1v6a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-6a1 1 0 0 1 1 -1" />
+        <path d="M15 12h4a1 1 0 0 1 1 1v6a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-6a1 1 0 0 1 1 -1" />
         <path d="M15 4h4a1 1 0 0 1 1 1v2a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1v-2a1 1 0 0 1 1 -1" />
         </svg>`,
-
-    "single" : `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+    single: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
         fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
         class="icon"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M9 11l3 3l8 -8">
         </path><path d="M20 12v6a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2h9"></path>
         </svg>`,
-
-    "approvals" : `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+    approvals: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
         fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
         class="icon icon-tabler icons-tabler-outline icon-tabler-user-check">
         <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
@@ -201,4 +244,4 @@ const iconsArr = {
         <path d="M6 21v-2a4 4 0 0 1 4 -4h4"/>
         <path d="M15 19l2 2l4 -4"/>
         </svg>`,
-}
+};

--- a/front/templates/pages/operation/generic.iframe.html
+++ b/front/templates/pages/operation/generic.iframe.html
@@ -1,0 +1,4 @@
+<div class="iframe-wrapper" id="genericMenuIframe" height="100%" data-menu-id="{{ MenuId }}"></div>
+
+{{ javascriptTag("common/iframe/iframe.js") | raw }}
+{{ javascriptTag("pages/operation/plugins/genericMenuLoader.js") | raw }}

--- a/front/templates/pages/operations/analytics/costanalysis.iframe.html
+++ b/front/templates/pages/operations/analytics/costanalysis.iframe.html
@@ -1,4 +1,5 @@
-<!-- <iframe src="http://43.202.179.178"></iframe> -->
 <div class="iframe-wrapper" id="costIframe" height="100%" ></div>
 
+{{ javascriptTag("common/iframe/iframe.js") | raw }}
+{{ javascriptTag("pages/operation/plugins/genericMenuLoader.js") | raw }}
 {{ javascriptTag("pages/operation/plugins/costoptimizer.iframe.js") | raw }}

--- a/front/templates/pages/operations/analytics/observability.iframe.html
+++ b/front/templates/pages/operations/analytics/observability.iframe.html
@@ -2,4 +2,5 @@
 <div class="iframe-wrapper" id="targetIframe-observability" height="100%"></div>
 
 {{ javascriptTag("common/iframe/iframe.js") | raw }}
+{{ javascriptTag("pages/operation/plugins/genericMenuLoader.js") | raw }}
 {{ javascriptTag("pages/operation/plugins/observability.iframe.js") | raw }}

--- a/front/templates/pages/operations/manage/datamigrations.iframe.html
+++ b/front/templates/pages/operations/manage/datamigrations.iframe.html
@@ -1,5 +1,5 @@
-<!-- <iframe src="http://43.202.179.178"></iframe> -->
 <div class="iframe-wrapper" id="targetIframe" height="100%" ></div>
 
 {{ javascriptTag("common/iframe/iframe.js") | raw }}
+{{ javascriptTag("pages/operation/plugins/genericMenuLoader.js") | raw }}
 {{ javascriptTag("pages/operation/plugins/datamanager.iframe.js") | raw }}

--- a/front/templates/pages/operations/manage/swcatalogs.iframe.html
+++ b/front/templates/pages/operations/manage/swcatalogs.iframe.html
@@ -1,6 +1,5 @@
-<!-- <iframe src="http://43.202.179.178"></iframe> -->
-<!-- <div class="iframe-wrapper" id="targetIframe-repository" height="50%" ></div> -->
 <div class="iframe-wrapper" id="targetIframe-sofrwareCatalog" height="100%"></div>
 
 {{ javascriptTag("common/iframe/iframe.js") | raw }}
+{{ javascriptTag("pages/operation/plugins/genericMenuLoader.js") | raw }}
 {{ javascriptTag("pages/operation/plugins/softwaremanager.iframe.js") | raw }}

--- a/front/templates/pages/operations/manage/workflows.iframe.html
+++ b/front/templates/pages/operations/manage/workflows.iframe.html
@@ -1,5 +1,5 @@
-<!-- <iframe src="http://43.202.179.178"></iframe> -->
 <div class="iframe-wrapper" id="targetIframe" height="100%" ></div>
 
 {{ javascriptTag("common/iframe/iframe.js") | raw }}
+{{ javascriptTag("pages/operation/plugins/genericMenuLoader.js") | raw }}
 {{ javascriptTag("pages/operation/plugins/workflowmanager.iframe.js") | raw }}

--- a/front/templates/pages/settings/accountnaccess/organizations/menus.html
+++ b/front/templates/pages/settings/accountnaccess/organizations/menus.html
@@ -49,6 +49,18 @@
                   <div class="datagrid-title">Menu Number</div>
                   <div class="datagrid-content" id="detail-menu-menunumber"></div>
                 </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">View Type</div>
+                  <div class="datagrid-content" id="detail-menu-viewtype"></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Framework Service</div>
+                  <div class="datagrid-content" id="detail-menu-frameworkservice"></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Path</div>
+                  <div class="datagrid-content" id="detail-menu-path"></div>
+                </div>
               </div>
             </div>
             <div class="card-footer">
@@ -136,6 +148,24 @@
           </label>
         </div>
         <div class="mb-3">
+          <label class="form-label">View Type</label>
+          <select class="form-select" id="create-menu-viewtype">
+            <option value="local" selected>local</option>
+            <option value="iframe">iframe</option>
+            <option value="popup">popup</option>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Framework Service</label>
+          <input type="text" class="form-control" id="create-menu-frameworkservice"
+            placeholder="e.g. mc-cost-optimizer-fe" />
+          <small class="text-muted">Required for iframe/popup (getapihosts key)</small>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Path</label>
+          <input type="text" class="form-control" id="create-menu-path" placeholder="e.g. / or /web/workflow/list" />
+        </div>
+        <div class="mb-3">
           <label class="form-label">Roles</label>
           <div id="create-menu-roles" class="d-flex flex-column gap-1" style="max-height: 180px; overflow-y: auto;">
             <!-- role checkboxes rendered by JS -->
@@ -188,6 +218,23 @@
             <input class="form-check-input" type="checkbox" id="edit-menu-isaction" />
             <span class="form-check-label">Is Action (clickable page menu)</span>
           </label>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">View Type</label>
+          <select class="form-select" id="edit-menu-viewtype">
+            <option value="local">local</option>
+            <option value="iframe">iframe</option>
+            <option value="popup">popup</option>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Framework Service</label>
+          <input type="text" class="form-control" id="edit-menu-frameworkservice"
+            placeholder="e.g. mc-cost-optimizer-fe" />
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Path</label>
+          <input type="text" class="form-control" id="edit-menu-path" placeholder="e.g. / or /web/workflow/list" />
         </div>
         <div class="mb-3">
           <label class="form-label">Roles</label>


### PR DESCRIPTION
## Summary
- IAM 메뉴의 `viewType` / `frameworkService` / `path`를 사용해 사이드바·페이지 라우팅을 분기합니다.
- `_view/{menuId}` 제네릭 셸과 `genericMenuLoader`로 iframe 메뉴를 동적으로 로드합니다.
- 기존 iframe 플러그인은 thin wrapper로 정리하고, Menus UI에 새 필드를 노출합니다.
