### PR TITLE
[feat]: requestId async toast + notification center 

### DIFF
--- a/api/internal/middleware/cors.go
+++ b/api/internal/middleware/cors.go
@@ -22,6 +22,8 @@ func CustomCORSConfig() echo.MiddlewareFunc {
 			echo.HeaderContentType,
 			echo.HeaderAccept,
 			echo.HeaderAuthorization,
+			echo.HeaderXRequestID,
+			"x-request-id",
 		},
 		AllowCredentials: true,
 		MaxAge:           86400, // 24시간

--- a/front/assets/js/common/api/asyncRequestNotify.js
+++ b/front/assets/js/common/api/asyncRequestNotify.js
@@ -1,0 +1,190 @@
+/**
+ * Navbar notification dropdown bound to asyncRequestTracker jobs.
+ */
+
+function tracker() {
+  return webconsolejs && webconsolejs['common/api/asyncRequestTracker'];
+}
+
+function shortId(requestId) {
+  if (!requestId || requestId.length < 8) {
+    return requestId || '';
+  }
+  return '…' + requestId.slice(-8);
+}
+
+function statusDotClass(status) {
+  if (status === 'Handling') {
+    return 'status-dot status-dot-animated bg-azure d-block';
+  }
+  if (status === 'Success') {
+    return 'status-dot bg-green d-block';
+  }
+  if (status === 'Error' || status === 'Timeout') {
+    return 'status-dot bg-red d-block';
+  }
+  return 'status-dot d-block';
+}
+
+function statusLabel(status) {
+  if (status === 'Handling') {
+    return 'Processing';
+  }
+  if (status === 'Success') {
+    return 'Success';
+  }
+  if (status === 'Timeout') {
+    return 'Timeout';
+  }
+  if (status === 'Error') {
+    return 'Error';
+  }
+  return status || '';
+}
+
+function formatTime(ts) {
+  if (!ts) {
+    return '';
+  }
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) {
+    return '';
+  }
+  return d.toLocaleTimeString();
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderJobs(jobs) {
+  const listEl = document.getElementById('async-request-notif-list');
+  const badgeEl = document.getElementById('async-request-notif-badge');
+  const emptyEl = document.getElementById('async-request-notif-empty');
+  if (!listEl || !badgeEl) {
+    return;
+  }
+
+  const handling = (jobs || []).filter((j) => j.status === 'Handling').length;
+  if (handling > 0) {
+    badgeEl.textContent = String(handling);
+    badgeEl.classList.remove('d-none');
+  } else {
+    badgeEl.textContent = '';
+    badgeEl.classList.add('d-none');
+  }
+
+  if (!jobs || jobs.length === 0) {
+    listEl.innerHTML = '';
+    if (emptyEl) {
+      emptyEl.classList.remove('d-none');
+    }
+    return;
+  }
+  if (emptyEl) {
+    emptyEl.classList.add('d-none');
+  }
+
+  listEl.innerHTML = jobs
+    .map((job) => {
+      const sub =
+        (job.operationId ? escapeHtml(job.operationId) + ' · ' : '') +
+        shortId(job.requestId) +
+        (job.startedAt ? ' · ' + formatTime(job.startedAt) : '');
+      const title = escapeHtml(job.label || job.operationId || 'Request');
+      const st = statusLabel(job.status);
+      const msg =
+        job.status !== 'Handling' && job.message
+          ? '<div class="d-block text-secondary text-truncate mt-n1">' +
+            escapeHtml(job.message) +
+            '</div>'
+          : '<div class="d-block text-secondary text-truncate mt-n1">' +
+            escapeHtml(sub) +
+            '</div>';
+      return (
+        '<div class="list-group-item" data-request-id="' +
+        escapeHtml(job.requestId) +
+        '">' +
+        '<div class="row align-items-center">' +
+        '<div class="col-auto"><span class="' +
+        statusDotClass(job.status) +
+        '" title="' +
+        escapeHtml(st) +
+        '"></span></div>' +
+        '<div class="col text-truncate">' +
+        '<span class="text-body d-block">' +
+        title +
+        ' <span class="text-secondary small">(' +
+        escapeHtml(st) +
+        ')</span></span>' +
+        msg +
+        '</div>' +
+        '<div class="col-auto">' +
+        '<a href="#" class="list-group-item-actions async-request-dismiss" ' +
+        'data-request-id="' +
+        escapeHtml(job.requestId) +
+        '" title="Dismiss">' +
+        '<svg xmlns="http://www.w3.org/2000/svg" class="icon text-muted" width="24" height="24" ' +
+        'viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" ' +
+        'stroke-linecap="round" stroke-linejoin="round">' +
+        '<path stroke="none" d="M0 0h24v24H0z" fill="none"/>' +
+        '<path d="M18 6l-12 12"/><path d="M6 6l12 12"/></svg></a>' +
+        '</div></div></div>'
+      );
+    })
+    .join('');
+}
+
+function bindActions() {
+  const clearBtn = document.getElementById('async-request-notif-clear');
+  if (clearBtn && !clearBtn.dataset.bound) {
+    clearBtn.dataset.bound = '1';
+    clearBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const t = tracker();
+      if (t && t.clearFinished) {
+        t.clearFinished();
+      }
+    });
+  }
+
+  const listEl = document.getElementById('async-request-notif-list');
+  if (listEl && !listEl.dataset.bound) {
+    listEl.dataset.bound = '1';
+    listEl.addEventListener('click', (e) => {
+      const dismiss = e.target.closest('.async-request-dismiss');
+      if (!dismiss) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      const id = dismiss.getAttribute('data-request-id');
+      const t = tracker();
+      if (t && t.dismiss && id) {
+        t.dismiss(id);
+      }
+    });
+  }
+}
+
+export function initAsyncRequestNotify() {
+  const t = tracker();
+  if (!t || !t.subscribe) {
+    return;
+  }
+  bindActions();
+  t.subscribe(renderJobs);
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAsyncRequestNotify);
+  } else {
+    setTimeout(initAsyncRequestNotify, 0);
+  }
+}

