### PR TITLE
fix(front): remote command localhost 하드코딩 제거 — getapihosts 기반 주소 해석

### DIFF
--- a/api/internal/handler/apihosts.go
+++ b/api/internal/handler/apihosts.go
@@ -16,9 +16,11 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// ServiceNoAuth Auth 정보를 제외한 서비스 호스트 정보 (Buffalo ServiceNoAuth 호환)
+// ServiceNoAuth credential(username/password)을 제외한 서비스 호스트 정보 (Buffalo ServiceNoAuth 호환).
+// AuthType은 호출 측이 프레임워크별 인증 방식(basic/bearer)을 선택하는 데 필요해 노출한다.
 type ServiceNoAuth struct {
-	BaseURL string `json:"BaseURL"`
+	BaseURL  string `json:"BaseURL"`
+	AuthType string `json:"AuthType,omitempty"`
 }
 
 // GetApiHosts POST /api/getapihosts
@@ -39,7 +41,7 @@ func GetApiHosts(c echo.Context) error {
 
 	// api.yaml을 기본값으로 사용 (레지스트리 미등록 서비스도 포함)
 	for k, v := range cfg.ApiSpec.Services {
-		apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL}
+		apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL, AuthType: v.Auth.Type}
 	}
 
 	if cfg.MCIAM.Use && cfg.RegistryCache != nil {
@@ -54,7 +56,11 @@ func GetApiHosts(c echo.Context) error {
 		// 레지스트리 값으로 override (BaseURL이 있는 경우만)
 		for k, v := range cached {
 			if v.BaseURL != "" {
-				apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL}
+				authType := v.Auth.Type
+				if authType == "" {
+					authType = apiHosts[k].AuthType
+				}
+				apiHosts[k] = ServiceNoAuth{BaseURL: v.BaseURL, AuthType: authType}
 			}
 		}
 	}

