### PR TITLE
[feat]: notice - Persist requestId async jobs 

### DIFF
--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -49,6 +49,7 @@ func main() {
 	jwt.SetSecretKey(jwtSecret)
 
 	// 데이터베이스 초기화 (MC_WEB_CONSOLE_POSTGRES_HOST 환경변수가 설정된 경우에만 활성화)
+	dbEnabled := false
 	if os.Getenv("MC_WEB_CONSOLE_POSTGRES_HOST") != "" {
 		if err := repository.InitDatabase(cfg); err != nil {
 			log.Fatalf("Failed to initialize database: %v", err)
@@ -59,6 +60,7 @@ func main() {
 		if err := repository.AutoMigrate(); err != nil {
 			log.Fatalf("Failed to migrate database: %v", err)
 		}
+		dbEnabled = true
 	} else {
 		log.Println("⚠️  MC_WEB_CONSOLE_POSTGRES_HOST not configured, running without database (session management disabled)")
 	}
@@ -119,6 +121,17 @@ func main() {
 	// 단일 세그먼트 내부 핸들러
 	api.POST("/disklookup", handler.DiskLookup)
 	api.POST("/getapihosts", handler.GetApiHosts)
+
+	// Async request history (WEB-TECH-017) — must register before subsystem wildcard
+	asyncReq := api.Group("/async-requests")
+	asyncReq.GET("", handler.ListAsyncRequests)
+	asyncReq.DELETE("", handler.ClearFinishedAsyncRequests)
+	asyncReq.PATCH("/:requestId", handler.PatchAsyncRequest)
+	asyncReq.DELETE("/:requestId", handler.DeleteAsyncRequest)
+
+	if dbEnabled {
+		service.StartAsyncRequestPoller(cfg)
+	}
 
 	// 관리자 전용 BFF 라우트 (와일드카드보다 먼저 등록되어야 정적 매칭됨)
 	// FR-CLOUD-ADMIN-006-08: 외부 raw YAML 도달성 확인 (CORS 우회 + 토큰 노출 방지)

--- a/api/internal/handler/async_request.go
+++ b/api/internal/handler/async_request.go
@@ -1,0 +1,228 @@
+package handler
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"mc_web_console_api/internal/model"
+	"mc_web_console_api/internal/repository"
+	"mc_web_console_api/internal/service"
+	"mc_web_console_api/pkg/errors"
+	"mc_web_console_api/pkg/jwt"
+
+	"github.com/labstack/echo/v4"
+)
+
+// ResolveUserIDFromRequest resolves user id from Bearer / raw JWT / session token.
+// Used by Proxy upsert and async-request APIs under MCIAM (Keycloak) tokens.
+func ResolveUserIDFromRequest(c echo.Context) string {
+	if uid, ok := c.Get("userId").(string); ok && uid != "" {
+		return uid
+	}
+	raw := extractRawAccessToken(c)
+	if raw == "" {
+		return ""
+	}
+	if claims, err := jwt.ParseToken(raw); err == nil && claims.UserID != "" {
+		return claims.UserID
+	}
+	if db := repository.GetDB(); db != nil {
+		var sess model.UserSession
+		if err := db.Where("access_token = ?", raw).First(&sess).Error; err == nil {
+			return sess.UserID
+		}
+	}
+	return decodeUnverifiedJWTSubject(raw)
+}
+
+func extractRawAccessToken(c echo.Context) string {
+	auth := c.Request().Header.Get("Authorization")
+	if auth == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(auth), "bearer ") {
+		return strings.TrimSpace(auth[7:])
+	}
+	return strings.TrimSpace(auth)
+}
+
+func decodeUnverifiedJWTSubject(token string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		payload, err = base64.StdEncoding.DecodeString(parts[1])
+		if err != nil {
+			return ""
+		}
+	}
+	var claims map[string]interface{}
+	if json.Unmarshal(payload, &claims) != nil {
+		return ""
+	}
+	for _, key := range []string{"upn", "preferred_username", "email", "sub"} {
+		if v, ok := claims[key].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func requireAsyncRepo() (*repository.AsyncRequestRepository, error) {
+	db := repository.GetDB()
+	if db == nil {
+		return nil, errors.NewBadRequest("async request store unavailable (database not configured)")
+	}
+	return repository.NewAsyncRequestRepository(db), nil
+}
+
+// ListAsyncRequests GET /api/async-requests
+func ListAsyncRequests(c echo.Context) error {
+	userID := ResolveUserIDFromRequest(c)
+	if userID == "" {
+		return errors.NewUnauthorized("Missing or invalid authorization")
+	}
+	repo, err := requireAsyncRepo()
+	if err != nil {
+		return err
+	}
+	rows, err := repo.ListByUser(userID, 50)
+	if err != nil {
+		return errors.NewInternalServerError("Failed to list async requests", err)
+	}
+	dtos := make([]model.AsyncRequestDTO, 0, len(rows))
+	for i := range rows {
+		dtos = append(dtos, rows[i].ToDTO())
+	}
+	resp := model.CommonResponseStatusOK(dtos)
+	return c.JSON(resp.Status.Code, resp)
+}
+
+// PatchAsyncRequestBody optional meta enrichment.
+type PatchAsyncRequestBody struct {
+	Label string `json:"label"`
+	Href  string `json:"href"`
+	NsID  string `json:"nsId"`
+}
+
+// PatchAsyncRequest PATCH /api/async-requests/:requestId
+func PatchAsyncRequest(c echo.Context) error {
+	userID := ResolveUserIDFromRequest(c)
+	if userID == "" {
+		return errors.NewUnauthorized("Missing or invalid authorization")
+	}
+	requestID := c.Param("requestId")
+	if requestID == "" {
+		return errors.NewBadRequest("requestId is required")
+	}
+	var body PatchAsyncRequestBody
+	_ = c.Bind(&body)
+	repo, err := requireAsyncRepo()
+	if err != nil {
+		return err
+	}
+	if err := repo.PatchMeta(requestID, userID, body.Label, body.Href, body.NsID); err != nil {
+		return errors.NewInternalServerError("Failed to patch async request", err)
+	}
+	resp := model.CommonResponseStatusOK(map[string]string{"requestId": requestID})
+	return c.JSON(resp.Status.Code, resp)
+}
+
+// DeleteAsyncRequest DELETE /api/async-requests/:requestId
+func DeleteAsyncRequest(c echo.Context) error {
+	userID := ResolveUserIDFromRequest(c)
+	if userID == "" {
+		return errors.NewUnauthorized("Missing or invalid authorization")
+	}
+	requestID := c.Param("requestId")
+	if requestID == "" {
+		return errors.NewBadRequest("requestId is required")
+	}
+	repo, err := requireAsyncRepo()
+	if err != nil {
+		return err
+	}
+	if err := repo.DeleteByRequestIDAndUser(requestID, userID); err != nil {
+		return errors.NewInternalServerError("Failed to dismiss async request", err)
+	}
+	resp := model.CommonResponseStatusOK(map[string]string{"requestId": requestID})
+	return c.JSON(resp.Status.Code, resp)
+}
+
+// ClearFinishedAsyncRequests DELETE /api/async-requests?finished=1
+func ClearFinishedAsyncRequests(c echo.Context) error {
+	userID := ResolveUserIDFromRequest(c)
+	if userID == "" {
+		return errors.NewUnauthorized("Missing or invalid authorization")
+	}
+	if c.QueryParam("finished") != "1" && c.QueryParam("finished") != "true" {
+		return c.NoContent(http.StatusMethodNotAllowed)
+	}
+	repo, err := requireAsyncRepo()
+	if err != nil {
+		return err
+	}
+	if err := repo.DeleteFinishedByUser(userID); err != nil {
+		return errors.NewInternalServerError("Failed to clear finished requests", err)
+	}
+	resp := model.CommonResponseStatusOK(map[string]string{"cleared": "finished"})
+	return c.JSON(resp.Status.Code, resp)
+}
+
+// PersistTrackedProxyRequest upserts Handling before proxy Do (best-effort).
+func PersistTrackedProxyRequest(
+	c echo.Context,
+	subsystemName, operationID, requestID string,
+) {
+	if requestID == "" || !strings.EqualFold(subsystemName, "mc-infra-manager") {
+		return
+	}
+	db := repository.GetDB()
+	if db == nil {
+		return
+	}
+	if !service.IsAsyncTrackOperation(operationID) {
+		return
+	}
+	userID := ResolveUserIDFromRequest(c)
+	if userID == "" {
+		log.Printf("async persist skip: no userId for requestId=%s op=%s", requestID, operationID)
+		return
+	}
+	label := c.Request().Header.Get("x-mcwc-label")
+	href := c.Request().Header.Get("x-mcwc-href")
+	nsID := c.Request().Header.Get("x-mcwc-ns-id")
+	if label == "" {
+		label = operationID
+	}
+	row := &model.AsyncRequest{
+		RequestID:   requestID,
+		UserID:      userID,
+		OperationID: operationID,
+		Label:       label,
+		Status:      model.AsyncStatusHandling,
+		Href:        href,
+		NsID:        nsID,
+		StartedAt:   time.Now().UTC(),
+	}
+	repo := repository.NewAsyncRequestRepository(db)
+	if err := repo.UpsertHandling(row); err != nil {
+		log.Printf("async persist upsert error requestId=%s: %v", requestID, err)
+	}
+}
+
+// MarkTrackedProxyError sets Error when proxy transport fails.
+func MarkTrackedProxyError(requestID, message string) {
+	db := repository.GetDB()
+	if db == nil || requestID == "" {
+		return
+	}
+	repo := repository.NewAsyncRequestRepository(db)
+	_ = repo.UpdateStatus(requestID, model.AsyncStatusError, message)
+}

--- a/api/internal/handler/proxy.go
+++ b/api/internal/handler/proxy.go
@@ -183,8 +183,14 @@ func SubsystemAnyController(c echo.Context) error {
 		if credHolder != "" {
 			httpReq.Header.Set("x-credential-holder", credHolder)
 		}
+		trackedReqID := ""
 		if reqID := c.Request().Header.Get("x-request-id"); reqID != "" {
 			httpReq.Header.Set("x-request-id", reqID)
+			trackedReqID = reqID
+		}
+		// Persist allowlisted async request before Do so Handling is visible immediately.
+		if trackedReqID != "" {
+			PersistTrackedProxyRequest(c, subsystemName, operationId, trackedReqID)
 		}
 	}
 
@@ -193,6 +199,9 @@ func SubsystemAnyController(c echo.Context) error {
 	client := &http.Client{}
 	resp, err := client.Do(httpReq)
 	if err != nil {
+		if reqID := c.Request().Header.Get("x-request-id"); reqID != "" {
+			MarkTrackedProxyError(reqID, "Failed to reach backend service: "+subsystemName)
+		}
 		return errors.NewInternalServerError("Failed to reach backend service: "+subsystemName, err)
 	}
 	defer resp.Body.Close()

--- a/api/internal/middleware/cors.go
+++ b/api/internal/middleware/cors.go
@@ -24,6 +24,10 @@ func CustomCORSConfig() echo.MiddlewareFunc {
 			echo.HeaderAuthorization,
 			echo.HeaderXRequestID,
 			"x-request-id",
+			"x-mcwc-label",
+			"x-mcwc-href",
+			"x-mcwc-ns-id",
+			"x-credential-holder",
 		},
 		AllowCredentials: true,
 		MaxAge:           86400, // 24시간

--- a/api/internal/model/async_request.go
+++ b/api/internal/model/async_request.go
@@ -1,0 +1,76 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Async request status values (API/DB enum; UI maps Success -> Completed).
+const (
+	AsyncStatusHandling = "Handling"
+	AsyncStatusSuccess  = "Success"
+	AsyncStatusError    = "Error"
+	AsyncStatusTimeout  = "Timeout"
+)
+
+// AsyncRequest tracks an allowlisted mc-infra-manager request by x-request-id.
+type AsyncRequest struct {
+	ID          string     `gorm:"primaryKey;type:uuid" json:"id"`
+	RequestID   string     `gorm:"column:request_id;uniqueIndex;not null;size:128" json:"request_id"`
+	UserID      string     `gorm:"column:user_id;index;not null;size:255" json:"user_id"`
+	OperationID string     `gorm:"column:operation_id;not null;size:128" json:"operation_id"`
+	Label       string     `gorm:"column:label;size:255" json:"label"`
+	Status      string     `gorm:"column:status;index;not null;size:32" json:"status"`
+	Message     string     `gorm:"column:message;type:text" json:"message"`
+	Href        string     `gorm:"column:href;type:text" json:"href"`
+	NsID        string     `gorm:"column:ns_id;size:128" json:"ns_id"`
+	StartedAt   time.Time  `gorm:"column:started_at;index;not null" json:"started_at"`
+	FinishedAt  *time.Time `gorm:"column:finished_at" json:"finished_at"`
+	CreatedAt   time.Time  `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt   time.Time  `gorm:"autoUpdateTime" json:"updated_at"`
+}
+
+// TableName GORM table name.
+func (AsyncRequest) TableName() string {
+	return "async_requests"
+}
+
+// BeforeCreate assigns a UUID primary key.
+func (a *AsyncRequest) BeforeCreate(tx *gorm.DB) error {
+	if a.ID == "" {
+		a.ID = uuid.New().String()
+	}
+	return nil
+}
+
+// AsyncRequestDTO is the Front/API list item shape.
+type AsyncRequestDTO struct {
+	RequestID   string  `json:"requestId"`
+	OperationID string  `json:"operationId"`
+	Label       string  `json:"label"`
+	Status      string  `json:"status"`
+	StartedAt   string  `json:"startedAt"`
+	FinishedAt  *string `json:"finishedAt"`
+	Message     string  `json:"message,omitempty"`
+	Href        string  `json:"href,omitempty"`
+}
+
+// ToDTO maps the model to the Front job DTO (ISO-8601 times).
+func (a *AsyncRequest) ToDTO() AsyncRequestDTO {
+	dto := AsyncRequestDTO{
+		RequestID:   a.RequestID,
+		OperationID: a.OperationID,
+		Label:       a.Label,
+		Status:      a.Status,
+		StartedAt:   a.StartedAt.UTC().Format(time.RFC3339Nano),
+		Message:     a.Message,
+		Href:        a.Href,
+	}
+	if a.FinishedAt != nil {
+		s := a.FinishedAt.UTC().Format(time.RFC3339Nano)
+		dto.FinishedAt = &s
+	}
+	return dto
+}

--- a/api/internal/repository/async_request_repository.go
+++ b/api/internal/repository/async_request_repository.go
@@ -1,0 +1,159 @@
+package repository
+
+import (
+	"errors"
+	"time"
+
+	"mc_web_console_api/internal/model"
+
+	"gorm.io/gorm"
+)
+
+// AsyncRequestRepository persists async request tracking rows.
+type AsyncRequestRepository struct {
+	db *gorm.DB
+}
+
+// NewAsyncRequestRepository creates a repository.
+func NewAsyncRequestRepository(db *gorm.DB) *AsyncRequestRepository {
+	return &AsyncRequestRepository{db: db}
+}
+
+// UpsertHandling inserts a Handling row or refreshes label/href/ns without
+// overwriting started_at or a terminal status.
+func (r *AsyncRequestRepository) UpsertHandling(row *model.AsyncRequest) error {
+	if r == nil || r.db == nil || row == nil {
+		return errors.New("async request repository not ready")
+	}
+	if row.Status == "" {
+		row.Status = model.AsyncStatusHandling
+	}
+	if row.StartedAt.IsZero() {
+		row.StartedAt = time.Now().UTC()
+	}
+
+	var existing model.AsyncRequest
+	err := r.db.Where("request_id = ?", row.RequestID).First(&existing).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return r.db.Create(row).Error
+		}
+		return err
+	}
+
+	updates := map[string]interface{}{}
+	if row.Label != "" && existing.Label == "" {
+		updates["label"] = row.Label
+	} else if row.Label != "" {
+		updates["label"] = row.Label
+	}
+	if row.Href != "" {
+		updates["href"] = row.Href
+	}
+	if row.NsID != "" {
+		updates["ns_id"] = row.NsID
+	}
+	if row.UserID != "" && existing.UserID == "" {
+		updates["user_id"] = row.UserID
+	}
+	if existing.Status == model.AsyncStatusHandling {
+		// keep Handling; no started_at overwrite
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	return r.db.Model(&existing).Updates(updates).Error
+}
+
+// UpdateStatus updates status/message/finished_at on the same request_id row.
+// finished_at is set only on first transition to a terminal status.
+func (r *AsyncRequestRepository) UpdateStatus(
+	requestID, status, message string,
+) error {
+	if r == nil || r.db == nil {
+		return errors.New("async request repository not ready")
+	}
+	var existing model.AsyncRequest
+	if err := r.db.Where("request_id = ?", requestID).First(&existing).Error; err != nil {
+		return err
+	}
+	updates := map[string]interface{}{
+		"status": status,
+	}
+	if message != "" {
+		updates["message"] = message
+	}
+	terminal := status == model.AsyncStatusSuccess ||
+		status == model.AsyncStatusError ||
+		status == model.AsyncStatusTimeout
+	if terminal && existing.FinishedAt == nil {
+		now := time.Now().UTC()
+		updates["finished_at"] = now
+	}
+	return r.db.Model(&existing).Updates(updates).Error
+}
+
+// ListByUser returns recent jobs for a user (Handling first).
+func (r *AsyncRequestRepository) ListByUser(userID string, limit int) ([]model.AsyncRequest, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	var rows []model.AsyncRequest
+	err := r.db.Where("user_id = ?", userID).
+		Order("CASE WHEN status = 'Handling' THEN 0 ELSE 1 END ASC").
+		Order("started_at DESC").
+		Limit(limit).
+		Find(&rows).Error
+	return rows, err
+}
+
+// ListHandling returns Handling rows newer than since for the poller.
+func (r *AsyncRequestRepository) ListHandling(since time.Time) ([]model.AsyncRequest, error) {
+	var rows []model.AsyncRequest
+	err := r.db.Where("status = ? AND started_at >= ?", model.AsyncStatusHandling, since).
+		Order("started_at ASC").
+		Limit(200).
+		Find(&rows).Error
+	return rows, err
+}
+
+// DeleteByRequestIDAndUser deletes one row owned by userID.
+func (r *AsyncRequestRepository) DeleteByRequestIDAndUser(requestID, userID string) error {
+	return r.db.Where("request_id = ? AND user_id = ?", requestID, userID).
+		Delete(&model.AsyncRequest{}).Error
+}
+
+// DeleteFinishedByUser deletes terminal rows for a user.
+func (r *AsyncRequestRepository) DeleteFinishedByUser(userID string) error {
+	return r.db.Where(
+		"user_id = ? AND status IN ?",
+		userID,
+		[]string{
+			model.AsyncStatusSuccess,
+			model.AsyncStatusError,
+			model.AsyncStatusTimeout,
+		},
+	).Delete(&model.AsyncRequest{}).Error
+}
+
+// PatchMeta updates label/href/ns for a user's request.
+func (r *AsyncRequestRepository) PatchMeta(
+	requestID, userID, label, href, nsID string,
+) error {
+	updates := map[string]interface{}{}
+	if label != "" {
+		updates["label"] = label
+	}
+	if href != "" {
+		updates["href"] = href
+	}
+	if nsID != "" {
+		updates["ns_id"] = nsID
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	return r.db.Model(&model.AsyncRequest{}).
+		Where("request_id = ? AND user_id = ?", requestID, userID).
+		Updates(updates).Error
+}

--- a/api/internal/repository/database.go
+++ b/api/internal/repository/database.go
@@ -58,6 +58,7 @@ func AutoMigrate() error {
 	// 모델 등록
 	models := []interface{}{
 		&model.UserSession{},
+		&model.AsyncRequest{},
 	}
 
 	for _, model := range models {

--- a/api/internal/service/async_request_poller.go
+++ b/api/internal/service/async_request_poller.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"mc_web_console_api/internal/config"
+	"mc_web_console_api/internal/model"
+	"mc_web_console_api/internal/repository"
+)
+
+const (
+	asyncPollInterval = 2 * time.Second
+	asyncPollTTL      = 1 * time.Hour
+)
+
+// StartAsyncRequestPoller polls tumblebug GetRequest for Handling rows.
+func StartAsyncRequestPoller(cfg *config.Config) {
+	if repository.GetDB() == nil || cfg == nil {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(asyncPollInterval)
+		defer ticker.Stop()
+		log.Println("async request poller started")
+		for range ticker.C {
+			pollOnce(cfg)
+		}
+	}()
+}
+
+func pollOnce(cfg *config.Config) {
+	db := repository.GetDB()
+	if db == nil {
+		return
+	}
+	repo := repository.NewAsyncRequestRepository(db)
+	since := time.Now().UTC().Add(-asyncPollTTL)
+	rows, err := repo.ListHandling(since)
+	if err != nil {
+		log.Printf("async poller list error: %v", err)
+		return
+	}
+	for i := range rows {
+		row := &rows[i]
+		status, message, ok := fetchGetRequestStatus(cfg, row.RequestID)
+		if !ok {
+			// missing request past half TTL → Timeout
+			if time.Since(row.StartedAt) > asyncPollTTL/2 {
+				_ = repo.UpdateStatus(row.RequestID, model.AsyncStatusTimeout, "status check timed out")
+			}
+			continue
+		}
+		mapped, msg := mapTBStatus(status, message, row.Label)
+		if mapped == model.AsyncStatusHandling {
+			if msg != "" && msg != row.Message {
+				_ = repo.UpdateStatus(row.RequestID, model.AsyncStatusHandling, msg)
+			}
+			continue
+		}
+		_ = repo.UpdateStatus(row.RequestID, mapped, msg)
+	}
+}
+
+func mapTBStatus(status, errMsg, label string) (string, string) {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "success":
+		msg := label + " — completed"
+		if label == "" {
+			msg = "completed"
+		}
+		return model.AsyncStatusSuccess, msg
+	case "error":
+		msg := errMsg
+		if msg == "" {
+			msg = "failed"
+		}
+		if label != "" {
+			msg = label + " — " + msg
+		}
+		return model.AsyncStatusError, msg
+	default:
+		return model.AsyncStatusHandling, errMsg
+	}
+}
+
+func fetchGetRequestStatus(cfg *config.Config, requestID string) (status, message string, ok bool) {
+	service, actionSpec, err := cfg.ApiSpec.GetAction("mc-infra-manager", "GetRequest")
+	if err != nil || service == nil || actionSpec == nil {
+		return "", "", false
+	}
+	baseURL := service.BaseURL
+	if cfg.RegistryCache != nil && cfg.MCIAM.UseRegistryURL {
+		if u := cfg.RegistryCache.GetBaseURL("mc-infra-manager", "GetRequest"); u != "" {
+			baseURL = u
+		}
+	}
+	path := strings.ReplaceAll(actionSpec.ResourcePath, "{reqId}", requestID)
+	targetURL := baseURL + path
+
+	req, err := http.NewRequest(strings.ToUpper(actionSpec.Method), targetURL, nil)
+	if err != nil {
+		return "", "", false
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if service.Auth.Type == "basic" && service.Auth.Username != "" {
+		encoded := base64.StdEncoding.EncodeToString(
+			[]byte(service.Auth.Username + ":" + service.Auth.Password),
+		)
+		req.Header.Set("Authorization", "Basic "+encoded)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", false
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return "", "", false
+	}
+	if resp.StatusCode >= 400 {
+		return "", "", false
+	}
+
+	var payload map[string]interface{}
+	if json.Unmarshal(body, &payload) != nil {
+		return "", "", false
+	}
+	st, _ := payload["status"].(string)
+	if st == "" {
+		st, _ = payload["Status"].(string)
+	}
+	msg, _ := payload["errorResponse"].(string)
+	if msg == "" {
+		msg, _ = payload["ErrorResponse"].(string)
+	}
+	if st == "" {
+		return "", "", false
+	}
+	return st, msg, true
+}

--- a/api/internal/service/async_track.go
+++ b/api/internal/service/async_track.go
@@ -1,0 +1,35 @@
+package service
+
+import "strings"
+
+// AsyncTrackOperationIDs mirrors Front ASYNC_TRACK_OPERATION_IDS (WEB-TECH-017).
+var AsyncTrackOperationIDs = map[string]struct{}{
+	"PostInfraDynamic":             {},
+	"PostInfraDynamicFromTemplate": {},
+	"PostK8sClusterDynamic":        {},
+	"PostInfraNodeGroupDynamic":    {},
+	"PostInfraNodeGroupScaleOut":   {},
+	"PostK8sNodeGroupDynamic":      {},
+	"Postk8snodegroup":             {},
+	"GetControlInfra":              {},
+	"GetControlInfraNode":          {},
+	"DelInfra":                     {},
+	"DelInfraNode":                 {},
+	"Deletek8scluster":             {},
+	"Deletek8snodegroup":           {},
+}
+
+// IsAsyncTrackOperation reports whether operationId should be persisted.
+func IsAsyncTrackOperation(operationID string) bool {
+	_, ok := AsyncTrackOperationIDs[operationID]
+	if ok {
+		return true
+	}
+	// case-insensitive fallback for yaml casing quirks
+	for id := range AsyncTrackOperationIDs {
+		if strings.EqualFold(id, operationID) {
+			return true
+		}
+	}
+	return false
+}

--- a/front/assets/js/common/api/asyncRequestNotify.js
+++ b/front/assets/js/common/api/asyncRequestNotify.js
@@ -26,18 +26,21 @@ function statusDotClass(status) {
   return 'status-dot d-block';
 }
 
-function statusLabel(status) {
+/**
+ * UI labels: never show "Success" (ambiguous with request acceptance).
+ */
+function statusPhrase(status) {
   if (status === 'Handling') {
-    return 'Processing';
+    return 'In progress';
   }
   if (status === 'Success') {
-    return 'Success';
+    return 'Completed';
   }
   if (status === 'Timeout') {
-    return 'Timeout';
+    return 'Timed out';
   }
   if (status === 'Error') {
-    return 'Error';
+    return 'Failed';
   }
   return status || '';
 }
@@ -46,7 +49,7 @@ function formatTime(ts) {
   if (!ts) {
     return '';
   }
-  const d = new Date(ts);
+  const d = typeof ts === 'number' ? new Date(ts) : new Date(ts);
   if (Number.isNaN(d.getTime())) {
     return '';
   }
@@ -59,6 +62,24 @@ function escapeHtml(s) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
+}
+
+function buildSubtitle(job) {
+  const parts = [];
+  if (job.startedAt) {
+    parts.push('Requested ' + formatTime(job.startedAt));
+  }
+  if (job.status !== 'Handling' && job.finishedAt) {
+    parts.push('Finished ' + formatTime(job.finishedAt));
+  }
+  parts.push(shortId(job.requestId));
+  if (job.status !== 'Handling' && job.message) {
+    const shortMsg = String(job.message).replace(/^.*?—\s*/, '');
+    if (shortMsg && shortMsg !== 'completed') {
+      parts.push(shortMsg);
+    }
+  }
+  return parts.join(' · ');
 }
 
 function renderJobs(jobs) {
@@ -91,20 +112,9 @@ function renderJobs(jobs) {
 
   listEl.innerHTML = jobs
     .map((job) => {
-      const sub =
-        (job.operationId ? escapeHtml(job.operationId) + ' · ' : '') +
-        shortId(job.requestId) +
-        (job.startedAt ? ' · ' + formatTime(job.startedAt) : '');
       const title = escapeHtml(job.label || job.operationId || 'Request');
-      const st = statusLabel(job.status);
-      const msg =
-        job.status !== 'Handling' && job.message
-          ? '<div class="d-block text-secondary text-truncate mt-n1">' +
-            escapeHtml(job.message) +
-            '</div>'
-          : '<div class="d-block text-secondary text-truncate mt-n1">' +
-            escapeHtml(sub) +
-            '</div>';
+      const st = statusPhrase(job.status);
+      const sub = buildSubtitle(job);
       return (
         '<div class="list-group-item" data-request-id="' +
         escapeHtml(job.requestId) +
@@ -118,10 +128,12 @@ function renderJobs(jobs) {
         '<div class="col text-truncate">' +
         '<span class="text-body d-block">' +
         title +
-        ' <span class="text-secondary small">(' +
+        ' <span class="text-secondary small">· ' +
         escapeHtml(st) +
-        ')</span></span>' +
-        msg +
+        '</span></span>' +
+        '<div class="d-block text-secondary text-truncate mt-n1">' +
+        escapeHtml(sub) +
+        '</div>' +
         '</div>' +
         '<div class="col-auto">' +
         '<a href="#" class="list-group-item-actions async-request-dismiss" ' +
@@ -173,12 +185,11 @@ function bindActions() {
 }
 
 export function initAsyncRequestNotify() {
-  const t = tracker();
-  if (!t || !t.subscribe) {
-    return;
-  }
   bindActions();
-  t.subscribe(renderJobs);
+  const t = tracker();
+  if (t && t.subscribe) {
+    t.subscribe(renderJobs);
+  }
 }
 
 if (typeof document !== 'undefined') {

--- a/front/assets/js/common/api/asyncRequestNotify.js
+++ b/front/assets/js/common/api/asyncRequestNotify.js
@@ -64,22 +64,30 @@ function escapeHtml(s) {
     .replace(/"/g, '&quot;');
 }
 
-function buildSubtitle(job) {
-  const parts = [];
+function buildSubtitleLines(job) {
+  const line1 = [];
   if (job.startedAt) {
-    parts.push('Requested ' + formatTime(job.startedAt));
+    line1.push('Requested ' + formatTime(job.startedAt));
   }
+  if (job.requestId) {
+    line1.push(shortId(job.requestId));
+  }
+
+  const line2 = [];
   if (job.status !== 'Handling' && job.finishedAt) {
-    parts.push('Finished ' + formatTime(job.finishedAt));
+    line2.push('Finished ' + formatTime(job.finishedAt));
   }
-  parts.push(shortId(job.requestId));
   if (job.status !== 'Handling' && job.message) {
     const shortMsg = String(job.message).replace(/^.*?—\s*/, '');
     if (shortMsg && shortMsg !== 'completed') {
-      parts.push(shortMsg);
+      line2.push(shortMsg);
     }
   }
-  return parts.join(' · ');
+
+  return {
+    line1: line1.join(' · '),
+    line2: line2.join(' · '),
+  };
 }
 
 function renderJobs(jobs) {
@@ -114,7 +122,18 @@ function renderJobs(jobs) {
     .map((job) => {
       const title = escapeHtml(job.label || job.operationId || 'Request');
       const st = statusPhrase(job.status);
-      const sub = buildSubtitle(job);
+      const { line1, line2 } = buildSubtitleLines(job);
+      const subHtml =
+        (line1
+          ? '<div class="d-block text-secondary small text-wrap">' +
+            escapeHtml(line1) +
+            '</div>'
+          : '') +
+        (line2
+          ? '<div class="d-block text-secondary small text-wrap">' +
+            escapeHtml(line2) +
+            '</div>'
+          : '');
       return (
         '<div class="list-group-item" data-request-id="' +
         escapeHtml(job.requestId) +
@@ -125,15 +144,13 @@ function renderJobs(jobs) {
         '" title="' +
         escapeHtml(st) +
         '"></span></div>' +
-        '<div class="col text-truncate">' +
-        '<span class="text-body d-block">' +
+        '<div class="col text-break">' +
+        '<span class="text-body d-block text-truncate">' +
         title +
         ' <span class="text-secondary small">· ' +
         escapeHtml(st) +
         '</span></span>' +
-        '<div class="d-block text-secondary text-truncate mt-n1">' +
-        escapeHtml(sub) +
-        '</div>' +
+        subHtml +
         '</div>' +
         '<div class="col-auto">' +
         '<a href="#" class="list-group-item-actions async-request-dismiss" ' +

--- a/front/assets/js/common/api/asyncRequestNotify.js
+++ b/front/assets/js/common/api/asyncRequestNotify.js
@@ -6,14 +6,6 @@ function tracker() {
   return webconsolejs && webconsolejs['common/api/asyncRequestTracker'];
 }
 
-function shortId(requestId) {
-  if (!requestId) {
-    return '';
-  }
-  // Show full requestId; wide Requests panel wraps if needed
-  return requestId;
-}
-
 function statusDotClass(status) {
   if (status === 'Handling') {
     return 'status-dot status-dot-animated bg-azure d-block';
@@ -71,7 +63,7 @@ function buildSubtitleLines(job) {
     line1.push('Requested ' + formatTime(job.startedAt));
   }
   if (job.requestId) {
-    line1.push(shortId(job.requestId));
+    line1.push(job.requestId);
   }
 
   const line2 = [];
@@ -91,6 +83,21 @@ function buildSubtitleLines(job) {
   };
 }
 
+let lastRenderKey = '';
+
+function jobsRenderKey(jobs) {
+  return JSON.stringify(
+    (jobs || []).map((j) => [
+      j.requestId,
+      j.status,
+      j.label,
+      j.startedAt,
+      j.finishedAt,
+      j.message || '',
+    ]),
+  );
+}
+
 function renderJobs(jobs) {
   const listEl = document.getElementById('async-request-notif-list');
   const badgeEl = document.getElementById('async-request-notif-badge');
@@ -107,6 +114,29 @@ function renderJobs(jobs) {
     badgeEl.textContent = '';
     badgeEl.classList.add('d-none');
   }
+
+  // Skip DOM rewrite when content unchanged — preserves text selection / drag-copy
+  const key = jobsRenderKey(jobs);
+  if (key === lastRenderKey) {
+    return;
+  }
+  // Defer rewrite while user is selecting text inside the menu
+  try {
+    const sel = window.getSelection && window.getSelection();
+    const menu = document.getElementById('async-request-notif-menu');
+    if (
+      sel &&
+      sel.rangeCount > 0 &&
+      String(sel).length > 0 &&
+      menu &&
+      menu.contains(sel.anchorNode)
+    ) {
+      return;
+    }
+  } catch (e) {
+    // ignore selection probe errors
+  }
+  lastRenderKey = key;
 
   if (!jobs || jobs.length === 0) {
     listEl.innerHTML = '';
@@ -126,17 +156,17 @@ function renderJobs(jobs) {
       const { line1, line2 } = buildSubtitleLines(job);
       const subHtml =
         (line1
-          ? '<div class="d-block text-secondary small text-wrap">' +
+          ? '<div class="d-block text-secondary small text-wrap user-select-auto">' +
             escapeHtml(line1) +
             '</div>'
           : '') +
         (line2
-          ? '<div class="d-block text-secondary small text-wrap">' +
+          ? '<div class="d-block text-secondary small text-wrap user-select-auto">' +
             escapeHtml(line2) +
             '</div>'
           : '');
       return (
-        '<div class="list-group-item" data-request-id="' +
+        '<div class="list-group-item user-select-auto" data-request-id="' +
         escapeHtml(job.requestId) +
         '">' +
         '<div class="row align-items-center">' +
@@ -180,6 +210,15 @@ function bindActions() {
       if (t && t.clearFinished) {
         t.clearFinished();
       }
+    });
+  }
+
+  const menuEl = document.getElementById('async-request-notif-menu');
+  if (menuEl && !menuEl.dataset.selectBound) {
+    menuEl.dataset.selectBound = '1';
+    // Keep dropdown open while selecting text (mouseup may land outside)
+    menuEl.addEventListener('mousedown', (e) => {
+      e.stopPropagation();
     });
   }
 

--- a/front/assets/js/common/api/asyncRequestNotify.js
+++ b/front/assets/js/common/api/asyncRequestNotify.js
@@ -7,10 +7,11 @@ function tracker() {
 }
 
 function shortId(requestId) {
-  if (!requestId || requestId.length < 8) {
-    return requestId || '';
+  if (!requestId) {
+    return '';
   }
-  return '…' + requestId.slice(-8);
+  // Show full requestId; wide Requests panel wraps if needed
+  return requestId;
 }
 
 function statusDotClass(status) {

--- a/front/assets/js/common/api/asyncRequestTracker.js
+++ b/front/assets/js/common/api/asyncRequestTracker.js
@@ -1,17 +1,22 @@
 /**
- * Track long-running mc-infra-manager requests via GetRequest + Toast.
- * Jobs persist in sessionStorage (incl. finished history for navbar).
+ * Track long-running mc-infra-manager requests via console API + GetRequest.
+ * Primary: GET /api/async-requests (Postgres). Fallback: sessionStorage + poll.
  */
 
 const STORAGE_KEY = 'mcwc_async_requests';
 const POLL_MS = 2500;
+const LIST_REFRESH_MS = 2000;
 const MAX_MS = 15 * 60 * 1000;
 const MAX_JOBS = 20;
 const GET_REQUEST_URL = '/api/mc-infra-manager/GetRequest';
+const LIST_URL = '/api/async-requests';
 const EVENT_NAME = 'mcwc-async-request-changed';
 
 const timers = new Map();
 const listeners = new Set();
+let useServer = null;
+let listTimer = null;
+let lastToastStatus = new Map();
 
 function toastApi() {
   return webconsolejs && webconsolejs['common/utils/toast'];
@@ -21,21 +26,49 @@ function toastIdFor(requestId) {
   return 'async-req-' + requestId;
 }
 
-function loadJobs() {
+function toMillis(ts) {
+  if (ts == null || ts === '') {
+    return 0;
+  }
+  if (typeof ts === 'number') {
+    return ts;
+  }
+  const n = Date.parse(ts);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+function normalizeJob(job) {
+  if (!job) {
+    return null;
+  }
+  return {
+    requestId: job.requestId || job.request_id,
+    operationId: job.operationId || job.operation_id || '',
+    label: job.label || job.operationId || 'Request',
+    status: job.status || 'Handling',
+    startedAt: toMillis(job.startedAt || job.started_at) || Date.now(),
+    finishedAt: job.finishedAt || job.finished_at
+      ? toMillis(job.finishedAt || job.finished_at)
+      : undefined,
+    message: job.message || '',
+    href: job.href || '',
+  };
+}
+
+function loadJobsLocal() {
   try {
     const raw = sessionStorage.getItem(STORAGE_KEY);
     if (!raw) {
       return [];
     }
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
+    return Array.isArray(parsed) ? parsed.map(normalizeJob).filter(Boolean) : [];
   } catch (e) {
     return [];
   }
 }
 
-function saveJobs(jobs) {
-  // Keep Handling first by startedAt, then finished by finishedAt; cap size
+function saveJobsLocal(jobs) {
   const handling = jobs
     .filter((j) => j.status === 'Handling')
     .sort((a, b) => (b.startedAt || 0) - (a.startedAt || 0));
@@ -48,7 +81,7 @@ function saveJobs(jobs) {
 }
 
 function emit(jobs) {
-  const list = jobs || loadJobs();
+  const list = jobs || loadJobsLocal();
   listeners.forEach((cb) => {
     try {
       cb(list);
@@ -63,10 +96,10 @@ function emit(jobs) {
   }
 }
 
-function upsertJob(job) {
-  const jobs = loadJobs().filter((j) => j.requestId !== job.requestId);
+function upsertJobLocal(job) {
+  const jobs = loadJobsLocal().filter((j) => j.requestId !== job.requestId);
   jobs.push(job);
-  const saved = saveJobs(jobs);
+  const saved = saveJobsLocal(jobs);
   emit(saved);
 }
 
@@ -84,7 +117,7 @@ function showProgress(job) {
   }
   toast.showToast(
     toast.TOAST_TYPES ? toast.TOAST_TYPES.PROGRESS : 'progress',
-    job.label + ' — processing...',
+    job.label + ' — in progress...',
     { id: toastIdFor(job.requestId), autohide: false }
   );
 }
@@ -105,9 +138,9 @@ function finishToast(job, type, message) {
   }
 }
 
-function markFinished(requestId, status, message) {
+function markFinishedLocal(requestId, status, message) {
   stopTimer(requestId);
-  const jobs = loadJobs();
+  const jobs = loadJobsLocal();
   const job = jobs.find((j) => j.requestId === requestId);
   if (!job) {
     return;
@@ -117,9 +150,97 @@ function markFinished(requestId, status, message) {
   if (message) {
     job.message = message;
   }
-  const saved = saveJobs(jobs);
+  const saved = saveJobsLocal(jobs);
   emit(saved);
   return job;
+}
+
+function maybeToastTransition(prevJobs, nextJobs) {
+  const prevMap = new Map((prevJobs || []).map((j) => [j.requestId, j]));
+  (nextJobs || []).forEach((job) => {
+    const prev = prevMap.get(job.requestId);
+    const prevStatus = prev ? prev.status : lastToastStatus.get(job.requestId);
+    if (prevStatus === job.status) {
+      return;
+    }
+    lastToastStatus.set(job.requestId, job.status);
+    if (job.status === 'Handling') {
+      showProgress(job);
+      return;
+    }
+    if (job.status === 'Success') {
+      finishToast(job, 'success', job.label + ' — completed');
+      stopTimer(job.requestId);
+      return;
+    }
+    if (job.status === 'Error' || job.status === 'Timeout') {
+      finishToast(
+        job,
+        'error',
+        job.message || job.label + ' — ' + (job.status === 'Timeout' ? 'timed out' : 'failed')
+      );
+      stopTimer(job.requestId);
+    }
+  });
+}
+
+async function fetchServerJobs() {
+  const http = webconsolejs && webconsolejs['common/api/http'];
+  if (!http || !http.commonAPIGet) {
+    return null;
+  }
+  const response = await http.commonAPIGet(LIST_URL);
+  if (!response || response.status !== 200) {
+    return null;
+  }
+  const data =
+    (response.data && response.data.responseData) ||
+    (response.data && response.data.data) ||
+    response.data;
+  if (!Array.isArray(data)) {
+    return null;
+  }
+  return data.map(normalizeJob).filter(Boolean);
+}
+
+async function refreshFromServer() {
+  try {
+    const jobs = await fetchServerJobs();
+    if (jobs == null) {
+      if (useServer === true) {
+        // transient failure — keep server mode
+        return;
+      }
+      useServer = false;
+      return;
+    }
+    const prev = useServer === true ? (window.__mcwcAsyncJobsCache || []) : loadJobsLocal();
+    useServer = true;
+    window.__mcwcAsyncJobsCache = jobs;
+    maybeToastTransition(prev, jobs);
+    emit(jobs);
+    // still poll GetRequest for Handling toast progress when server list lags
+    jobs.filter((j) => j.status === 'Handling').forEach((job) => {
+      if (!timers.has(job.requestId)) {
+        startPolling(job);
+      }
+    });
+  } catch (e) {
+    if (useServer !== true) {
+      useServer = false;
+    }
+  }
+}
+
+function ensureListRefresh() {
+  if (listTimer) {
+    return;
+  }
+  listTimer = setInterval(function () {
+    if (useServer !== false) {
+      refreshFromServer();
+    }
+  }, LIST_REFRESH_MS);
 }
 
 async function pollOnce(job) {
@@ -141,14 +262,26 @@ async function pollOnce(job) {
     if (status === 'Success' || status === 'success') {
       const msg = job.label + ' — completed';
       finishToast(job, 'success', msg);
-      markFinished(job.requestId, 'Success', msg);
+      if (useServer) {
+        lastToastStatus.set(job.requestId, 'Success');
+        stopTimer(job.requestId);
+        refreshFromServer();
+      } else {
+        markFinishedLocal(job.requestId, 'Success', msg);
+      }
       return;
     }
     if (status === 'Error' || status === 'error') {
       const errMsg = details.errorResponse || details.ErrorResponse || 'failed';
       const msg = job.label + ' — ' + errMsg;
       finishToast(job, 'error', msg);
-      markFinished(job.requestId, 'Error', msg);
+      if (useServer) {
+        lastToastStatus.set(job.requestId, 'Error');
+        stopTimer(job.requestId);
+        refreshFromServer();
+      } else {
+        markFinishedLocal(job.requestId, 'Error', msg);
+      }
       return;
     }
 
@@ -165,7 +298,8 @@ function startPolling(job) {
     return;
   }
   const tick = () => {
-    const current = loadJobs().find((j) => j.requestId === job.requestId);
+    const current = (useServer ? (window.__mcwcAsyncJobsCache || []) : loadJobsLocal())
+      .find((j) => j.requestId === job.requestId);
     if (!current || current.status !== 'Handling') {
       stopTimer(job.requestId);
       return;
@@ -173,13 +307,20 @@ function startPolling(job) {
     if (Date.now() - current.startedAt > MAX_MS) {
       const msg = current.label + ' — status check timed out';
       finishToast(current, 'error', msg);
-      markFinished(current.requestId, 'Timeout', msg);
+      if (!useServer) {
+        markFinishedLocal(current.requestId, 'Timeout', msg);
+      }
+      stopTimer(job.requestId);
       return;
     }
     pollOnce(current);
   };
-  timers.set(job.requestId, setInterval(tick, POLL_MS));
+  timers.set(job.requestId, setInterval(tick, DEFAULT_POLL_MS()));
   tick();
+}
+
+function DEFAULT_POLL_MS() {
+  return POLL_MS;
 }
 
 /**
@@ -196,28 +337,47 @@ export function track(opts) {
     label: opts.label || opts.operationId || 'Request',
     startedAt: Date.now(),
     status: 'Handling',
-    href: opts.href || ''
+    href: opts.href || '',
   };
-  upsertJob(job);
+  lastToastStatus.set(requestId, 'Handling');
   showProgress(job);
+  if (useServer !== true) {
+    upsertJobLocal(job);
+  } else {
+    const cache = window.__mcwcAsyncJobsCache || [];
+    const next = cache.filter((j) => j.requestId !== requestId).concat([job]);
+    window.__mcwcAsyncJobsCache = next;
+    emit(next);
+  }
   startPolling(job);
+  ensureListRefresh();
+  refreshFromServer();
 }
 
 export function resume() {
-  const jobs = loadJobs();
-  jobs.filter((j) => j.status === 'Handling').forEach((job) => {
-    showProgress(job);
-    startPolling(job);
+  ensureListRefresh();
+  refreshFromServer().then(function () {
+    if (useServer) {
+      return;
+    }
+    const jobs = loadJobsLocal();
+    jobs.filter((j) => j.status === 'Handling').forEach((job) => {
+      showProgress(job);
+      startPolling(job);
+    });
+    emit(jobs);
   });
-  emit(jobs);
 }
 
 export function listJobs() {
-  return loadJobs();
+  if (useServer && window.__mcwcAsyncJobsCache) {
+    return window.__mcwcAsyncJobsCache;
+  }
+  return loadJobsLocal();
 }
 
 export function getHandlingCount() {
-  return loadJobs().filter((j) => j.status === 'Handling').length;
+  return listJobs().filter((j) => j.status === 'Handling').length;
 }
 
 export function subscribe(cb) {
@@ -225,21 +385,51 @@ export function subscribe(cb) {
     return function noop() {};
   }
   listeners.add(cb);
-  cb(loadJobs());
+  cb(listJobs());
   return function unsubscribe() {
     listeners.delete(cb);
   };
 }
 
-export function clearFinished() {
-  const saved = saveJobs(loadJobs().filter((j) => j.status === 'Handling'));
+export async function clearFinished() {
+  if (useServer) {
+    try {
+      await axiosDelete(LIST_URL + '?finished=1');
+      await refreshFromServer();
+      return;
+    } catch (e) {
+      /* fall through */
+    }
+  }
+  const saved = saveJobsLocal(loadJobsLocal().filter((j) => j.status === 'Handling'));
   emit(saved);
 }
 
-export function dismiss(requestId) {
+export async function dismiss(requestId) {
   stopTimer(requestId);
-  const saved = saveJobs(loadJobs().filter((j) => j.requestId !== requestId));
+  if (useServer) {
+    try {
+      await axiosDelete(LIST_URL + '/' + encodeURIComponent(requestId));
+      await refreshFromServer();
+      return;
+    } catch (e) {
+      /* fall through */
+    }
+  }
+  const saved = saveJobsLocal(loadJobsLocal().filter((j) => j.requestId !== requestId));
   emit(saved);
+}
+
+async function axiosDelete(url) {
+  const response = await fetch(url, {
+    method: 'DELETE',
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    throw new Error('DELETE ' + url + ' failed: ' + response.status);
+  }
+  return response;
 }
 
 export const ASYNC_REQUEST_EVENT = EVENT_NAME;

--- a/front/assets/js/common/api/requestId.js
+++ b/front/assets/js/common/api/requestId.js
@@ -77,16 +77,27 @@ export function isAsyncTrackOperation(operationId) {
  * @param {string} [label] - navbar / toast label
  * @returns {{ requestId: string, headers: Object, httpOptions: Object }}
  */
-export function beginTrackedRequest(operationId, label) {
+export function beginTrackedRequest(operationId, label, meta) {
   const requestId = generateRequestId();
   const headers = xRequestIdHeaders(requestId);
+  const resolvedLabel = label || operationId;
+  if (resolvedLabel) {
+    headers['x-mcwc-label'] = resolvedLabel;
+  }
+  if (meta && meta.href) {
+    headers['x-mcwc-href'] = meta.href;
+  }
+  if (meta && meta.nsId) {
+    headers['x-mcwc-ns-id'] = meta.nsId;
+  }
   if (isAsyncTrackOperation(operationId)) {
     const tracker = webconsolejs && webconsolejs['common/api/asyncRequestTracker'];
     if (tracker && typeof tracker.track === 'function') {
       tracker.track({
         requestId: requestId,
         operationId: operationId,
-        label: label || operationId,
+        label: resolvedLabel,
+        href: (meta && meta.href) || '',
       });
     }
   }

--- a/front/templates/partials/layout/_navbar.html
+++ b/front/templates/partials/layout/_navbar.html
@@ -21,15 +21,15 @@
 
                 <div class="nav-item dropdown d-none d-md-flex me-3">
 
-                    <a href="#" class="nav-link px-0" data-bs-toggle="dropdown" data-bs-auto-close="outside" tabindex="-1" aria-label="Show notifications" id="async-request-notif-toggle">
+                    <a href="#" class="nav-link px-0" data-bs-toggle="dropdown" data-bs-auto-close="false" tabindex="-1" aria-label="Show notifications" id="async-request-notif-toggle">
                         <!-- Download SVG icon from http://tabler-icons.io/i/bell -->
                         <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 5a2 2 0 1 1 4 0a7 7 0 0 1 4 6v3a4 4 0 0 0 2 3h-16a4 4 0 0 0 2 -3v-3a7 7 0 0 1 4 -6" /><path d="M9 17v1a3 3 0 0 0 6 0v-1" /></svg>
                         <span class="badge bg-red d-none" id="async-request-notif-badge"></span>
                     </a>
 
-                    <div class="dropdown-menu dropdown-menu-arrow dropdown-menu-end dropdown-menu-card" id="async-request-notif-menu">
+                    <div class="dropdown-menu dropdown-menu-arrow dropdown-menu-end dropdown-menu-card" id="async-request-notif-menu" style="user-select: text;">
 
-                        <div class="card" style="min-width: 36rem; max-width: 42rem; width: 36rem;">
+                        <div class="card" style="min-width: 36rem; max-width: 42rem; width: 36rem; user-select: text;">
 
                             <div class="card-header">
                                 <h3 class="card-title">Requests</h3>

--- a/front/templates/partials/layout/_navbar.html
+++ b/front/templates/partials/layout/_navbar.html
@@ -29,7 +29,7 @@
 
                     <div class="dropdown-menu dropdown-menu-arrow dropdown-menu-end dropdown-menu-card" id="async-request-notif-menu">
 
-                        <div class="card" style="min-width: 22rem; max-width: 28rem;">
+                        <div class="card" style="min-width: 36rem; max-width: 42rem; width: 36rem;">
 
                             <div class="card-header">
                                 <h3 class="card-title">Requests</h3>

--- a/front/templates/partials/layout/_navbar.html
+++ b/front/templates/partials/layout/_navbar.html
@@ -21,7 +21,7 @@
 
                 <div class="nav-item dropdown d-none d-md-flex me-3">
 
-                    <a href="#" class="nav-link px-0" data-bs-toggle="dropdown" tabindex="-1" aria-label="Show notifications" id="async-request-notif-toggle">
+                    <a href="#" class="nav-link px-0" data-bs-toggle="dropdown" data-bs-auto-close="outside" tabindex="-1" aria-label="Show notifications" id="async-request-notif-toggle">
                         <!-- Download SVG icon from http://tabler-icons.io/i/bell -->
                         <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 5a2 2 0 1 1 4 0a7 7 0 0 1 4 6v3a4 4 0 0 0 2 3h-16a4 4 0 0 0 2 -3v-3a7 7 0 0 1 4 -6" /><path d="M9 17v1a3 3 0 0 0 6 0v-1" /></svg>
                         <span class="badge bg-red d-none" id="async-request-notif-badge"></span>


### PR DESCRIPTION
## Summary
- Proxy upserts allowlisted `x-request-id` jobs into Postgres (`async_requests`) before forwarding to mc-infra-manager
- Background poller calls tumblebug `GetRequest` and updates the same row (`started_at` kept, `finished_at` on terminal status)
- Adds `GET/PATCH/DELETE /api/async-requests` and Front Requests dropdown uses server list (sessionStorage fallback); UI shows In progress / Completed (not Success)
- Requests dropdown: full requestId, Finished on its own line, drag-select/copy preserved across 2s list refresh