--- a/front/assets/js/common/api/asyncRequestTracker.js
+++ b/front/assets/js/common/api/asyncRequestTracker.js
@@ -1,0 +1,253 @@
+/**
+ * Track long-running mc-infra-manager requests via GetRequest + Toast.
+ * Jobs persist in sessionStorage (incl. finished history for navbar).
+ */
+
+const STORAGE_KEY = 'mcwc_async_requests';
+const POLL_MS = 2500;
+const MAX_MS = 15 * 60 * 1000;
+const MAX_JOBS = 20;
+const GET_REQUEST_URL = '/api/mc-infra-manager/GetRequest';
+const EVENT_NAME = 'mcwc-async-request-changed';
+
+const timers = new Map();
+const listeners = new Set();
+
+function toastApi() {
+  return webconsolejs && webconsolejs['common/utils/toast'];
+}
+
+function toastIdFor(requestId) {
+  return 'async-req-' + requestId;
+}
+
+function loadJobs() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (e) {
+    return [];
+  }
+}
+
+function saveJobs(jobs) {
+  // Keep Handling first by startedAt, then finished by finishedAt; cap size
+  const handling = jobs
+    .filter((j) => j.status === 'Handling')
+    .sort((a, b) => (b.startedAt || 0) - (a.startedAt || 0));
+  const finished = jobs
+    .filter((j) => j.status !== 'Handling')
+    .sort((a, b) => (b.finishedAt || 0) - (a.finishedAt || 0));
+  const merged = handling.concat(finished).slice(0, MAX_JOBS);
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
+  return merged;
+}
+
+function emit(jobs) {
+  const list = jobs || loadJobs();
+  listeners.forEach((cb) => {
+    try {
+      cb(list);
+    } catch (e) {
+      /* subscriber error ignored */
+    }
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent(EVENT_NAME, { detail: { jobs: list } })
+    );
+  }
+}
+
+function upsertJob(job) {
+  const jobs = loadJobs().filter((j) => j.requestId !== job.requestId);
+  jobs.push(job);
+  const saved = saveJobs(jobs);
+  emit(saved);
+}
+
+function stopTimer(requestId) {
+  if (timers.has(requestId)) {
+    clearInterval(timers.get(requestId));
+    timers.delete(requestId);
+  }
+}
+
+function showProgress(job) {
+  const toast = toastApi();
+  if (!toast || !toast.showToast) {
+    return;
+  }
+  toast.showToast(
+    toast.TOAST_TYPES ? toast.TOAST_TYPES.PROGRESS : 'progress',
+    job.label + ' — processing...',
+    { id: toastIdFor(job.requestId), autohide: false }
+  );
+}
+
+function finishToast(job, type, message) {
+  const toast = toastApi();
+  if (!toast) {
+    return;
+  }
+  if (toast.hideToast) {
+    toast.hideToast(toastIdFor(job.requestId));
+  }
+  if (toast.showToast) {
+    const t = toast.TOAST_TYPES
+      ? (type === 'success' ? toast.TOAST_TYPES.SUCCESS : toast.TOAST_TYPES.ERROR)
+      : type;
+    toast.showToast(t, message);
+  }
+}
+
+function markFinished(requestId, status, message) {
+  stopTimer(requestId);
+  const jobs = loadJobs();
+  const job = jobs.find((j) => j.requestId === requestId);
+  if (!job) {
+    return;
+  }
+  job.status = status;
+  job.finishedAt = Date.now();
+  if (message) {
+    job.message = message;
+  }
+  const saved = saveJobs(jobs);
+  emit(saved);
+  return job;
+}
+
+async function pollOnce(job) {
+  try {
+    const response = await webconsolejs['common/api/http'].commonAPIPost(
+      GET_REQUEST_URL,
+      { pathParams: { reqId: job.requestId } },
+      undefined,
+      { loaderType: 'none' }
+    );
+
+    const statusCode = response && response.status;
+    const details =
+      (response && response.data && response.data.responseData) ||
+      (response && response.data) ||
+      {};
+    const status = details.status || details.Status;
+
+    if (status === 'Success' || status === 'success') {
+      const msg = job.label + ' — completed';
+      finishToast(job, 'success', msg);
+      markFinished(job.requestId, 'Success', msg);
+      return;
+    }
+    if (status === 'Error' || status === 'error') {
+      const errMsg = details.errorResponse || details.ErrorResponse || 'failed';
+      const msg = job.label + ' — ' + errMsg;
+      finishToast(job, 'error', msg);
+      markFinished(job.requestId, 'Error', msg);
+      return;
+    }
+
+    if (statusCode === 404 || (response && response.response && response.response.status === 404)) {
+      return;
+    }
+  } catch (e) {
+    // network blip — keep polling until timeout
+  }
+}
+
+function startPolling(job) {
+  if (timers.has(job.requestId)) {
+    return;
+  }
+  const tick = () => {
+    const current = loadJobs().find((j) => j.requestId === job.requestId);
+    if (!current || current.status !== 'Handling') {
+      stopTimer(job.requestId);
+      return;
+    }
+    if (Date.now() - current.startedAt > MAX_MS) {
+      const msg = current.label + ' — status check timed out';
+      finishToast(current, 'error', msg);
+      markFinished(current.requestId, 'Timeout', msg);
+      return;
+    }
+    pollOnce(current);
+  };
+  timers.set(job.requestId, setInterval(tick, POLL_MS));
+  tick();
+}
+
+/**
+ * Register async tracking for a requestId already (or about to be) sent.
+ */
+export function track(opts) {
+  const requestId = opts.requestId;
+  if (!requestId) {
+    return;
+  }
+  const job = {
+    requestId,
+    operationId: opts.operationId || '',
+    label: opts.label || opts.operationId || 'Request',
+    startedAt: Date.now(),
+    status: 'Handling',
+    href: opts.href || ''
+  };
+  upsertJob(job);
+  showProgress(job);
+  startPolling(job);
+}
+
+export function resume() {
+  const jobs = loadJobs();
+  jobs.filter((j) => j.status === 'Handling').forEach((job) => {
+    showProgress(job);
+    startPolling(job);
+  });
+  emit(jobs);
+}
+
+export function listJobs() {
+  return loadJobs();
+}
+
+export function getHandlingCount() {
+  return loadJobs().filter((j) => j.status === 'Handling').length;
+}
+
+export function subscribe(cb) {
+  if (typeof cb !== 'function') {
+    return function noop() {};
+  }
+  listeners.add(cb);
+  cb(loadJobs());
+  return function unsubscribe() {
+    listeners.delete(cb);
+  };
+}
+
+export function clearFinished() {
+  const saved = saveJobs(loadJobs().filter((j) => j.status === 'Handling'));
+  emit(saved);
+}
+
+export function dismiss(requestId) {
+  stopTimer(requestId);
+  const saved = saveJobs(loadJobs().filter((j) => j.requestId !== requestId));
+  emit(saved);
+}
+
+export const ASYNC_REQUEST_EVENT = EVENT_NAME;
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', resume);
+  } else {
+    setTimeout(resume, 0);
+  }
+}