--- a/front/actions/apihosts.go
+++ b/front/actions/apihosts.go
@@ -1,0 +1,160 @@
+package actions
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// FrameworkHost getapihosts가 내려주는 프레임워크별 접속 정보.
+// credential은 API 서버가 노출하지 않으므로 BaseURL과 AuthType만 갖는다.
+type FrameworkHost struct {
+	BaseURL  string `json:"BaseURL"`
+	AuthType string `json:"AuthType"`
+}
+
+// apiHostsCache getapihosts 응답 전체 맵의 인메모리 캐시.
+// TTL 이후 재조회하므로 레지스트리(USE_REGISTRY_URL) 주소 변경도 추종한다.
+var apiHostsCache = struct {
+	mu       sync.Mutex
+	hosts    map[string]FrameworkHost
+	storedAt time.Time
+}{}
+
+const apiHostsCacheTTL = 60 * time.Second
+
+// getApiHostsURL front가 이미 아는 API 서버 주소로 getapihosts 엔드포인트를 조립한다.
+// (ApiCaller 리버스 프록시와 동일한 주소 조합 — 신규 설정 불필요)
+func getApiHostsURL() string {
+	return API_SCHEME + "://" + API_ADDR + ":" + API_PORT + "/api/getapihosts"
+}
+
+// fetchApiHosts POST /api/getapihosts 를 호출해 전체 프레임워크 맵을 반환한다.
+// 캐시가 유효하면 원격 호출 없이 캐시를 반환한다.
+func fetchApiHosts(c echo.Context) (map[string]FrameworkHost, error) {
+	apiHostsCache.mu.Lock()
+	if apiHostsCache.hosts != nil && time.Since(apiHostsCache.storedAt) < apiHostsCacheTTL {
+		hosts := apiHostsCache.hosts
+		apiHostsCache.mu.Unlock()
+		return hosts, nil
+	}
+	apiHostsCache.mu.Unlock()
+
+	req, err := http.NewRequest(http.MethodPost, getApiHostsURL(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// 레지스트리 캐시 갱신 경로가 사용자 토큰/쿠키를 쓸 수 있으므로 원 요청 인증 정보를 전달
+	if c != nil {
+		if authorization, _ := c.Get("Authorization").(string); authorization != "" {
+			req.Header.Set("Authorization", authorization)
+		} else if authHeader := c.Request().Header.Get("Authorization"); authHeader != "" {
+			req.Header.Set("Authorization", authHeader)
+		}
+		for _, cookie := range c.Request().Cookies() {
+			req.AddCookie(cookie)
+		}
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("getapihosts returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed struct {
+		ResponseData map[string]FrameworkHost `json:"responseData"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, err
+	}
+	if len(parsed.ResponseData) == 0 {
+		return nil, fmt.Errorf("getapihosts returned empty host map")
+	}
+
+	apiHostsCache.mu.Lock()
+	apiHostsCache.hosts = parsed.ResponseData
+	apiHostsCache.storedAt = time.Now()
+	apiHostsCache.mu.Unlock()
+
+	return parsed.ResponseData, nil
+}
+
+// frameworkEnvKey 프레임워크명에서 env 키를 유도한다.
+// mc-infra-manager → MC_WEB_CONSOLE_INFRA_MANAGER (기존 변수명과 호환)
+func frameworkEnvKey(framework string) string {
+	name := strings.TrimPrefix(strings.ToLower(framework), "mc-")
+	name = strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+	return "MC_WEB_CONSOLE_" + name
+}
+
+// ResolveFramework 프레임워크의 BaseURL과 인증 방식을 해석한다.
+// 우선순위: MC_WEB_CONSOLE_{NAME}_URL env(명시 오버라이드 — 설정된 경우만)
+//   → getapihosts(캐시)  ← 일반 경로. 레지스트리의 backend 주소는 docker 네트워크명이므로
+//     front가 같은 네트워크에 있으면 그대로 도달. 네트워크 밖(로컬 개발 등)에서는 env로 오버라이드
+//   → fallbackURL(+경고 로그)
+func ResolveFramework(c echo.Context, framework, fallbackURL string) (string, string) {
+	if envURL := getEnvOrDefault(frameworkEnvKey(framework)+"_URL", ""); validFrameworkURL(envURL) {
+		return envURL, ""
+	}
+
+	if hosts, err := fetchApiHosts(c); err == nil {
+		if host, ok := hosts[framework]; ok && validFrameworkURL(host.BaseURL) {
+			return host.BaseURL, host.AuthType
+		}
+		log.Printf("[ResolveFramework] %s not found in getapihosts response", framework)
+	} else {
+		log.Printf("[ResolveFramework] getapihosts failed: %v", err)
+	}
+
+	log.Printf("[ResolveFramework] WARNING: falling back to default URL for %s: %s — check API server or set %s_URL",
+		framework, fallbackURL, frameworkEnvKey(framework))
+	return fallbackURL, ""
+}
+
+// validFrameworkURL 토큰/요청을 내보낼 대상 URL의 스킴을 방어적으로 검증한다.
+func validFrameworkURL(rawURL string) bool {
+	return strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://")
+}
+
+// applyFrameworkAuth 프레임워크가 요구하는 인증 방식에 맞춰 요청에 인증을 부착한다.
+//   - basic: MC_WEB_CONSOLE_{NAME}_USER/PASS env 계정 (기본 default/default)
+//   - bearer: 원 요청(사용자)의 Authorization 헤더 전달 (basic 대상에는 절대 미전송)
+//   - 그 외: 인증 미부착
+func applyFrameworkAuth(req *http.Request, c echo.Context, framework, authType string) {
+	switch strings.ToLower(authType) {
+	case "basic":
+		user := getEnvOrDefault(frameworkEnvKey(framework)+"_USER", "default")
+		pass := getEnvOrDefault(frameworkEnvKey(framework)+"_PASS", "default")
+		req.SetBasicAuth(user, pass)
+	case "bearer":
+		authorization, _ := c.Get("Authorization").(string)
+		if authorization == "" {
+			authorization = c.Request().Header.Get("Authorization")
+		}
+		if authorization != "" {
+			if !strings.HasPrefix(authorization, "Bearer ") {
+				authorization = "Bearer " + authorization
+			}
+			req.Header.Set("Authorization", authorization)
+		}
+	}
+}

--- a/front/actions/apihosts_test.go
+++ b/front/actions/apihosts_test.go
@@ -1,0 +1,214 @@
+package actions
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// resetApiHostsCache 각 테스트가 독립적으로 캐시 상태를 제어하도록 초기화한다.
+func resetApiHostsCache() {
+	apiHostsCache.mu.Lock()
+	apiHostsCache.hosts = nil
+	apiHostsCache.storedAt = time.Time{}
+	apiHostsCache.mu.Unlock()
+}
+
+// pointApiToServer 테스트 서버 주소로 API_SCHEME/ADDR/PORT 전역을 임시 변경한다.
+func pointApiToServer(t *testing.T, serverURL string) {
+	t.Helper()
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	origScheme, origAddr, origPort := API_SCHEME, API_ADDR, API_PORT
+	API_SCHEME = parsed.Scheme
+	API_ADDR = parsed.Hostname()
+	API_PORT = parsed.Port()
+	t.Cleanup(func() {
+		API_SCHEME, API_ADDR, API_PORT = origScheme, origAddr, origPort
+	})
+}
+
+func newTestContext() echo.Context {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec)
+}
+
+func newGetApiHostsServer(hosts map[string]FrameworkHost, calls *int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls != nil {
+			*calls++
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"responseData": hosts,
+			"status":       map[string]interface{}{"code": 200, "message": "OK"},
+		})
+	}))
+}
+
+func TestResolveFrameworkFromGetApiHosts(t *testing.T) {
+	resetApiHostsCache()
+	server := newGetApiHostsServer(map[string]FrameworkHost{
+		"mc-infra-manager":       {BaseURL: "http://tumblebug.example:1323/tumblebug", AuthType: "basic"},
+		"mc-application-manager": {BaseURL: "http://appmgr.example:18084", AuthType: ""},
+		"mc-iam-manager":         {BaseURL: "http://iam.example:5000", AuthType: "bearer"},
+	}, nil)
+	defer server.Close()
+	pointApiToServer(t, server.URL)
+
+	baseURL, authType := ResolveFramework(newTestContext(), "mc-infra-manager", "http://localhost:1323/tumblebug")
+	if baseURL != "http://tumblebug.example:1323/tumblebug" || authType != "basic" {
+		t.Fatalf("unexpected resolve result: %s %s", baseURL, authType)
+	}
+
+	// 타 프레임워크명도 같은 캐시로 조회
+	baseURL, authType = ResolveFramework(newTestContext(), "mc-application-manager", "http://fallback")
+	if baseURL != "http://appmgr.example:18084" || authType != "" {
+		t.Fatalf("unexpected resolve result for application-manager: %s %s", baseURL, authType)
+	}
+	baseURL, authType = ResolveFramework(newTestContext(), "mc-iam-manager", "http://fallback")
+	if baseURL != "http://iam.example:5000" || authType != "bearer" {
+		t.Fatalf("unexpected resolve result for iam-manager: %s %s", baseURL, authType)
+	}
+}
+
+func TestResolveFrameworkEnvOverride(t *testing.T) {
+	resetApiHostsCache()
+	// env 오버라이드는 getapihosts가 정상이어도 최우선 적용된다 (네트워크 외부 dev 등)
+	server := newGetApiHostsServer(map[string]FrameworkHost{
+		"mc-infra-manager": {BaseURL: "http://mc-infra-manager:1323/tumblebug", AuthType: "basic"},
+	}, nil)
+	defer server.Close()
+	pointApiToServer(t, server.URL)
+
+	os.Setenv("MC_WEB_CONSOLE_INFRA_MANAGER_URL", "http://env-tumblebug:1323/tumblebug")
+	defer os.Unsetenv("MC_WEB_CONSOLE_INFRA_MANAGER_URL")
+
+	baseURL, authType := ResolveFramework(newTestContext(), "mc-infra-manager", "http://localhost:1323/tumblebug")
+	if baseURL != "http://env-tumblebug:1323/tumblebug" {
+		t.Fatalf("expected env override, got %s", baseURL)
+	}
+	if authType != "" {
+		t.Fatalf("env override must not carry authType, got %s", authType)
+	}
+}
+
+func TestResolveFrameworkFinalFallback(t *testing.T) {
+	resetApiHostsCache()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	pointApiToServer(t, server.URL)
+	server.Close()
+	os.Unsetenv("MC_WEB_CONSOLE_INFRA_MANAGER_URL")
+
+	baseURL, _ := ResolveFramework(newTestContext(), "mc-infra-manager", "http://localhost:1323/tumblebug")
+	if baseURL != "http://localhost:1323/tumblebug" {
+		t.Fatalf("expected final fallback, got %s", baseURL)
+	}
+}
+
+func TestFetchApiHostsCacheTTL(t *testing.T) {
+	resetApiHostsCache()
+	calls := 0
+	server := newGetApiHostsServer(map[string]FrameworkHost{
+		"mc-infra-manager": {BaseURL: "http://tumblebug.example:1323/tumblebug", AuthType: "basic"},
+	}, &calls)
+	defer server.Close()
+	pointApiToServer(t, server.URL)
+
+	for i := 0; i < 3; i++ {
+		if _, err := fetchApiHosts(newTestContext()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 remote call within TTL, got %d", calls)
+	}
+
+	// TTL 만료 시 재조회
+	apiHostsCache.mu.Lock()
+	apiHostsCache.storedAt = time.Now().Add(-2 * apiHostsCacheTTL)
+	apiHostsCache.mu.Unlock()
+	if _, err := fetchApiHosts(newTestContext()); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected refetch after TTL, got %d calls", calls)
+	}
+}
+
+func TestApplyFrameworkAuth(t *testing.T) {
+	// basic: env 계정(기본 default/default)
+	req, _ := http.NewRequest(http.MethodPost, "http://target", nil)
+	applyFrameworkAuth(req, newTestContext(), "mc-infra-manager", "basic")
+	user, pass, ok := req.BasicAuth()
+	if !ok || user != "default" || pass != "default" {
+		t.Fatalf("expected default basic auth, got %s/%s ok=%v", user, pass, ok)
+	}
+
+	// basic: env 계정 오버라이드
+	os.Setenv("MC_WEB_CONSOLE_INFRA_MANAGER_USER", "opuser")
+	os.Setenv("MC_WEB_CONSOLE_INFRA_MANAGER_PASS", "oppass")
+	defer os.Unsetenv("MC_WEB_CONSOLE_INFRA_MANAGER_USER")
+	defer os.Unsetenv("MC_WEB_CONSOLE_INFRA_MANAGER_PASS")
+	req, _ = http.NewRequest(http.MethodPost, "http://target", nil)
+	applyFrameworkAuth(req, newTestContext(), "mc-infra-manager", "basic")
+	if user, pass, _ = req.BasicAuth(); user != "opuser" || pass != "oppass" {
+		t.Fatalf("expected env basic auth override, got %s/%s", user, pass)
+	}
+
+	// bearer: 원 요청 Authorization 전달
+	c := newTestContext()
+	c.Request().Header.Set("Authorization", "Bearer user-token")
+	req, _ = http.NewRequest(http.MethodPost, "http://target", nil)
+	applyFrameworkAuth(req, c, "mc-infra-manager", "bearer")
+	if got := req.Header.Get("Authorization"); got != "Bearer user-token" {
+		t.Fatalf("expected bearer forwarding, got %q", got)
+	}
+
+	// 인증 없음: 아무것도 부착하지 않음 (basic 대상 외 Bearer 미전송 규칙 포함)
+	c = newTestContext()
+	c.Request().Header.Set("Authorization", "Bearer user-token")
+	req, _ = http.NewRequest(http.MethodPost, "http://target", nil)
+	applyFrameworkAuth(req, c, "mc-application-manager", "")
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("expected no auth header, got %q", got)
+	}
+}
+
+func TestFrameworkEnvKey(t *testing.T) {
+	cases := map[string]string{
+		"mc-infra-manager":       "MC_WEB_CONSOLE_INFRA_MANAGER",
+		"mc-application-manager": "MC_WEB_CONSOLE_APPLICATION_MANAGER",
+		"mc-data-manager":        "MC_WEB_CONSOLE_DATA_MANAGER",
+	}
+	for in, want := range cases {
+		if got := frameworkEnvKey(in); got != want {
+			t.Fatalf("frameworkEnvKey(%s) = %s, want %s", in, got, want)
+		}
+	}
+}
+
+// TestValidFrameworkURL 스킴 방어 검증 (토큰 전송 대상 한정)
+func TestValidFrameworkURL(t *testing.T) {
+	valid := []string{"http://a", "https://a"}
+	invalid := []string{"", "ftp://a", "a.example.com", "//a"}
+	for _, u := range valid {
+		if !validFrameworkURL(u) {
+			t.Fatalf("expected valid: %s", u)
+		}
+	}
+	for _, u := range invalid {
+		if validFrameworkURL(u) {
+			t.Fatalf("expected invalid: %s", u)
+		}
+	}
+}

--- a/front/actions/cmd.go
+++ b/front/actions/cmd.go
@@ -29,7 +29,9 @@ type cmdCommonRequest struct {
 
 // PostCmdInfraHandler forwards a remote command request to mc-infra-manager.
 // The JS sends JSON with pathParams/Request; this handler calls mc-infra-manager
-// directly with Basic auth, bypassing the API proxy which lacks this action.
+// directly (bypassing the API proxy) so the raw command payload passes through
+// unchanged. The target BaseURL/auth type come from the API server's getapihosts
+// (api.yaml + registry), so no address is hardcoded here.
 func PostCmdInfraHandler(c echo.Context) error {
 	var req cmdCommonRequest
 	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
@@ -42,8 +44,12 @@ func PostCmdInfraHandler(c echo.Context) error {
 		return respondCmdError(c, http.StatusBadRequest, "nsId and infraId are required")
 	}
 
-	// Build mc-infra-manager URL
-	targetURL := fmt.Sprintf("%s/ns/%s/cmd/infra/%s", INFRA_MANAGER_URL, nsId, mciId)
+	// Build mc-infra-manager URL (getapihosts → env → localhost fallback)
+	baseURL, authType := ResolveFramework(c, "mc-infra-manager", "http://localhost:1323/tumblebug")
+	if authType == "" {
+		authType = "basic" // legacy default for mc-infra-manager (cb-tumblebug)
+	}
+	targetURL := fmt.Sprintf("%s/ns/%s/cmd/infra/%s", baseURL, nsId, mciId)
 
 	// Forward optional queryParams (subGroupId, vmId, etc.)
 	if len(req.QueryParams) > 0 {
@@ -65,7 +71,7 @@ func PostCmdInfraHandler(c echo.Context) error {
 		return respondCmdError(c, http.StatusInternalServerError, "failed to build request: "+err.Error())
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.SetBasicAuth(INFRA_MANAGER_USER, INFRA_MANAGER_PASS)
+	applyFrameworkAuth(httpReq, c, "mc-infra-manager", authType)
 
 	client := &http.Client{}
 	resp, err := client.Do(httpReq)

--- a/front/actions/env.go
+++ b/front/actions/env.go
@@ -11,9 +11,6 @@ var API_SCHEME string
 var API_ADDR string
 var API_PORT string
 var SESSION_SECRET string
-var INFRA_MANAGER_URL string
-var INFRA_MANAGER_USER string
-var INFRA_MANAGER_PASS string
 
 func init() {
 	// Get environment variables with defaults
@@ -23,9 +20,8 @@ func init() {
 	API_ADDR = getEnvOrDefault("MC_WEB_CONSOLE_API_ADDR", "localhost")
 	API_PORT = getEnvOrDefault("MC_WEB_CONSOLE_API_PORT", "3000")
 	SESSION_SECRET = getEnvOrDefault("MC_WEB_CONSOLE_SESSION_SECRET", "mc-web-console-secret-key")
-	INFRA_MANAGER_URL = getEnvOrDefault("MC_WEB_CONSOLE_INFRA_MANAGER_URL", "http://localhost:1323/tumblebug")
-	INFRA_MANAGER_USER = getEnvOrDefault("MC_WEB_CONSOLE_INFRA_MANAGER_USER", "default")
-	INFRA_MANAGER_PASS = getEnvOrDefault("MC_WEB_CONSOLE_INFRA_MANAGER_PASS", "default")
+	// mc-infra-manager 접속 정보는 apihosts.go의 ResolveFramework/applyFrameworkAuth가
+	// getapihosts(+MC_WEB_CONSOLE_INFRA_MANAGER_URL/_USER/_PASS env 폴백)로 해석한다.
 }
 
 func getEnvOrDefault(key, defaultValue string) string {

--- a/front/actions/upload.go
+++ b/front/actions/upload.go
@@ -92,8 +92,12 @@ func PostFileToInfraHandler(c echo.Context) error {
 	}
 	writer.Close()
 
-	// Build target URL with path substitution
-	targetURL := fmt.Sprintf("%s/ns/%s/transferFile/infra/%s", INFRA_MANAGER_URL, nsId, infraId)
+	// Build target URL with path substitution (getapihosts → env → localhost fallback)
+	baseURL, authType := ResolveFramework(c, "mc-infra-manager", "http://localhost:1323/tumblebug")
+	if authType == "" {
+		authType = "basic" // legacy default for mc-infra-manager (cb-tumblebug)
+	}
+	targetURL := fmt.Sprintf("%s/ns/%s/transferFile/infra/%s", baseURL, nsId, infraId)
 
 	// Forward queryParams as URL query string (e.g. subGroupId, vmId)
 	if len(req.QueryParams) > 0 {
@@ -109,9 +113,7 @@ func PostFileToInfraHandler(c echo.Context) error {
 		return respondUploadError(c, http.StatusInternalServerError, "failed to build request: "+err.Error())
 	}
 	httpReq.Header.Set("Content-Type", writer.FormDataContentType())
-
-	// Use Basic auth for mc-infra-manager (cb-tumblebug)
-	httpReq.SetBasicAuth(INFRA_MANAGER_USER, INFRA_MANAGER_PASS)
+	applyFrameworkAuth(httpReq, c, "mc-infra-manager", authType)
 
 	client := &http.Client{}
 	resp, err := client.Do(httpReq)


### PR DESCRIPTION
## 개요

- 원격 Command(`PostCmdInfra`)·파일 전송(`PostFileToInfra`)은 front 서버가 API 프록시를 우회해 mc-infra-manager를 직접 호출하는데, 대상 주소 `INFRA_MANAGER_URL` 기본값이 `front/actions/env.go`에 `http://localhost:1323/tumblebug`으로 하드코딩되어 있었음
- 배포 환경에서 오버라이드 env 미설정 시 localhost로 전송되어 실패

## 수정 내용

- **`front/actions/apihosts.go` (신규)**: 프레임워크 공용 주소 리졸버
  - 우선순위: `MC_WEB_CONSOLE_{NAME}_URL` env 명시 오버라이드(docker 네트워크 밖 로컬 개발용) → **API 서버 `POST /api/getapihosts`**(전체 서비스 맵 60초 TTL 캐시, 레지스트리 동적 주소 추종) → 기존 localhost 폴백 + 경고 로그
  - `applyFrameworkAuth`: 프레임워크별 요구 인증에 맞춰 적용 — basic → `MC_WEB_CONSOLE_{NAME}_USER/PASS` env 계정(기본 default/default), bearer → 사용자 Authorization 헤더 전달, 없음 → 미부착
- **`api/internal/handler/apihosts.go`**: getapihosts 응답에 `AuthType`(basic/bearer) 추가 — credential(계정/비밀번호)은 기존대로 미노출, 기존 소비처(iframe.js)는 BaseURL만 읽으므로 하위 호환
- **`front/actions/cmd.go` / `upload.go`**: 하드코딩된 URL·SetBasicAuth 대신 리졸버 사용
- **`front/actions/env.go`**: `INFRA_MANAGER_*` 전역 제거

`conf/.env`·docker-compose·JS 변경 없음. 운영(docker 네트워크 내부) 배포는 무설정으로 레지스트리의 `http://mc-infra-manager:1323` 주소가 그대로 동작하며, front가 네트워크 밖인 로컬 개발 환경만 `MC_WEB_CONSOLE_INFRA_MANAGER_URL` 오버라이드 필요.
