### PR TITLE
fix: navbar 워크스페이스/프로젝트 셀렉터를 본인 소속 범위로 스코프

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -966,6 +966,10 @@ serviceActions:
       method: get
       resourcePath: /api/workspaces/id/{workspaceId}/projects/list
       description: workspace - projects mapping workspace 기준 목록 조회
+    listUserProjectsByWorkspace:
+      method: get
+      resourcePath: /api/users/workspaces/id/{workspaceId}/projects/list
+      description: workspace - projects mapping, 로그인 사용자 본인 소속 workspace만 조회
     listUserWorkspaces:
       method: post
       resourcePath: /api/users/workspaces/list

--- a/front/assets/js/common/api/services/workspace_api.js
+++ b/front/assets/js/common/api/services/workspace_api.js
@@ -99,7 +99,7 @@ export async function getProjectListByWorkspaceId(workspaceId) {
     }
   }
   let projectList = [];
-  const response = await webconsolejs["common/api/http"].commonAPIPost('/api/mc-iam-manager/getProjectsByWorkspaceId', requestObject)
+  const response = await webconsolejs["common/api/http"].commonAPIPost('/api/mc-iam-manager/listUserProjectsByWorkspace', requestObject)
   let data = response.data.responseData.projects
   console.debug("GetWPmappingListByWorkspaceId data :", data)
   data.forEach(item => {


### PR DESCRIPTION
## 배경
로그인 사용자의 프로젝트 목록 조회시 사용자 소속확인 로직 포함.
 `getProjectListByWorkspaceId()`가 `getProjectsByWorkspaceId` 대신 `listUserProjectsByWorkspace`를 호출하도록 변경