--- a/front/assets/js/common/api/http.js
+++ b/front/assets/js/common/api/http.js
@@ -85,9 +85,15 @@ export async function commonAPIPost(url, data, attempt, options = {}) {
   console.log("Loader Type :", loaderType);
   console.log("-----------------------");
   
+  // Custom headers (e.g. x-request-id for tumblebug RequestMap)
+  const axiosConfig = {};
+  if (options.headers && typeof options.headers === 'object') {
+    axiosConfig.headers = options.headers;
+  }
+
   try {
     if (data === undefined || data === null) {
-      var response = await axios.post(url);
+      var response = await axios.post(url, undefined, axiosConfig);
     } else if (data.formData instanceof FormData) {
       // FormData 처리 분기 - axios 사용
       console.log("FormData detected, sending with axios");
@@ -110,9 +116,9 @@ export async function commonAPIPost(url, data, attempt, options = {}) {
       
       // FormData 사용 시 Content-Type 헤더를 설정하지 않음
       // 브라우저가 자동으로 boundary 정보와 함께 올바른 헤더를 설정
-      var response = await axios.post(url, data.formData);
+      var response = await axios.post(url, data.formData, axiosConfig);
     } else {
-      var response = await axios.post(url, data);
+      var response = await axios.post(url, data, axiosConfig);
     }
     
     console.log("#### commonAPIPost Response");

--- a/front/assets/js/common/api/requestId.js
+++ b/front/assets/js/common/api/requestId.js
@@ -1,0 +1,98 @@
+/**
+ * Generate client X-Request-ID for mc-infra-manager (cb-tumblebug) RequestMap.
+ * Format: mcwc-{yyyyMMddHHmmss}-{8hex}
+ *
+ * ASYNC_TRACK_OPERATION_IDS: GetRequest toast/navbar allowlist
+ * (WEB-TECH-017 Phase1 create + Phase2 Control/Delete/NodeGroup)
+ */
+
+/** @type {readonly string[]} */
+export const ASYNC_TRACK_OPERATION_IDS = Object.freeze([
+  // Phase 1 — create
+  'PostInfraDynamic',
+  'PostInfraDynamicFromTemplate',
+  'PostK8sClusterDynamic',
+  // Phase 2 — nodegroup / scale
+  'PostInfraNodeGroupDynamic',
+  'PostInfraNodeGroupScaleOut',
+  'PostK8sNodeGroupDynamic',
+  'Postk8snodegroup',
+  // Phase 2 — control
+  'GetControlInfra',
+  'GetControlInfraNode',
+  // Phase 2 — delete
+  'DelInfra',
+  'DelInfraNode',
+  'Deletek8scluster',
+  'Deletek8snodegroup',
+]);
+
+function pad(n, width) {
+  const s = String(n);
+  return s.length >= width ? s : ('0'.repeat(width - s.length) + s);
+}
+
+function formatTimestamp(date) {
+  return (
+    date.getFullYear() +
+    pad(date.getMonth() + 1, 2) +
+    pad(date.getDate(), 2) +
+    pad(date.getHours(), 2) +
+    pad(date.getMinutes(), 2) +
+    pad(date.getSeconds(), 2)
+  );
+}
+
+function randomHex8() {
+  const bytes = new Uint8Array(4);
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  return Array.from(bytes, (b) => pad(b.toString(16), 2)).join('');
+}
+
+/**
+ * @returns {string} requestId for x-request-id header
+ */
+export function generateRequestId() {
+  return 'mcwc-' + formatTimestamp(new Date()) + '-' + randomHex8();
+}
+
+export function xRequestIdHeaders(requestId) {
+  return { 'x-request-id': requestId };
+}
+
+export function isAsyncTrackOperation(operationId) {
+  return ASYNC_TRACK_OPERATION_IDS.indexOf(operationId) !== -1;
+}
+
+/**
+ * Mint requestId, register tracker (allowlist only), return http options.
+ *
+ * @param {string} operationId - tumblebug / api.yaml operationId
+ * @param {string} [label] - navbar / toast label
+ * @returns {{ requestId: string, headers: Object, httpOptions: Object }}
+ */
+export function beginTrackedRequest(operationId, label) {
+  const requestId = generateRequestId();
+  const headers = xRequestIdHeaders(requestId);
+  if (isAsyncTrackOperation(operationId)) {
+    const tracker = webconsolejs && webconsolejs['common/api/asyncRequestTracker'];
+    if (tracker && typeof tracker.track === 'function') {
+      tracker.track({
+        requestId: requestId,
+        operationId: operationId,
+        label: label || operationId,
+      });
+    }
+  }
+  return {
+    requestId: requestId,
+    headers: headers,
+    httpOptions: { loaderType: 'none', headers: headers },
+  };
+}

--- a/front/assets/js/common/api/services/infratemplate_api.js
+++ b/front/assets/js/common/api/services/infratemplate_api.js
@@ -59,7 +59,27 @@ export async function deployFromTemplate(ns, templateId, applyReq, option, optio
     request: applyReq
   };
   if (option) params.queryParams = { option };
-  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, params, undefined, options);
+
+  const labelName = (applyReq && applyReq.name) ? applyReq.name : templateId;
+  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+    'PostInfraDynamicFromTemplate',
+    'MCI from template: ' + labelName
+  );
+
+  const mergedOptions = Object.assign({}, options || {}, {
+    loaderType: (options && options.loaderType) || 'none',
+    headers: Object.assign(
+      {},
+      (options && options.headers) || {},
+      tracked.headers
+    )
+  });
+  const response = await webconsolejs['common/api/http'].commonAPIPost(
+    controller,
+    params,
+    undefined,
+    mergedOptions
+  );
   return response;
 }
 

