### PR TITLE
fix: project 단건조회/수정/삭제 operationId legacy 경로 수정

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -821,17 +821,17 @@ serviceActions:
       method: post
       resourcePath: /api/permission/file/framework/{framework}
       description: CSV 기반으로 권한을 업데이트 합니다.
-    Getprojectbyid:
+    getProjectByID:
       method: get
-      resourcePath: /api/prj/project/id/{projectId}
+      resourcePath: /api/projects/id/{projectId}
       description: project 단건 조회
-    Updateprojectbyid:
+    updateProject:
       method: put
-      resourcePath: /api/prj/project/id/{projectId}
+      resourcePath: /api/projects/id/{projectId}
       description: project 수정
-    Deleteprojectbyid:
+    deleteProject:
       method: delete
-      resourcePath: /api/prj/project/id/{projectId}
+      resourcePath: /api/projects/id/{projectId}
       description: project 삭제
     deleteWorkspace:
       method: delete


### PR DESCRIPTION
## 배경

`conf/api.yaml`: 세 operationId를 mc-iam-manager swagger `@Id`와 일치하도록 이름/resourcePath 수정
- `Getprojectbyid` → `getProjectByID` (`GET /api/projects/id/{projectId}`)
- `Updateprojectbyid` → `updateProject` (`PUT /api/projects/id/{projectId}`)
- `Deleteprojectbyid` → `deleteProject` (`DELETE /api/projects/id/{projectId}`)
