### PR TITLE
[feat]: Company Info 화면을 Company API로 전환

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -1138,6 +1138,26 @@ serviceActions:
       method: get
       resourcePath: /api/groups/id/{groupId}/platform-roles
       description: 그룹의 Platform Role 목록 조회
+    getCompany:
+      method: get
+      resourcePath: /api/company
+      description: 플랫폼 회사 정보 조회 (싱글톤)
+    createCompany:
+      method: post
+      resourcePath: /api/company
+      description: 플랫폼 회사 정보 생성 (싱글톤, platformAdmin)
+    updateCompany:
+      method: put
+      resourcePath: /api/company
+      description: 플랫폼 회사 이름/설명 수정 (platformAdmin)
+    deactivateCompany:
+      method: delete
+      resourcePath: /api/company
+      description: 플랫폼 회사 비활성화 (platformAdmin, 멱등)
+    activateCompany:
+      method: post
+      resourcePath: /api/company/activate
+      description: 플랫폼 회사 활성화 (platformAdmin, 멱등)
     listCspAccounts:
       method: post
       resourcePath: /api/csp-accounts/list

--- a/front/assets/js/common/api/services/company_api.js
+++ b/front/assets/js/common/api/services/company_api.js
@@ -1,0 +1,72 @@
+// Company(플랫폼 싱글톤) API 서비스 — mc-iam-manager /api/company
+
+function unwrapResponse(response) {
+  if (!response) {
+    throw new Error('Invalid response from server');
+  }
+  // commonAPIPost는 404/403 등에서 axios error 객체를 그대로 반환
+  if (response.response) {
+    const status = response.response.status;
+    const body = response.response.data || {};
+    const msg = (body.status && body.status.message)
+      || body.message
+      || body.error
+      || (body.responseData && body.responseData.error)
+      || response.message
+      || 'Request failed';
+    const err = new Error(msg);
+    err.status = status;
+    err.response = response.response;
+    throw err;
+  }
+  if (response.status === 204) {
+    return null;
+  }
+  if (!response.data) {
+    throw new Error('Invalid response from server');
+  }
+  if (response.status >= 400) {
+    const msg = (response.data.status && response.data.status.message)
+      || response.data.message
+      || response.data.error
+      || (response.data.responseData && response.data.responseData.error)
+      || 'Request failed';
+    const err = new Error(msg);
+    err.status = response.status;
+    err.response = response;
+    throw err;
+  }
+  return response.data.responseData;
+}
+
+export async function getCompany() {
+  const controller = '/api/mc-iam-manager/getCompany';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller);
+  return unwrapResponse(response);
+}
+
+export async function createCompany(companyData) {
+  const controller = '/api/mc-iam-manager/createCompany';
+  const data = { request: companyData };
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, data);
+  return unwrapResponse(response);
+}
+
+export async function updateCompany(companyData) {
+  const controller = '/api/mc-iam-manager/updateCompany';
+  const data = { request: companyData };
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, data);
+  return unwrapResponse(response);
+}
+
+export async function deactivateCompany() {
+  const controller = '/api/mc-iam-manager/deactivateCompany';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller);
+  return unwrapResponse(response);
+}
+
+export async function activateCompany() {
+  const controller = '/api/mc-iam-manager/activateCompany';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller);
+  return unwrapResponse(response);
+}

--- a/front/assets/js/pages/settings/accountnaccess/organizations/companyinfo.js
+++ b/front/assets/js/pages/settings/accountnaccess/organizations/companyinfo.js
@@ -1,76 +1,196 @@
-if (typeof webconsolejs === 'undefined') window.webconsolejs = {};
+if (typeof webconsolejs === 'undefined') {
+  window.webconsolejs = {};
+}
 if (typeof webconsolejs['pages/settings/accountnaccess/organizations/companyinfo'] === 'undefined') {
-    webconsolejs['pages/settings/accountnaccess/organizations/companyinfo'] = {};
+  webconsolejs['pages/settings/accountnaccess/organizations/companyinfo'] = {};
 }
 
 const AppState = {
-    org: null
+  company: null
 };
 