--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -152,9 +152,15 @@ export function mciLifeCycle(type, currentMciId, nsId) {
     }
   };
   let controller = "/api/" + "mc-infra-manager/" + "GetControlInfra";
+  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+    'GetControlInfra',
+    'MCI ' + type + ': ' + currentMciId
+  );
   let response = webconsolejs["common/api/http"].commonAPIPost(
     controller,
-    data
+    data,
+    false,
+    tracked.httpOptions
   );
   return response;
 }
@@ -171,9 +177,15 @@ export function mciDelete(currentMciId, nsId) {
     }
   };
   let controller = "/api/" + "mc-infra-manager/" + "DelInfra";
+  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+    'DelInfra',
+    'MCI delete: ' + currentMciId
+  );
   let response = webconsolejs["common/api/http"].commonAPIPost(
     controller,
-    data
+    data,
+    false,
+    tracked.httpOptions
   );
   return response;
 }
@@ -190,9 +202,15 @@ export function vmDelete(mciId, nsId, vmId) {
     }
   };
   let controller = "/api/" + "mc-infra-manager/" + "DelInfraNode";
+  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+    'DelInfraNode',
+    'VM delete: ' + vmId
+  );
   let response = webconsolejs["common/api/http"].commonAPIPost(
     controller,
-    data
+    data,
+    false,
+    tracked.httpOptions
   );
   return response;
 }
