### PR TITLE
Infra Template Add NodeGroup — 생성 폼 프리필(추가) 매핑

### DIFF
--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -460,48 +460,9 @@ export function expressDone_btn() {
   express_form["imageId"] = $("#p_imageId").val(); // imageId 추가
   express_form["specId"] = $("#p_specId").val(); // specId 추가
   express_form["command"] = $("#p_command").val();
-  
-  var server_name = express_form.name;
-  var server_cnt = parseInt(express_form.subGroupSize);
 
-  // 수정 모드인지 신규 추가 모드인지 판단
-  if (currentEditingIndex >= 0 && currentEditingIndex < Express_Server_Config_Arr.length) {
-    // 수정 모드: 기존 데이터를 업데이트
-    Express_Server_Config_Arr[currentEditingIndex] = express_form;
-    
-    // 리스트 아이템 텍스트 업데이트
-    var vmEleId = "vm";
-    if (!isVm) {
-      vmEleId = "mci";
-    }
-    var displayServerCnt = '(' + server_cnt + ')';
-    var listItem = $("#" + vmEleId + "_server_list li").eq(currentEditingIndex + 1); // +1은 plusIcon 때문
-    listItem.text(server_name + displayServerCnt);
-    
-    // 수정 모드 플래그 초기화
-    currentEditingIndex = -1;
-  } else {
-    // 신규 추가 모드: 배열에 추가하고 리스트에 추가
-    var add_server_html = "";
+  addServerConfigToList(express_form);
 
-    Express_Server_Config_Arr.push(express_form);
-
-    var displayServerCnt = '(' + server_cnt + ')';
-    add_server_html += '<li class="removebullet btn btn-info" onclick="webconsolejs[\'partials/operation/manage/mcicreate\'].view_express(\'' + express_data_cnt + '\')">'
-      + server_name + displayServerCnt
-      + '</li>';
-
-    var vmEleId = "vm";
-    if (!isVm) {
-      vmEleId = "mci";
-    }
-    $("#" + vmEleId + "_plusVmIcon").remove();
-    $("#" + vmEleId + "_server_list").append(add_server_html);
-    $("#" + vmEleId + "_server_list").prepend(getPlusVm(vmEleId));
-
-    express_data_cnt++;
-  }
-  
   // 서버 입력 폼 숨기기
   var div = document.getElementById("server_configuration");
   webconsolejs["partials/layout/navigatePages"].toggleSubElement(div);
@@ -531,6 +492,50 @@ export function expressDone_btn() {
   
   // 모달들 초기화
   resetModals();
+}
+
+// express_form을 Express_Server_Config_Arr에 반영(신규 push 또는 수정 모드 갱신) + <li> 렌더
+function addServerConfigToList(express_form) {
+  var server_name = express_form.name;
+  var server_cnt = parseInt(express_form.subGroupSize);
+
+  // 수정 모드인지 신규 추가 모드인지 판단
+  if (currentEditingIndex >= 0 && currentEditingIndex < Express_Server_Config_Arr.length) {
+    // 수정 모드: 기존 데이터를 업데이트
+    Express_Server_Config_Arr[currentEditingIndex] = express_form;
+
+    // 리스트 아이템 텍스트 업데이트
+    var vmEleId = "vm";
+    if (!isVm) {
+      vmEleId = "mci";
+    }
+    var displayServerCnt = '(' + server_cnt + ')';
+    var listItem = $("#" + vmEleId + "_server_list li").eq(currentEditingIndex + 1); // +1은 plusIcon 때문
+    listItem.text(server_name + displayServerCnt);
+
+    // 수정 모드 플래그 초기화
+    currentEditingIndex = -1;
+  } else {
+    // 신규 추가 모드: 배열에 추가하고 리스트에 추가
+    var add_server_html = "";
+
+    Express_Server_Config_Arr.push(express_form);
+
+    var displayServerCnt = '(' + server_cnt + ')';
+    add_server_html += '<li class="removebullet btn btn-info" onclick="webconsolejs[\'partials/operation/manage/mcicreate\'].view_express(\'' + express_data_cnt + '\')">'
+      + server_name + displayServerCnt
+      + '</li>';
+
+    var vmEleId = "vm";
+    if (!isVm) {
+      vmEleId = "mci";
+    }
+    $("#" + vmEleId + "_plusVmIcon").remove();
+    $("#" + vmEleId + "_server_list").append(add_server_html);
+    $("#" + vmEleId + "_server_list").prepend(getPlusVm(vmEleId));
+
+    express_data_cnt++;
+  }
 }
 
 // 모달들 초기화 함수
@@ -1306,4 +1311,64 @@ export async function deployFromSelectedTemplate() {
 		if (deployBtn) deployBtn.disabled = false;
 		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Failed to deploy from template: " + (e?.message || e));
 	}
+}
+
+// 선택한 template의 nodeGroups를 기존 SubGroup 목록에 추가(append) — 수정 후 배포용 프리필
+// infra 단위 값(description/policyOnPartialFailure/installMonAgent/sgTemplateId/vNetTemplateId/postCommand.userName·timeoutMinutes)은
+// 이 모듈 상태에 보관만 하고, 실제 배포 payload 병합은 WEB-TECH-019(FR-05-02)에서 처리한다.
+let templatePrefillInfraState = null;
+
+export function addTemplateToForm() {
+	const selected = templateSelectTable ? templateSelectTable.getSelectedData() : [];
+	if (selected.length === 0) {
+		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Please select a template");
+		return;
+	}
+	const template = selected[0];
+	const req = template.infraDynamicReq || {};
+	const groups = req.nodeGroups || [];
+
+	// 항상 append 모드로 동작 — 모달 오픈 시점에 편집 중이던 상태가 남아있지 않도록 방어
+	currentEditingIndex = -1;
+
+	groups.forEach(function (g, idx) {
+		var express_form = {};
+		express_form["provider"] = (g.specId || "").split("+")[0];
+		express_form["connectionName"] = g.connectionName || "";
+		express_form["name"] = g.name || "";
+		express_form["description"] = g.description || "";
+		express_form["subGroupSize"] = String(g.nodeGroupSize != null ? g.nodeGroupSize : 1);
+		express_form["rootDiskSize"] = g.rootDiskSize;
+		express_form["rootDiskType"] = g.rootDiskType || "";
+		express_form["commonSpec"] = g.specId || "";
+		express_form["commonImage"] = g.imageId || "";
+		express_form["imageId"] = g.imageId || "";
+		express_form["specId"] = g.specId || "";
+		// infra 단위 postCommand는 첫 SubGroup에만 반영(기존 command 처리 관례와 동일)
+		express_form["command"] = idx === 0 ? (req.postCommand?.command || []).join("\n") : "";
+
+		// 정식 매핑 승격 5필드(CreateNodeGroupDynamicReq) — template에 값이 있을 때만 carry-through
+		if (g.zone) express_form["zone"] = g.zone;
+		if (g.nodeUserPassword) express_form["nodeUserPassword"] = g.nodeUserPassword;
+		if (g.label && Object.keys(g.label).length > 0) express_form["label"] = g.label;
+		if (g.vNetTemplateId) express_form["vNetTemplateId"] = g.vNetTemplateId;
+		if (g.sgTemplateId) express_form["sgTemplateId"] = g.sgTemplateId;
+
+		addServerConfigToList(express_form);
+	});
+
+	templatePrefillInfraState = {
+		description: req.description || "",
+		policyOnPartialFailure: req.policyOnPartialFailure || "",
+		installMonAgent: req.installMonAgent || "",
+		vNetTemplateId: req.vNetTemplateId || "",
+		sgTemplateId: req.sgTemplateId || "",
+		postCommandUserName: req.postCommand?.userName || "",
+		postCommandTimeoutMinutes: req.postCommand?.timeoutMinutes
+	};
+	if (!$("#mci_desc").val() && templatePrefillInfraState.description) {
+		$("#mci_desc").val(templatePrefillInfraState.description);
+	}
+
+	bootstrap.Modal.getInstance(document.getElementById("infra-template-select-modal"))?.hide();
 }

