### PR TITLE
feat(mci): 편집 폼 template carry-through 필드 read-only 표시 및 Extend VM template Add NodeGroup 지원

### DIFF
--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -355,40 +355,46 @@ export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, ns
 
 export async function vmDynamic(mciId, nsId, Express_Server_Config_Arr) {
 
-  var obj = {}
-  obj = Express_Server_Config_Arr[0]
-  const data = {
-    pathParams: {
-      nsId: nsId,
-      infraId: mciId,
-    },
-    request: {
-      "imageId": obj.commonImage,
-      "specId": obj.commonSpec,
-      "connectionName": obj.connectionName,
-      "description": obj.description,
-      // "label": "",
-      "name": obj.name,
-      "nodeGroupSize": parseInt(obj.subGroupSize) || 1,
-      "rootDiskSize": (obj.rootDiskSize !== "" && obj.rootDiskSize !== undefined) ? parseInt(obj.rootDiskSize) : 0,
-      "rootDiskType": obj.rootDiskType,
-    }
-  }
-
-
+  // 서버 body가 단일 CreateNodeGroupDynamicReq이므로 nodeGroup별로 순차 호출
   var controller = "/api/" + "mc-infra-manager/" + "PostInfraNodeGroupDynamic";
-  const ngName = (obj && obj.name) ? obj.name : 'nodegroup';
-  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
-    'PostInfraNodeGroupDynamic',
-    'NodeGroup add: ' + ngName
-  );
-  const response = await webconsolejs["common/api/http"].commonAPIPost(
-    controller,
-    data,
-    false,
-    tracked.httpOptions
-  );
-  return response;
+  const responses = [];
+  for (const obj of Express_Server_Config_Arr) {
+    const data = {
+      pathParams: {
+        nsId: nsId,
+        infraId: mciId,
+      },
+      request: {
+        "imageId": obj.commonImage,
+        "specId": obj.commonSpec,
+        "connectionName": obj.connectionName,
+        "description": obj.description,
+        "name": obj.name,
+        "nodeGroupSize": parseInt(obj.subGroupSize) || 1,
+        "rootDiskSize": (obj.rootDiskSize !== "" && obj.rootDiskSize !== undefined) ? parseInt(obj.rootDiskSize) : 0,
+        "rootDiskType": obj.rootDiskType,
+        ...(obj.zone ? { zone: obj.zone } : {}),
+        ...(obj.nodeUserPassword ? { nodeUserPassword: obj.nodeUserPassword } : {}),
+        ...(obj.label && Object.keys(obj.label).length > 0 ? { label: obj.label } : {}),
+        ...(obj.vNetTemplateId ? { vNetTemplateId: obj.vNetTemplateId } : {}),
+        ...(obj.sgTemplateId ? { sgTemplateId: obj.sgTemplateId } : {})
+      }
+    }
+
+    const ngName = (obj && obj.name) ? obj.name : 'nodegroup';
+    const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+      'PostInfraNodeGroupDynamic',
+      'NodeGroup add: ' + ngName
+    );
+    const response = await webconsolejs["common/api/http"].commonAPIPost(
+      controller,
+      data,
+      false,
+      tracked.httpOptions
+    );
+    responses.push(response);
+  }
+  return responses;
 }
 
 export async function mciRecommendVm(data) {

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -329,7 +329,10 @@ export async function displayNewServerForm() {
     
     // 모달들 초기화
     resetModals();
-    
+
+    // 신규 모드 — 직전 편집(template li)의 carry-through 섹션 잔상 제거
+    renderCarryThroughSection(null);
+
     var div = document.getElementById("server_configuration");
     webconsolejs["partials/layout/navigatePages"].toggleSubElement(div)
 
@@ -614,11 +617,55 @@ export function view_express(cnt) {
   $("#p_subGroupSize").val(select_form_data.subGroupSize || "1");
   $("#p_vm_cnt").val(select_form_data.subGroupSize || "1");
   
+  // template carry-through 필드 read-only 표시 (값이 있는 필드만)
+  renderCarryThroughSection(select_form_data);
+
   // 서버 입력 폼 표시
   var div = document.getElementById("server_configuration");
   if (!div.classList.contains("active")) {
     webconsolejs["partials/layout/navigatePages"].toggleSubElement(div);
   }
+}
+
+// template Add NodeGroup carry-through 필드(zone/nodeUserPassword/label/vNetTemplateId/sgTemplateId)를
+// 편집 폼에 read-only로 표시 — 값이 있는 필드만 렌더, 전부 없으면(수동 입력 SubGroup) 섹션 숨김.
+// nodeUserPassword는 존재 여부만 마스킹 표시하고 평문을 노출하지 않는다.
+function renderCarryThroughSection(data) {
+  var section = document.getElementById("carry_through_section");
+  var fields = document.getElementById("carry_through_fields");
+  if (!section || !fields) return;
+
+  var items = [];
+  if (data && data.zone) items.push(["zone", "Zone", data.zone]);
+  if (data && data.nodeUserPassword) items.push(["nodeUserPassword", "Node User Password", "••••••"]);
+  if (data && data.label && Object.keys(data.label).length > 0) {
+    items.push(["label", "Label", Object.keys(data.label).map(function (k) { return k + "=" + data.label[k]; }).join(", ")]);
+  }
+  if (data && data.vNetTemplateId) items.push(["vNetTemplateId", "vNet Template ID", data.vNetTemplateId]);
+  if (data && data.sgTemplateId) items.push(["sgTemplateId", "SG Template ID", data.sgTemplateId]);
+
+  fields.innerHTML = "";
+  if (items.length === 0) {
+    section.classList.add("d-none");
+    return;
+  }
+  items.forEach(function (item) {
+    var col = document.createElement("div");
+    col.className = "col-md-6";
+    var label = document.createElement("label");
+    label.className = "form-label";
+    label.textContent = item[1];
+    var input = document.createElement("input");
+    input.type = "text";
+    input.className = "form-control";
+    input.readOnly = true;
+    input.setAttribute("data-carry-field", item[0]);
+    input.value = item[2]; // DOM value 할당 — template 값의 HTML 해석(XSS) 방지
+    col.appendChild(label);
+    col.appendChild(input);
+    fields.appendChild(col);
+  });
+  section.classList.remove("d-none");
 }
 
 

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -314,7 +314,8 @@ export async function displayNewServerForm() {
   // +SubGroup 버튼 클릭 시 수정 모드 플래그 초기화 (신규 추가 모드)
   currentEditingIndex = -1;
   
-  var deploymentAlgo = $("#mci_deploy_algorithm").val();
+  // 화면별 select 참조 — Create MCI는 #mci_deploy_algorithm, Extend VM은 #vm_deploy_algorithm
+  var deploymentAlgo = $(isVm ? "#vm_deploy_algorithm" : "#mci_deploy_algorithm").val();
 
   if (deploymentAlgo == "express") {
     // 폼을 열기 전에 추가 초기화
@@ -905,9 +906,7 @@ export async function createVmDynamic() {
     var selectedNsId = selectedWorkspaceProject.nsId;
     var mciId = window.currentMciId;
 
-    webconsolejs["common/api/services/mci_api"].vmDynamic(mciId, selectedNsId, Express_Server_Config_Arr)
-
-    // response가 있으면 
+    await webconsolejs["common/api/services/mci_api"].vmDynamic(mciId, selectedNsId, Express_Server_Config_Arr)
 
     alert("VM creation request completed")
     window.location = `/webconsole/operations/manage/workloads/mciworkloads`;
@@ -1172,13 +1171,15 @@ export function clearExpressForm() {
 // ─── Infra Template으로 MCI 배포 ─────────────────────────────────────────
 
 let templateSelectTable = null;
-let mciDeployAlgorithmPrev = "express";
+// Create MCI(#mci_deploy_algorithm)와 Extend VM(#vm_deploy_algorithm) 두 select가 template 모달을 공유한다
+let deployAlgorithmPrev = { mci_deploy_algorithm: "express", vm_deploy_algorithm: "express" };
+let templateModalSourceSelectId = "mci_deploy_algorithm"; // 모달을 연 select — 닫힐 때 이 select만 되돌린다
 let templateDeploySucceeded = false;
 let templateDeployInFlight = false;
 
 function revertDeployAlgorithmSelect() {
-	const sel = document.getElementById("mci_deploy_algorithm");
-	if (sel && sel.value === "template") sel.value = mciDeployAlgorithmPrev;
+	const sel = document.getElementById(templateModalSourceSelectId);
+	if (sel && sel.value === "template") sel.value = deployAlgorithmPrev[templateModalSourceSelectId] || "express";
 }
 
 // 템플릿 미리보기 초기화 (선택 없음 → 안내문구 표시)
@@ -1235,22 +1236,28 @@ function renderTemplateSelectDetail(template) {
 }
 
 function initTemplateDeploySelect() {
-	const sel = document.getElementById("mci_deploy_algorithm");
-	if (!sel) return;
-	mciDeployAlgorithmPrev = sel.value;
-	sel.addEventListener("change", async function () {
-		if (this.value !== "template") {
-			mciDeployAlgorithmPrev = this.value;
-			return;
-		}
-		const mciName = ($("#mci_name").val() || "").trim();
-		if (!mciName) {
-			webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Please input MCI Name first");
-			this.value = "express";
-			mciDeployAlgorithmPrev = "express";
-			return;
-		}
-		await openTemplateSelectModal();
+	["mci_deploy_algorithm", "vm_deploy_algorithm"].forEach(function (selId) {
+		const sel = document.getElementById(selId);
+		if (!sel) return;
+		deployAlgorithmPrev[selId] = sel.value;
+		sel.addEventListener("change", async function () {
+			if (this.value !== "template") {
+				deployAlgorithmPrev[selId] = this.value;
+				return;
+			}
+			// Create MCI 경로만 MCI Name 선입력 필수 — Extend VM은 기존 MCI 대상이라 불필요
+			if (selId === "mci_deploy_algorithm") {
+				const mciName = ($("#mci_name").val() || "").trim();
+				if (!mciName) {
+					webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Please input MCI Name first");
+					this.value = "express";
+					deployAlgorithmPrev[selId] = "express";
+					return;
+				}
+			}
+			templateModalSourceSelectId = selId;
+			await openTemplateSelectModal();
+		});
 	});
 }
 
@@ -1312,6 +1319,9 @@ export async function openTemplateSelectModal() {
 	modalEl.addEventListener("hidden.bs.modal", function () {
 		if (!templateDeploySucceeded) revertDeployAlgorithmSelect();
 	}, { once: true });
+	// Extend VM 경로에서는 새 MCI를 배포하는 [Deploy from Template] 버튼을 숨긴다 (Add NodeGroup만)
+	const deployFromTplBtn = document.getElementById("btn-deploy-from-template");
+	if (deployFromTplBtn) deployFromTplBtn.classList.toggle("d-none", templateModalSourceSelectId === "vm_deploy_algorithm");
 	resetTemplateSelectDetail();
 	new bootstrap.Modal(modalEl).show();
 }
@@ -1413,7 +1423,8 @@ export function addTemplateToForm() {
 		postCommandUserName: req.postCommand?.userName || "",
 		postCommandTimeoutMinutes: req.postCommand?.timeoutMinutes
 	};
-	if (!$("#mci_desc").val() && templatePrefillInfraState.description) {
+	// Create MCI 경로에서만 — Extend VM은 기존 MCI의 description을 유지한다
+	if (!isVm && !$("#mci_desc").val() && templatePrefillInfraState.description) {
 		$("#mci_desc").val(templatePrefillInfraState.description);
 	}
 

--- a/front/templates/pages/operations/manage/workloads/mciworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/mciworkloads.html
@@ -804,6 +804,7 @@
                   <option value="express">Express</option>
                   <option value="simple">Simple</option>
                   <option value="expert">Expert</option>
+                  <option value="template">Template</option>
                 </select>
               </div>
 

--- a/front/templates/partials/operation/manage/_mcicreate.html
+++ b/front/templates/partials/operation/manage/_mcicreate.html
@@ -206,6 +206,11 @@
               </div>
             </div>
           </div>
+          <!-- template Add NodeGroup carry-through 필드 read-only 표시 — 값이 있을 때만 JS가 렌더 -->
+          <div class="form-group mb-2 d-none" id="carry_through_section">
+            <label class="form-label">Template-defined Fields (read-only)</label>
+            <div class="row g-2" id="carry_through_fields"></div>
+          </div>
         </div>
         <div class="card-footer">
           <div align="right">


### PR DESCRIPTION
## Summary
- **편집 폼 read-only carry-through 필드 표시** — Template [Add NodeGroup]으로 실려온 `zone` / `nodeUserPassword` / `label` / `vNetTemplateId` / `sgTemplateId` 5필드를 SubGroup 편집 폼(`#server_configuration`)에 read-only 섹션으로 표시. 값이 있는 필드만 렌더하고 전부 없으면(수동 입력 SubGroup) 섹션 자체 숨김. `nodeUserPassword`는 `••••••` 마스킹으로 존재 여부만 표시(평문 미노출), `label`은 `key=value` 목록 표시. 값은 DOM `value` 할당으로 렌더해 template 값의 HTML 해석(XSS) 방지

- 근거: cb-tumblebug 소스 확인 — `vNetTemplateId`/`sgTemplateId`는 실제 생성되는 vNet/SG 리소스명·CIDR·정책을 바꾸는 필드(`provisioning.go:3246-3265`, `resource/common.go:2317` 이하)라, 값이 있는 template을 편집·배포할 때 최소 인지 가능하도록 노출


- **Extend VM에 template Add NodeGroup 지원** — `#vm_deploy_algorithm`에 Template 옵션 추가, template 선택 모달을 Create MCI/Extend VM 두 select 공용으로 일반화(모달을 연 select만 닫힘 시 원복). Extend VM 경로에서는 새 MCI를 배포하는 [Deploy from Template] 버튼을 숨기고 [Add NodeGroup]만 노출. read-only 섹션은 공유 폼이라 Extend VM에도 동일 적용
- **NodeGroup 추가 배포 매핑 확장** — `vmDynamic()`(`PostInfraNodeGroupDynamic`)을 nodeGroup별 순차 호출 루프로 전환(기존에 2개 이상 추가해도 `Arr[0]` 첫 항목만 전송되던 잠재 버그 해소) + carry-through 5필드를 omitempty 스프레드로 payload에 포함(#225의 `mciDynamic`과 동일 패턴). 서버 `RestPostInfraNodeGroupDynamic`은 `CreateNodeGroupDynamicReq` 전체를 bind하므로 콘솔 매핑만 보완
- 부수 정정: `displayNewServerForm()`이 Extend VM에서도 `#mci_deploy_algorithm`을 읽던 하드코딩을 isVm 분기로 정정, `addTemplateToForm()`의 `#mci_desc` 프리필은 Create MCI 경로로 한정