-const groupsApi = () => webconsolejs['common/api/services/groups_api'];
+const companyApi = () => webconsolejs['common/api/services/company_api'];
+
+function formatDate(value) {
+  if (!value) {
+    return '-';
+  }
+  try {
+    return new Date(value).toLocaleString();
+  } catch (e) {
+    return String(value);
+  }
+}
+
+function setVisible(id, visible) {
+  const el = document.getElementById(id);
+  if (!el) {
+    return;
+  }
+  el.classList.toggle('d-none', !visible);
+  if (visible) {
+    el.style.display = '';
+  }
+}
 
 const companyInfoPage = {
-    async load() {
-        try {
-            const list = await groupsApi().getGroupList();
-            const orgs = Array.isArray(list) ? list : [];
-            if (orgs.length === 0) throw new Error('No organization found');
-            // 최상위 조직: level이 가장 낮은 항목
-            const root = orgs.reduce((min, o) => (o.level < min.level ? o : min), orgs[0]);
-            AppState.org = root;
-            this._render(root);
-        } catch (e) {
-            console.error('Failed to load organization info:', e);
-            document.getElementById('companyinfo-loading').innerHTML =
-                '<div class="alert alert-danger">Failed to load organization info.</div>';
-        }
-    },
+  async load() {
+    document.getElementById('companyinfo-loading').style.display = '';
+    document.getElementById('companyinfo-data').style.display = 'none';
+    document.getElementById('companyinfo-empty').style.display = 'none';
+    setVisible('companyinfo-edit-btn', false);
+    setVisible('companyinfo-create-btn', false);
+    setVisible('companyinfo-activate-btn', false);
 
-    _render(org) {
-        document.getElementById('ci-name').textContent = org.name || '-';
-        document.getElementById('ci-code').textContent = org.organizationCode || org.code || '-';
-        document.getElementById('ci-level').textContent = org.level ?? '-';
-        document.getElementById('ci-path').textContent = org.path || '-';
-        document.getElementById('ci-description').textContent = org.description || '-';
-        document.getElementById('ci-user-count').textContent = org.userCount ?? '-';
-        document.getElementById('companyinfo-loading').style.display = 'none';
-        document.getElementById('companyinfo-data').style.display = '';
-    },
-
-    enterEditMode() {
-        if (!AppState.org) return;
-        document.getElementById('ci-edit-name').value = AppState.org.name || '';
-        document.getElementById('ci-edit-description').value = AppState.org.description || '';
-        document.getElementById('companyinfo-view-card').style.display = 'none';
-        document.getElementById('companyinfo-edit-card').style.display = '';
-    },
-
-    cancelEdit() {
-        document.getElementById('companyinfo-edit-card').style.display = 'none';
-        document.getElementById('companyinfo-view-card').style.display = '';
-    },
-
-    async saveEdit() {
-        const name = document.getElementById('ci-edit-name').value.trim();
-        if (!name) {
-            alert('Name is required.');
-            return;
-        }
-        const description = document.getElementById('ci-edit-description').value.trim();
-        try {
-            const updated = await groupsApi().updateGroup(AppState.org.id, { name, description });
-            AppState.org = { ...AppState.org, name, description, ...updated };
-            this._render(AppState.org);
-            this.cancelEdit();
-        } catch (e) {
-            console.error('Failed to update organization:', e);
-            alert('Failed to save. Please try again.');
-        }
+    try {
+      const company = await companyApi().getCompany();
+      AppState.company = company;
+      this._render(company);
+    } catch (e) {
+      console.error('Failed to load company info:', e);
+      AppState.company = null;
+      document.getElementById('companyinfo-loading').style.display = 'none';
+      if (e.status === 404) {
+        document.getElementById('companyinfo-empty').style.display = '';
+        setVisible('companyinfo-create-btn', true);
+        return;
+      }
+      document.getElementById('companyinfo-loading').innerHTML =
+        '<div class="alert alert-danger">Failed to load company info.</div>';
     }
+  },
+
+  _render(company) {
+    document.getElementById('ci-name').textContent = company.name || '-';
+    document.getElementById('ci-description').textContent = company.description || '-';
+    document.getElementById('ci-realm').textContent = company.realm_name || '-';
+    document.getElementById('ci-client-id').textContent = company.kc_client_id || '-';
+    document.getElementById('ci-status').textContent = company.status || '-';
+    document.getElementById('ci-created-at').textContent = formatDate(company.created_at);
+    document.getElementById('ci-updated-at').textContent = formatDate(company.updated_at);
+
+    document.getElementById('companyinfo-loading').style.display = 'none';
+    document.getElementById('companyinfo-empty').style.display = 'none';
+    document.getElementById('companyinfo-data').style.display = '';
+    setVisible('companyinfo-edit-btn', true);
+
+    // Deactivate는 UI에서 숨김. inactive일 때만 Activate 노출.
+    const isActive = (company.status || '').toLowerCase() === 'active';
+    setVisible('companyinfo-activate-btn', !isActive);
+  },
+
+  enterEditMode() {
+    if (!AppState.company) {
+      return;
+    }
+    document.getElementById('ci-edit-name').value = AppState.company.name || '';
+    document.getElementById('ci-edit-description').value = AppState.company.description || '';
+    document.getElementById('ci-edit-realm').value = AppState.company.realm_name || '';
+    document.getElementById('ci-edit-client-id').value = AppState.company.kc_client_id || '';
+    document.getElementById('companyinfo-view-card').style.display = 'none';
+    document.getElementById('companyinfo-create-card').style.display = 'none';
+    document.getElementById('companyinfo-edit-card').style.display = '';
+  },
+
+  cancelEdit() {
+    document.getElementById('companyinfo-edit-card').style.display = 'none';
+    document.getElementById('companyinfo-view-card').style.display = '';
+  },
+
+  async saveEdit() {
+    const name = document.getElementById('ci-edit-name').value.trim();
+    if (!name) {
+      alert('Name is required.');
+      return;
+    }
+    const description = document.getElementById('ci-edit-description').value.trim();
+    try {
+      const updated = await companyApi().updateCompany({ name, description });
+      AppState.company = { ...AppState.company, ...updated };
+      this._render(AppState.company);
+      this.cancelEdit();
+    } catch (e) {
+      console.error('Failed to update company:', e);
+      alert(e.message || 'Failed to save. Please try again.');
+    }
+  },
+
+  enterCreateMode() {
+    document.getElementById('ci-create-name').value = '';
+    document.getElementById('ci-create-realm').value = '';
+    document.getElementById('ci-create-client-id').value = '';
+    document.getElementById('ci-create-client-secret').value = '';
+    document.getElementById('ci-create-description').value = '';
+    document.getElementById('companyinfo-view-card').style.display = 'none';
+    document.getElementById('companyinfo-edit-card').style.display = 'none';
+    document.getElementById('companyinfo-create-card').style.display = '';
+  },
+
+  cancelCreate() {
+    document.getElementById('companyinfo-create-card').style.display = 'none';
+    document.getElementById('companyinfo-view-card').style.display = '';
+  },
+
+  async saveCreate() {
+    const name = document.getElementById('ci-create-name').value.trim();
+    const realmName = document.getElementById('ci-create-realm').value.trim();
+    const kcClientId = document.getElementById('ci-create-client-id').value.trim();
+    const kcClientSecret = document.getElementById('ci-create-client-secret').value.trim();
+    const description = document.getElementById('ci-create-description').value.trim();
+
+    if (!name || !realmName || !kcClientId || !kcClientSecret) {
+      alert('Name, Realm Name, Client ID, and Client Secret are required.');
+      return;
+    }
+
+    try {
+      const created = await companyApi().createCompany({
+        name,
+        realm_name: realmName,
+        kc_client_id: kcClientId,
+        kc_client_secret: kcClientSecret,
+        description
+      });
+      AppState.company = created;
+      this._render(created);
+      this.cancelCreate();
+    } catch (e) {
+      console.error('Failed to create company:', e);
+      alert(e.message || 'Failed to create. Please try again.');
+    }
+  },
+
+  async activate() {
+    if (!confirm('Activate this company?')) {
+      return;
+    }
+    try {
+      const updated = await companyApi().activateCompany();
+      AppState.company = { ...AppState.company, ...updated };
+      this._render(AppState.company);
+    } catch (e) {
+      console.error('Failed to activate company:', e);
+      alert(e.message || 'Failed to activate.');
+    }
+  },
+
+  async deactivate() {
+    if (!confirm('Deactivate this company?')) {
+      return;
+    }
+    try {
+      const updated = await companyApi().deactivateCompany();
+      AppState.company = { ...AppState.company, ...updated };
+      this._render(AppState.company);
+    } catch (e) {
+      console.error('Failed to deactivate company:', e);
+      alert(e.message || 'Failed to deactivate.');
+    }
+  }
 };
 
 window.companyInfoPage = companyInfoPage;
 
 document.addEventListener('DOMContentLoaded', () => {
-    companyInfoPage.load();
+  companyInfoPage.load();
 });

--- a/front/templates/pages/settings/accountnaccess/organizations/companyinfo.html
+++ b/front/templates/pages/settings/accountnaccess/organizations/companyinfo.html
@@ -6,22 +6,33 @@
         <!-- Info Card -->
         <div class="card" id="companyinfo-view-card">
           <div class="card-header">
-            <h3 class="card-title">Organization Info</h3>
+            <h3 class="card-title">Company Info</h3>
             <div class="card-actions btn-actions">
-              <button class="btn btn-outline-warning" id="companyinfo-edit-btn" onclick="companyInfoPage.enterEditMode()">
-                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <button class="btn btn-outline-secondary d-none" id="companyinfo-activate-btn"
+                onclick="companyInfoPage.activate()">Activate</button>
+              <button class="btn btn-outline-warning d-none" id="companyinfo-edit-btn"
+                onclick="companyInfoPage.enterEditMode()">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
+                  viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
+                  stroke-linecap="round" stroke-linejoin="round">
                   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
                   <path d="M7 7h-1a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-1"></path>
-                  <path d="M20.385 6.585a2.1 2.1 0 0 0 -2.97 -2.97l-8.415 8.385v3h3l8.385 -8.415z"></path>
+                  <path d="M20.385 6.585a2.1 2.1 0 0 0 -2.97 -2.97l-8.415 8.385v3h3l8.385 -8.415z">
+                  </path>
                   <path d="M16 5l3 3"></path>
                 </svg>
                 Edit
               </button>
+              <button class="btn btn-primary d-none" id="companyinfo-create-btn"
+                onclick="companyInfoPage.enterCreateMode()">Create Company</button>
             </div>
           </div>
           <div class="card-body">
             <div id="companyinfo-loading" class="text-center py-4">
               <div class="spinner-border text-primary" role="status"></div>
+            </div>
+            <div id="companyinfo-empty" class="text-secondary py-3" style="display:none;">
+              No company is registered. Create the platform company to continue.
             </div>
             <div id="companyinfo-data" style="display:none;">
               <div class="datagrid">
@@ -30,24 +41,32 @@
                   <div class="datagrid-content" id="ci-name"></div>
                 </div>
                 <div class="datagrid-item">
-                  <div class="datagrid-title">Code</div>
-                  <div class="datagrid-content"><code id="ci-code"></code></div>
-                </div>
-                <div class="datagrid-item">
-                  <div class="datagrid-title">Level</div>
-                  <div class="datagrid-content" id="ci-level"></div>
-                </div>
-                <div class="datagrid-item">
-                  <div class="datagrid-title">Path</div>
-                  <div class="datagrid-content" id="ci-path"></div>
-                </div>
-                <div class="datagrid-item">
                   <div class="datagrid-title">Description</div>
                   <div class="datagrid-content" id="ci-description"></div>
                 </div>
                 <div class="datagrid-item">
-                  <div class="datagrid-title">Members</div>
-                  <div class="datagrid-content" id="ci-user-count"></div>
+                  <div class="datagrid-title">Status</div>
+                  <div class="datagrid-content" id="ci-status"></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Created At</div>
+                  <div class="datagrid-content" id="ci-created-at"></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Updated At</div>
+                  <div class="datagrid-content" id="ci-updated-at"></div>
+                </div>
+              </div>
+
+              <h4 class="mt-4 mb-2">Keycloak Settings</h4>
+              <div class="datagrid">
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Realm Name</div>
+                  <div class="datagrid-content"><code id="ci-realm"></code></div>
+                </div>
+                <div class="datagrid-item">
+                  <div class="datagrid-title">Keycloak Client ID</div>
+                  <div class="datagrid-content"><code id="ci-client-id"></code></div>
                 </div>
               </div>
             </div>
@@ -57,21 +76,75 @@
         <!-- Edit Card -->
         <div class="card" id="companyinfo-edit-card" style="display:none;">
           <div class="card-header">
-            <h3 class="card-title">Edit Organization Info</h3>
+            <h3 class="card-title">Edit Company Info</h3>
           </div>
           <div class="card-body">
             <div class="mb-3">
               <label class="form-label required">Name</label>
-              <input type="text" class="form-control" id="ci-edit-name" placeholder="Organization name" />
+              <input type="text" class="form-control" id="ci-edit-name" placeholder="Company name" />
             </div>
             <div class="mb-3">
               <label class="form-label">Description</label>
-              <textarea class="form-control" id="ci-edit-description" rows="3" placeholder="Organization description"></textarea>
+              <textarea class="form-control" id="ci-edit-description" rows="3"
+                placeholder="Company description"></textarea>
+            </div>
+
+            <h4 class="mt-4 mb-2">Keycloak Settings</h4>
+            <div class="mb-3">
+              <label class="form-label">Realm Name</label>
+              <input type="text" class="form-control" id="ci-edit-realm" readonly disabled />
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Keycloak Client ID</label>
+              <input type="text" class="form-control" id="ci-edit-client-id" readonly disabled />
             </div>
           </div>
           <div class="card-footer text-end">
-            <button type="button" class="btn btn-secondary me-2" onclick="companyInfoPage.cancelEdit()">Cancel</button>
-            <button type="button" class="btn btn-primary" onclick="companyInfoPage.saveEdit()">Save</button>
+            <button type="button" class="btn btn-secondary me-2"
+              onclick="companyInfoPage.cancelEdit()">Cancel</button>
+            <button type="button" class="btn btn-primary"
+              onclick="companyInfoPage.saveEdit()">Save</button>
+          </div>
+        </div>
+
+        <!-- Create Card -->
+        <div class="card" id="companyinfo-create-card" style="display:none;">
+          <div class="card-header">
+            <h3 class="card-title">Create Company</h3>
+          </div>
+          <div class="card-body">
+            <div class="mb-3">
+              <label class="form-label required">Name</label>
+              <input type="text" class="form-control" id="ci-create-name" placeholder="Company name" />
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Description</label>
+              <textarea class="form-control" id="ci-create-description" rows="3"
+                placeholder="Company description"></textarea>
+            </div>
+
+            <h4 class="mt-4 mb-2">Keycloak Settings</h4>
+            <div class="mb-3">
+              <label class="form-label required">Realm Name</label>
+              <input type="text" class="form-control" id="ci-create-realm"
+                placeholder="Keycloak realm name" />
+            </div>
+            <div class="mb-3">
+              <label class="form-label required">Keycloak Client ID</label>
+              <input type="text" class="form-control" id="ci-create-client-id"
+                placeholder="Keycloak client id" />
+            </div>
+            <div class="mb-3">
+              <label class="form-label required">Keycloak Client Secret</label>
+              <input type="password" class="form-control" id="ci-create-client-secret"
+                placeholder="Keycloak client secret" autocomplete="new-password" />
+            </div>
+          </div>
+          <div class="card-footer text-end">
+            <button type="button" class="btn btn-secondary me-2"
+              onclick="companyInfoPage.cancelCreate()">Cancel</button>
+            <button type="button" class="btn btn-primary"
+              onclick="companyInfoPage.saveCreate()">Create</button>
           </div>
         </div>
 
@@ -82,5 +155,5 @@
 
 {{ partial("partials/layout/pageloader.html") | raw }}
 
-{{ javascriptTag("common/api/services/groups_api.js") | raw }}
+{{ javascriptTag("common/api/services/company_api.js") | raw }}
 {{ javascriptTag("pages/settings/accountnaccess/organizations/companyinfo.js") | raw }}


### PR DESCRIPTION
## Summary
- Company Info 메뉴가  IAM Company API(`getCompany`/`createCompany`/`updateCompany`)를 사용하도록 전환
- `conf/api.yaml`에 company operationId 5종 등록, `company_api.js` 추가
- Keycloak Settings(Realm Name, Client ID) 영역 분리, Deactivate 버튼 숨김