--- a/front/templates/pages/operations/manage/workloads/mciworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/mciworkloads.html
@@ -1746,6 +1746,14 @@
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
         <button
           type="button"
+          id="btn-add-nodegroup-to-form"
+          class="btn btn-outline-primary"
+          onclick="webconsolejs['partials/operation/manage/mcicreate'].addTemplateToForm()"
+        >
+          Add NodeGroup
+        </button>
+        <button
+          type="button"
           id="btn-deploy-from-template"
           class="btn btn-primary"
           onclick="webconsolejs['partials/operation/manage/mcicreate'].deployFromSelectedTemplate()"


### PR DESCRIPTION
## Summary
- Infra Template 선택 모달에 **[Add NodeGroup]** 버튼을 [Deploy from Template]과 독립적으로 추가
- 클릭 시 선택한 template의 nodeGroups를 **기존 SubGroup 목록에 append**(교체 아님) — 수동 입력 SubGroup과 template SubGroup을 섞어 배포하는 시나리오도 가능
- 추가된 SubGroup은 기존 편집(li 클릭)·[Deploy] 흐름을 그대로 재사용 — template을 시작점으로 spec/image/대수 등을 수정한 뒤 배포 가능
- 완료 시 성공 토스트는 띄우지 않음 — `<li>` 아이템이 목록에 바로 추가되는 것 자체가 시각적 확인
- 백엔드 변경 없음 — front 전용
