### PR TITLE
fix: navbar 알림 폴링 정지 조건 추가 및 완료 토스트 반복 표시 제거

### DIFF
--- a/front/assets/js/common/api/asyncRequestNotify.js
+++ b/front/assets/js/common/api/asyncRequestNotify.js
@@ -213,6 +213,19 @@ function bindActions() {
     });
   }
 
+  const toggleEl = document.getElementById('async-request-notif-toggle');
+  if (toggleEl && !toggleEl.dataset.refreshBound) {
+    toggleEl.dataset.refreshBound = '1';
+    // Interval polling stops while nothing is in flight — refresh once on open
+    // so the list reflects jobs started elsewhere (other tabs/sessions)
+    toggleEl.addEventListener('show.bs.dropdown', () => {
+      const t = tracker();
+      if (t && t.refreshNow) {
+        t.refreshNow();
+      }
+    });
+  }
+
   const menuEl = document.getElementById('async-request-notif-menu');
   if (menuEl && !menuEl.dataset.selectBound) {
     menuEl.dataset.selectBound = '1';

--- a/front/assets/js/common/api/asyncRequestTracker.js
+++ b/front/assets/js/common/api/asyncRequestTracker.js
@@ -225,10 +225,23 @@ async function refreshFromServer() {
         startPolling(job);
       }
     });
+    // Nothing in flight (server list has no Handling job and no active GetRequest
+    // poll — the timers guard covers the gap between track() and the server row
+    // appearing): stop the list interval. track() restarts it on the next request.
+    if (!jobs.some((j) => j.status === 'Handling') && timers.size === 0) {
+      stopListRefresh();
+    }
   } catch (e) {
     if (useServer !== true) {
       useServer = false;
     }
+  }
+}
+
+function stopListRefresh() {
+  if (listTimer) {
+    clearInterval(listTimer);
+    listTimer = null;
   }
 }
 
@@ -237,9 +250,13 @@ function ensureListRefresh() {
     return;
   }
   listTimer = setInterval(function () {
-    if (useServer !== false) {
-      refreshFromServer();
+    if (useServer === false) {
+      // fallback mode has no server list — per-request GetRequest timers
+      // handle progress and stop on their own
+      stopListRefresh();
+      return;
     }
+    refreshFromServer();
   }, LIST_REFRESH_MS);
 }
 
