### PR TITLE
feat(mci): MCI 배포 nodeGroups 매핑에 정식 필드 5개 추가 및 매핑 버그 수정

### DIFF
--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -254,8 +254,11 @@ export async function mciDynamicReview(mciName, mciDesc, Express_Server_Config_A
     description: config.description,
     rootDiskSize: (config.rootDiskSize !== "" && config.rootDiskSize !== undefined) ? parseInt(config.rootDiskSize) : 0,
     rootDiskType: config.rootDiskType,
-    label: config.label || {},
-    vmUserPassword: config.vmUserPassword || ""
+    ...(config.zone ? { zone: config.zone } : {}),
+    ...(config.nodeUserPassword ? { nodeUserPassword: config.nodeUserPassword } : {}),
+    ...(config.label && Object.keys(config.label).length > 0 ? { label: config.label } : {}),
+    ...(config.vNetTemplateId ? { vNetTemplateId: config.vNetTemplateId } : {}),
+    ...(config.sgTemplateId ? { sgTemplateId: config.sgTemplateId } : {})
   }));
 
   // command 처리 - 첫 번째 서버의 command를 사용 (모든 서버가 동일한 command를 사용한다고 가정)
@@ -302,7 +305,12 @@ export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, ns
     connectionName: config.connectionName,
     description: config.description,
     rootDiskSize: (config.rootDiskSize !== "" && config.rootDiskSize !== undefined) ? parseInt(config.rootDiskSize) : 0,
-    rootDiskType: config.rootDiskType
+    rootDiskType: config.rootDiskType,
+    ...(config.zone ? { zone: config.zone } : {}),
+    ...(config.nodeUserPassword ? { nodeUserPassword: config.nodeUserPassword } : {}),
+    ...(config.label && Object.keys(config.label).length > 0 ? { label: config.label } : {}),
+    ...(config.vNetTemplateId ? { vNetTemplateId: config.vNetTemplateId } : {}),
+    ...(config.sgTemplateId ? { sgTemplateId: config.sgTemplateId } : {})
   }));
 
   // command 처리 - 첫 번째 서버의 command를 사용 (모든 서버가 동일한 command를 사용한다고 가정)

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -501,8 +501,8 @@ function addServerConfigToList(express_form) {
 
   // 수정 모드인지 신규 추가 모드인지 판단
   if (currentEditingIndex >= 0 && currentEditingIndex < Express_Server_Config_Arr.length) {
-    // 수정 모드: 기존 데이터를 업데이트
-    Express_Server_Config_Arr[currentEditingIndex] = express_form;
+    // 수정 모드: 기존 데이터를 업데이트 (폼에 없는 carry-through 필드는 보존)
+    Express_Server_Config_Arr[currentEditingIndex] = { ...Express_Server_Config_Arr[currentEditingIndex], ...express_form };
 
     // 리스트 아이템 텍스트 업데이트
     var vmEleId = "vm";


### PR DESCRIPTION
## Summary
- **MCI 배포 nodeGroups 매핑에 정식 필드 5개 추가** — `mci_api.js`의 `mciDynamic()`/`mciDynamicReview()`가 cb-tumblebug `CreateNodeGroupDynamicReq`(model/infra.go:350-386) 13필드 중 누락하던 `zone` / `nodeUserPassword` / `label` / `vNetTemplateId` / `sgTemplateId`를 전송 (값 있을 때만 포함 — omitempty 스프레드)
- **기존 매핑 버그 수정** — `mciDynamicReview()`가 서버에 존재하지 않는 `vmUserPassword` 키로 전송해 항상 무시되던 죽은 코드를 `nodeUserPassword`로 정정, Review/Dynamic 매핑 대칭화
- **서버 구성 수정 모드 merge 보완** — `addServerConfigToList()` 수정 모드에서 객체 통째 교체 → `{...기존, ...새값}` merge로 변경. Template 프리필(Add NodeGroup, WEB-TECH-018)로 실려온 carry-through 필드(zone 등)가 SubGroup 편집 시 소실되지 않음
- 근거: cb-tumblebug 소스 확인 — sg/vNetTemplateId는 passthrough만 하면 서버가 이름 규칙(`{ns}-shared-{conn}[-{tpl}]`)+template 조회로 실제 vNet/SG를 결정 (`provisioning.go:1537-1544, 3246-3265`, `resource/common.go:2317`)

## 변경 파일
- `front/assets/js/common/api/services/mci_api.js` — nodeGroups 매핑 확장 (Review/Dynamic 동일 적용)
- `front/assets/js/partials/operation/manage/mcicreate.js` — 수정 모드 merge 1줄