@@ -211,9 +229,15 @@ export function vmLifeCycle(type, mciId, nsId, vmid) {
     }
   };
   let controller = "/api/" + "mc-infra-manager/" + "GetControlInfraNode";
+  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+    'GetControlInfraNode',
+    'VM ' + type + ': ' + vmid
+  );
   let response = webconsolejs["common/api/http"].commonAPIPost(
     controller,
-    data
+    data,
+    false,
+    tracked.httpOptions
   );
   return response;
 }
@@ -303,15 +327,20 @@ export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, ns
   }
 
   var controller = "/api/" + "mc-infra-manager/" + "PostInfraDynamic";
-  const response = webconsolejs["common/api/http"].commonAPIPost(
+  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+    'PostInfraDynamic',
+    'MCI create: ' + mciName
+  );
+  webconsolejs["common/api/http"].commonAPIPost(
     controller,
-    data
+    data,
+    undefined,
+    tracked.httpOptions
   );
 
-  alert("Creation request completed");
   var urlParamMap = new Map();
 
-  // 생성요청했으므로 결과를 기다리지 않고 mciList로 보냄
+  // 생성요청했으므로 결과를 기다리지 않고 mciList로 보냄 (상태는 tracker toast로 표시)
   // webconsolejs["common/util"].changePage("MciMng", urlParamMap)
   window.location = "/webconsole/operations/manage/workloads/mciworkloads"
 }
@@ -340,10 +369,18 @@ export async function vmDynamic(mciId, nsId, Express_Server_Config_Arr) {
 
 
   var controller = "/api/" + "mc-infra-manager/" + "PostInfraNodeGroupDynamic";
+  const ngName = (obj && obj.name) ? obj.name : 'nodegroup';
+  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+    'PostInfraNodeGroupDynamic',
+    'NodeGroup add: ' + ngName
+  );
   const response = await webconsolejs["common/api/http"].commonAPIPost(
     controller,
-    data
-  )
+    data,
+    false,
+    tracked.httpOptions
+  );
+  return response;
 }
 
 export async function mciRecommendVm(data) {
@@ -736,9 +773,13 @@ export async function postScaleOutSubGroup(nsId, mciId, subgroupId, numVMsToAdd)
   };
 
   var controller = "/api/" + "mc-infra-manager/" + "PostInfraNodeGroupScaleOut";
-  webconsolejs["common/api/http"].commonAPIPost(controller, data)
+  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+    'PostInfraNodeGroupScaleOut',
+    'ScaleOut: ' + subgroupId + ' +' + numVMsToAdd
+  );
+  webconsolejs["common/api/http"].commonAPIPost(controller, data, false, tracked.httpOptions)
     .catch(err => console.error("ScaleOut background error:", err));
-  return { status: "requested" }
+  return { status: "requested" };
 
 }
 

--- a/front/assets/js/common/api/services/pmk_api.js
+++ b/front/assets/js/common/api/services/pmk_api.js
@@ -289,10 +289,17 @@ export async function vmDynamic(pmkId, nsId, Express_Server_Config_Arr) {
   }
 
   var controller = "/api/" + "mc-infra-manager/" + "PostK8sNodeGroupDynamic";
+  const ngName = (obj && obj.name) ? obj.name : 'nodegroup';
+  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+    'PostK8sNodeGroupDynamic',
+    'K8s NG dynamic: ' + ngName
+  );
   const response = await webconsolejs["common/api/http"].commonAPIPost(
     controller,
-    data
-  )
+    data,
+    false,
+    tracked.httpOptions
+  );
 
   return response
 }