@@ -352,6 +369,14 @@ export function track(opts) {
   startPolling(job);
   ensureListRefresh();
   refreshFromServer();
+}
+
+/**
+ * One-shot server list refresh — used by the navbar dropdown on open so the
+ * list stays current even while interval polling is stopped.
+ */
+export function refreshNow() {
+  return refreshFromServer();
 }
 
 export function resume() {

--- a/front/assets/js/common/api/asyncRequestTracker.js
+++ b/front/assets/js/common/api/asyncRequestTracker.js
@@ -4,10 +4,13 @@
  */
 
 const STORAGE_KEY = 'mcwc_async_requests';
+const TOASTED_KEY = 'mcwc_async_toasted';
 const POLL_MS = 2500;
 const LIST_REFRESH_MS = 2000;
 const MAX_MS = 15 * 60 * 1000;
 const MAX_JOBS = 20;
+const RECENT_FINISH_TOAST_MS = 30 * 1000;
+const TOASTED_MAX = 40;
 const GET_REQUEST_URL = '/api/mc-infra-manager/GetRequest';
 const LIST_URL = '/api/async-requests';
 const EVENT_NAME = 'mcwc-async-request-changed';
@@ -16,7 +19,6 @@ const timers = new Map();
 const listeners = new Set();
 let useServer = null;
 let listTimer = null;
-let lastToastStatus = new Map();
 
 function toastApi() {
   return webconsolejs && webconsolejs['common/utils/toast'];
@@ -138,6 +140,48 @@ function finishToast(job, type, message) {
   }
 }
 
+function loadToasted() {
+  try {
+    const raw = sessionStorage.getItem(TOASTED_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch (e) {
+    return {};
+  }
+}
+
+function saveToasted(map) {
+  const keys = Object.keys(map);
+  if (keys.length > TOASTED_MAX) {
+    keys.slice(0, keys.length - TOASTED_MAX).forEach((k) => delete map[k]);
+  }
+  try {
+    sessionStorage.setItem(TOASTED_KEY, JSON.stringify(map));
+  } catch (e) {
+    /* storage full — dedupe degrades gracefully */
+  }
+}
+
+/**
+ * Terminal-status toast, at most once per requestId per tab session
+ * (ledger in sessionStorage so page reloads stay silent).
+ * Shows only when the transition was observed live on this page, or the job
+ * finished within RECENT_FINISH_TOAST_MS (completion during navigation).
+ */
+function maybeFinishToast(job, status, live, message) {
+  const toasted = loadToasted();
+  if (toasted[job.requestId] === status) {
+    return;
+  }
+  const recent =
+    job.finishedAt && Date.now() - job.finishedAt < RECENT_FINISH_TOAST_MS;
+  if (live || recent) {
+    finishToast(job, status === 'Success' ? 'success' : 'error', message);
+  }
+  toasted[job.requestId] = status;
+  saveToasted(toasted);
+}
+
 function markFinishedLocal(requestId, status, message) {
   stopTimer(requestId);
   const jobs = loadJobsLocal();
@@ -158,25 +202,22 @@ function markFinishedLocal(requestId, status, message) {
 function maybeToastTransition(prevJobs, nextJobs) {
   const prevMap = new Map((prevJobs || []).map((j) => [j.requestId, j]));
   (nextJobs || []).forEach((job) => {
-    const prev = prevMap.get(job.requestId);
-    const prevStatus = prev ? prev.status : lastToastStatus.get(job.requestId);
-    if (prevStatus === job.status) {
-      return;
-    }
-    lastToastStatus.set(job.requestId, job.status);
     if (job.status === 'Handling') {
-      showProgress(job);
+      // progress toast is shown only at track() time — never on load/refresh
       return;
     }
+    const prev = prevMap.get(job.requestId);
+    const live = !!prev && prev.status === 'Handling';
     if (job.status === 'Success') {
-      finishToast(job, 'success', job.label + ' — completed');
+      maybeFinishToast(job, 'Success', live, job.label + ' — completed');
       stopTimer(job.requestId);
       return;
     }
     if (job.status === 'Error' || job.status === 'Timeout') {
-      finishToast(
+      maybeFinishToast(
         job,
-        'error',
+        job.status,
+        live,
         job.message || job.label + ' — ' + (job.status === 'Timeout' ? 'timed out' : 'failed')
       );
       stopTimer(job.requestId);
@@ -278,9 +319,8 @@ async function pollOnce(job) {
 
     if (status === 'Success' || status === 'success') {
       const msg = job.label + ' — completed';
-      finishToast(job, 'success', msg);
+      maybeFinishToast(job, 'Success', true, msg);
       if (useServer) {
-        lastToastStatus.set(job.requestId, 'Success');
         stopTimer(job.requestId);
         refreshFromServer();
       } else {
@@ -291,9 +331,8 @@ async function pollOnce(job) {
     if (status === 'Error' || status === 'error') {
       const errMsg = details.errorResponse || details.ErrorResponse || 'failed';
       const msg = job.label + ' — ' + errMsg;
-      finishToast(job, 'error', msg);
+      maybeFinishToast(job, 'Error', true, msg);
       if (useServer) {
-        lastToastStatus.set(job.requestId, 'Error');
         stopTimer(job.requestId);
         refreshFromServer();
       } else {
@@ -323,7 +362,7 @@ function startPolling(job) {
     }
     if (Date.now() - current.startedAt > MAX_MS) {
       const msg = current.label + ' — status check timed out';
-      finishToast(current, 'error', msg);
+      maybeFinishToast(current, 'Timeout', true, msg);
       if (!useServer) {
         markFinishedLocal(current.requestId, 'Timeout', msg);
       }
@@ -356,7 +395,6 @@ export function track(opts) {
     status: 'Handling',
     href: opts.href || '',
   };
-  lastToastStatus.set(requestId, 'Handling');
   showProgress(job);
   if (useServer !== true) {
     upsertJobLocal(job);
@@ -387,7 +425,7 @@ export function resume() {
     }
     const jobs = loadJobsLocal();
     jobs.filter((j) => j.status === 'Handling').forEach((job) => {
-      showProgress(job);
+      // no progress re-toast on load — badge/list carry in-flight state
       startPolling(job);
     });
     emit(jobs);


### PR DESCRIPTION
## Summary

navbar 알림센터(Requests) 관련 프론트 버그 2건 수정 — 백엔드 변경 없음, `asyncRequestTracker.js`/`asyncRequestNotify.js` 전용.

### 1. 알림 목록 폴링이 정지 조건 없이 무한 반복

- 모든 페이지 로드 시 `resume()` → 2초 간격 `setInterval`(`listTimer`)로 `GET /api/async-requests`를 계속 호출, `clearInterval`이 코드 전체에 없어 Handling Job 0개여도 탭이 열려있는 동안 영구 폴링
- **수정**: 서버 목록에 Handling Job 0개 + 활성 GetRequest 타이머 없음 → 인터벌 정지. `track()`(새 비동기 요청) 시 자동 재개. fallback 모드(서버 목록 미지원)에서도 정지. 정지 상태에서 벨 드롭다운을 열면 1회성 refresh로 최신 목록 보장

### 2. 새로고침 시 완료 토스트 반복 표시

- 토스트 기준(`lastToastStatus`)이 메모리 변수라 새로고침마다 초기화 → 서버 이력 전체가 매번 "새 상태"로 판정되어 완료 이력까지 completed 토스트 반복
- **수정**: 토스트 원장(`mcwc_async_toasted`, sessionStorage) 도입 — terminal 토스트는 requestId당 1회, 실시간 전환 관찰 또는 완료 30초 이내 건만 표시. 과거 이력은 알림센터 목록으로만. Handling progress 토스트는 `track()` 시점에만 표시
- 부수 해소: pollOnce 직접 토스트 + 목록 refresh 전환 토스트가 겹치던 **완료 토스트 2개 표시** 버그 (`maybeFinishToast` 공통화)