@@ -459,12 +466,16 @@ async function dispatchNodeGroupsConcurrently(controller, k8sClusterId, nsId, co
   for (var i = 0; i < configArr.length; i++) {
     var obj = configArr[i];
     var data = buildNodeGroupRequest(k8sClusterId, nsId, obj);
+    var tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+      'Postk8snodegroup',
+      'K8s NG create: ' + obj.name
+    );
 
     var reqPromise = webconsolejs["common/api/http"].commonAPIPost(
       controller,
       data,
       undefined,
-      { loaderType: 'toast', progressLabel: 'NodeGroup ' + obj.name }
+      tracked.httpOptions
     );
     pending.push({ name: obj.name, promise: reqPromise });
 
@@ -513,11 +524,17 @@ async function sendNodeGroupsSequentially(controller, k8sClusterId, nsId, config
   for (var i = 0; i < configArr.length; i++) {
     var obj = configArr[i];
     var data = buildNodeGroupRequest(k8sClusterId, nsId, obj);
+    var tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+      'Postk8snodegroup',
+      'K8s NG create: ' + obj.name
+    );
 
     try {
       const response = await webconsolejs["common/api/http"].commonAPIPost(
         controller,
-        data
+        data,
+        false,
+        tracked.httpOptions
       );
 
       if (response && (response.status === 200 || response.status === 201)) {
@@ -819,11 +836,20 @@ export function pmkDelete(nsId, k8sClusterId, options = {}) {
     },
   };
   let controller = '/api/' + 'mc-infra-manager/' + 'Deletek8scluster';
+  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+    'Deletek8scluster',
+    'K8s delete: ' + k8sClusterId
+  );
+  const mergedOptions = Object.assign({}, options || {}, {
+    // tracked request: 강제 none — 페이지/API Processing 로더와 중복 방지
+    loaderType: 'none',
+    headers: Object.assign({}, (options && options.headers) || {}, tracked.headers),
+  });
   let response = webconsolejs['common/api/http'].commonAPIPost(
     controller,
     data,
     false,
-    options
+    mergedOptions
   );
   return response;
 }
@@ -853,11 +879,19 @@ export function nodeGroupDelete(nsId, k8sClusterId, k8sNodeGroupName, options = 
     },
   };
   let controller = '/api/' + 'mc-infra-manager/' + 'Deletek8snodegroup';
+  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+    'Deletek8snodegroup',
+    'K8s NG delete: ' + k8sNodeGroupName
+  );
+  const mergedOptions = Object.assign({}, options || {}, {
+    loaderType: 'none',
+    headers: Object.assign({}, (options && options.headers) || {}, tracked.headers),
+  });
   let response = webconsolejs['common/api/http'].commonAPIPost(
     controller,
     data,
     false,
-    options
+    mergedOptions
   );
   return response;
 }
@@ -972,9 +1006,16 @@ export async function createK8sClusterDynamic(nsId, clusterData) {
   };
 
   var controller = "/api/" + "mc-infra-manager/" + "Postk8sclusterdynamic";
-  const response = await webconsolejs["common/api/http"].commonAPIPost(
+  const clusterName = (clusterData && clusterData.name) ? clusterData.name : 'cluster';
+  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+    'PostK8sClusterDynamic',
+    'K8s create: ' + clusterName
+  );
+  const response = webconsolejs["common/api/http"].commonAPIPost(
     controller,
-    data
+    data,
+    undefined,
+    tracked.httpOptions
   );
 
   return response;

--- a/front/assets/js/pages/operation/manage/mci.js
+++ b/front/assets/js/pages/operation/manage/mci.js
@@ -568,15 +568,14 @@ function updateMciLabelsTab(mciData) {
   }
 }
 
-// mci 삭제
+// mci 삭제 — requestId tracker가 progress/결과 toast 담당
 export function deleteMci() {
   const deletingMciId = window.currentMciId;
   window.currentMciId = "";
   webconsolejs["partials/layout/navigatePages"].deactiveElement(document.getElementById("mci_info"));
   mciListTable.deselectRow();
-  executeWithToast(
+  executeTrackedRequest(
     () => webconsolejs["common/api/services/mci_api"].mciDelete(deletingMciId, window.currentNsId),
-    "MCI deleted successfully",
     "MCI deletion failed"
   ).then(() => {
     refreshMciList();
@@ -587,16 +586,28 @@ export function deleteMci() {
 export function deleteVm() {
   const deletingVmId = currentVmId;
   resetDefaultTabSelections();
-  executeWithToast(
+  executeTrackedRequest(
     () => webconsolejs["common/api/services/mci_api"].vmDelete(window.currentMciId, window.currentNsId, deletingVmId),
-    "VM deleted successfully",
     "VM deletion failed"
   ).then(() => {
     refreshMciList();
   });
 }
 
-// 공통 API 호출 래퍼 함수 (Toast 포함)
+// requestId 추적 API용: 레거시 "API Processing..." / 즉시 success toast 생략
+// (asyncRequestTracker가 GetRequest 기반 progress·결과 toast를 표시)
+function executeTrackedRequest(apiCall, errorMessage) {
+  return Promise.resolve(apiCall())
+    .catch((error) => {
+      webconsolejs["common/utils/toast"].showToast(
+        webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR,
+        errorMessage
+      );
+      throw error;
+    });
+}
+
+// 공통 API 호출 래퍼 함수 (Toast 포함) — 짧은 sync 작업용 (template save 등)
 function executeWithToast(apiCall, successMessage, errorMessage) {
   // 진행 상태 표시
   webconsolejs["common/utils/toast"].showProgressToast("API", "processing");
@@ -626,9 +637,8 @@ export function changeMciLifeCycle(type) {
     webconsolejs['partials/layout/modal'].commonShowDefaultModal('Validation', 'Please select an MCI')
     return;
   }
-  executeWithToast(
+  executeTrackedRequest(
     () => webconsolejs["common/api/services/mci_api"].mciLifeCycle(type, window.currentMciId, window.currentNsId),
-    `MCI ${type} completed successfully`,
     `MCI ${type} failed`
   ).then(() => {
     refreshMciList();
@@ -642,9 +652,8 @@ export function changeVmLifeCycle(type) {
     return;
   }
   if (selectedVmId) {
-    executeWithToast(
+    executeTrackedRequest(
       () => webconsolejs["common/api/services/mci_api"].vmLifeCycle(type, window.currentMciId, window.currentNsId, selectedVmId),
-      `VM ${type} completed successfully`,
       `VM ${type} failed`
     ).then(() => {
       refreshMciList();
@@ -2164,14 +2173,8 @@ function providerFormatterString(data) {
     btnOk.addEventListener('click', () => {
       var numVMsToAdd = parseInt(inputBox.value, 10)
       
-      // 로딩 프로그레스 토스트 표시
-      webconsolejs["common/utils/toast"].showProgressToast("ScaleOut", "processing");
-      
-      // API 호출 (fire-and-forget: tumblebug ScaleOut은 VM 생성 완료까지 수분 소요)
+      // fire-and-forget: requestId tracker가 ScaleOut progress/결과 toast 표시
       webconsolejs["common/api/services/mci_api"].postScaleOutSubGroup(window.currentNsId, currentMciId, currentSubGroupId, numVMsToAdd);
-      webconsolejs["common/utils/toast"].hideProgressToast();
-      alert(`ScaleOut 요청이 접수되었습니다.\nVM 생성이 완료되면 Group 탭을 새로고침하세요.`);
-
     });
     li.appendChild(btnOk);
     

--- a/front/assets/js/pages/operation/manage/pmk.js
+++ b/front/assets/js/pages/operation/manage/pmk.js
@@ -1693,14 +1693,11 @@ export async function deployPmkDynamic() {
             }
         }
 
-        // 동적 클러스터 생성 API 호출 (비동기 - 결과를 기다리지 않음)
+        // 동적 클러스터 생성 API 호출 (비동기 - requestId toast로 상태 표시)
         webconsolejs["common/api/services/pmk_api"].createK8sClusterDynamic(
             selectedWorkspaceProject.nsId,
             createData
         );
-
-        // 즉시 Toast 메시지 표시
-        webconsolejs['common/util'].showToast('Cluster creation request has been sent', 'info');
 
         // 폼 초기화
         $("#cluster_name_dynamic").val("");

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -1293,14 +1293,13 @@ export async function deployFromSelectedTemplate() {
 	if (deployBtn) deployBtn.disabled = true;
 
 	try {
-		// mciDynamic과 동일한 비동기 방식 — 생성 요청만 보내고 결과를 기다리지 않는다
+		// requestId toast로 상태 표시 — 생성 요청만 보내고 결과를 기다리지 않는다
 		webconsolejs["common/api/services/infratemplate_api"]
 			.deployFromTemplate(nsId, template.id, applyReq, undefined, { loaderType: "none" })
 			.catch(() => {});
 		templateDeploySucceeded = true;
 		bootstrap.Modal.getInstance(document.getElementById("infra-template-select-modal"))?.hide();
-		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.SUCCESS, "MCI creation request completed.");
-		// Toast가 보이도록 잠시 후 이동
+		// Toast가 보이도록 잠시 후 이동 (진행/완료는 asyncRequestTracker)
 		setTimeout(() => { window.location.href = "/webconsole/operations/manage/workloads/mciworkloads"; }, 1500);
 	} catch (e) {
 		templateDeployInFlight = false;

--- a/front/templates/application.html
+++ b/front/templates/application.html
@@ -56,6 +56,9 @@
   {{ javascriptTag("partials/layout/navigatePages.js") | raw }}
   {{ javascriptTag("partials/layout/modal.js") | raw }}
   {{ javascriptTag("common/utils/toast.js") | raw }}
+  {{ javascriptTag("common/api/requestId.js") | raw }}
+  {{ javascriptTag("common/api/asyncRequestTracker.js") | raw }}
+  {{ javascriptTag("common/api/asyncRequestNotify.js") | raw }}
 
   </body>
 

--- a/front/templates/partials/layout/_navbar.html
+++ b/front/templates/partials/layout/_navbar.html
@@ -21,89 +21,26 @@
 
                 <div class="nav-item dropdown d-none d-md-flex me-3">
 
-                    <a href="#" class="nav-link px-0" data-bs-toggle="dropdown" tabindex="-1" aria-label="Show notifications">
+                    <a href="#" class="nav-link px-0" data-bs-toggle="dropdown" tabindex="-1" aria-label="Show notifications" id="async-request-notif-toggle">
                         <!-- Download SVG icon from http://tabler-icons.io/i/bell -->
                         <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 5a2 2 0 1 1 4 0a7 7 0 0 1 4 6v3a4 4 0 0 0 2 3h-16a4 4 0 0 0 2 -3v-3a7 7 0 0 1 4 -6" /><path d="M9 17v1a3 3 0 0 0 6 0v-1" /></svg>
-                        <span class="badge bg-red"></span>
+                        <span class="badge bg-red d-none" id="async-request-notif-badge"></span>
                     </a>
 
-                    <div class="dropdown-menu dropdown-menu-arrow dropdown-menu-end dropdown-menu-card">
+                    <div class="dropdown-menu dropdown-menu-arrow dropdown-menu-end dropdown-menu-card" id="async-request-notif-menu">
 
-                        <div class="card">
+                        <div class="card" style="min-width: 22rem; max-width: 28rem;">
 
                             <div class="card-header">
-                                <h3 class="card-title">Last updates</h3>
+                                <h3 class="card-title">Requests</h3>
+                                <div class="card-actions">
+                                    <a href="#" class="btn btn-sm" id="async-request-notif-clear">Clear finished</a>
+                                </div>
                             </div>
 
-                            <div class="list-group list-group-flush list-group-hoverable">
-                                <div class="list-group-item">
-                                <div class="row align-items-center">
-                                    <div class="col-auto"><span class="status-dot status-dot-animated bg-red d-block"></span></div>
-                                    <div class="col text-truncate">
-                                    <a href="#" class="text-body d-block">Example 1</a>
-                                    <div class="d-block text-secondary text-truncate mt-n1">
-                                        Change deprecated html tags to text decoration classes (#29604)
-                                    </div>
-                                    </div>
-                                    <div class="col-auto">
-                                    <a href="#" class="list-group-item-actions">
-                                        <!-- Download SVG icon from http://tabler-icons.io/i/star -->
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon text-muted" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z" /></svg>
-                                    </a>
-                                    </div>
-                                </div>
-                                </div>
-                                <div class="list-group-item">
-                                <div class="row align-items-center">
-                                    <div class="col-auto"><span class="status-dot d-block"></span></div>
-                                    <div class="col text-truncate">
-                                    <a href="#" class="text-body d-block">Example 2</a>
-                                    <div class="d-block text-secondary text-truncate mt-n1">
-                                        justify-content:between ⇒ justify-content:space-between (#29734)
-                                    </div>
-                                    </div>
-                                    <div class="col-auto">
-                                    <a href="#" class="list-group-item-actions show">
-                                        <!-- Download SVG icon from http://tabler-icons.io/i/star -->
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon text-yellow" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z" /></svg>
-                                    </a>
-                                    </div>
-                                </div>
-                                </div>
-                                <div class="list-group-item">
-                                <div class="row align-items-center">
-                                    <div class="col-auto"><span class="status-dot d-block"></span></div>
-                                    <div class="col text-truncate">
-                                    <a href="#" class="text-body d-block">Example 3</a>
-                                    <div class="d-block text-secondary text-truncate mt-n1">
-                                        Update change-version.js (#29736)
-                                    </div>
-                                    </div>
-                                    <div class="col-auto">
-                                    <a href="#" class="list-group-item-actions">
-                                        <!-- Download SVG icon from http://tabler-icons.io/i/star -->
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon text-muted" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z" /></svg>
-                                    </a>
-                                    </div>
-                                </div>
-                                </div>
-                                <div class="list-group-item">
-                                <div class="row align-items-center">
-                                    <div class="col-auto"><span class="status-dot status-dot-animated bg-green d-block"></span></div>
-                                    <div class="col text-truncate">
-                                    <a href="#" class="text-body d-block">Example 4</a>
-                                    <div class="d-block text-secondary text-truncate mt-n1">
-                                        Regenerate package-lock.json (#29730)
-                                    </div>
-                                    </div>
-                                    <div class="col-auto">
-                                    <a href="#" class="list-group-item-actions">
-                                        <!-- Download SVG icon from http://tabler-icons.io/i/star -->
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon text-muted" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z" /></svg>
-                                    </a>
-                                    </div>
-                                </div>
-                                </div>
+                            <div class="list-group list-group-flush list-group-hoverable" id="async-request-notif-list"></div>
+                            <div class="card-body text-secondary text-center d-none" id="async-request-notif-empty">
+                                No request history
                             </div>
                             
                         </div>


### PR DESCRIPTION
## Summary
- Front mint `x-request-id` (`mcwc-{yyyyMMddHHmmss}-{8hex}`) and track long-running infra ops via `GetRequest` polling (toast + navbar Requests badge).
- Phase 1 create: `PostInfraDynamic` / `PostInfraDynamicFromTemplate` / `PostK8sClusterDynamic`.
- Phase 2: Control (`GetControlInfra`/`Node`), Delete (`DelInfra`/`Node`, K8s delete), NodeGroup/ScaleOut allowlist via `beginTrackedRequest`.
- Avoid duplicate "API Processing" toast on lifecycle by using tracker-only UX for tracked ops.
- CORS: allow `x-request-id` header.

