### PR TITLE
fix: CSP Role Edit 저장, IDP 필드 추가, 목록 표시·정렬 버그 수정

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -729,10 +729,10 @@ serviceActions:
       method: delete
       resourcePath: /api/roles/csp/id/{roleId}
       description: "CSP Role 삭제"
-    UpdateCspRoleRecord:
+    UpdateCspRole:
       method: put
       resourcePath: /api/roles/csp/id/{roleId}
-      description: "CSP Role 수정 (mc-iam-manager 레지스트리의 updateCspRole 액션명은 잘못된 경로(/api/roles/csp-roles/id/{roleId}, 실제 미존재)를 가리켜 이름 충돌 회피를 위해 별도 이름 사용 — 실제 핸들러 UpdateCspRoleRecord와 동일 매칭)"
+      description: "CSP Role 수정"
     listCspPolicies:
       method: post
       resourcePath: /api/csp-policies/list

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -729,6 +729,10 @@ serviceActions:
       method: delete
       resourcePath: /api/roles/csp/id/{roleId}
       description: "CSP Role 삭제"
+    UpdateCspRoleRecord:
+      method: put
+      resourcePath: /api/roles/csp/id/{roleId}
+      description: "CSP Role 수정 (mc-iam-manager 레지스트리의 updateCspRole 액션명은 잘못된 경로(/api/roles/csp-roles/id/{roleId}, 실제 미존재)를 가리켜 이름 충돌 회피를 위해 별도 이름 사용 — 실제 핸들러 UpdateCspRoleRecord와 동일 매칭)"
     listCspPolicies:
       method: post
       resourcePath: /api/csp-policies/list

--- a/front/assets/js/common/api/services/csproles_api.js
+++ b/front/assets/js/common/api/services/csproles_api.js
@@ -1,6 +1,16 @@
 // CSP Roles API Service
 // mc-iam-manager API를 통한 CSP Roles 관리
 
+// mc-iam-manager CspRole 응답은 csp_type(snake_case) — 화면 코드는 provider 필드를 읽으므로 정규화한다.
+function normalizeCspRole(raw) {
+    if (!raw) return raw;
+    return { ...raw, provider: raw.provider ?? raw.cspType ?? raw.csp_type };
+}
+
+function normalizeCspRoleList(list) {
+    return Array.isArray(list) ? list.map(normalizeCspRole) : list;
+}
+
 // CSP Roles 목록 조회
 export async function getCspRoleList(provider = null, limit = 50, offset = 0) {
     const controller = "/api/mc-iam-manager/listCSPRoles";
@@ -12,7 +22,7 @@ export async function getCspRoleList(provider = null, limit = 50, offset = 0) {
         }
     };
     const response = await webconsolejs["common/api/http"].commonAPIPost(controller, data);
-    return response.data.responseData;
+    return normalizeCspRoleList(response.data.responseData);
 }
 
 // 특정 CSP Role 조회
@@ -24,7 +34,7 @@ export async function getCspRoleById(roleId) {
         }
     };
     const response = await webconsolejs["common/api/http"].commonAPIPost(controller, data);
-    return response.data.responseData;
+    return normalizeCspRole(response.data.responseData);
 }
 
 // CSP Role 생성
@@ -35,10 +45,12 @@ export async function createCspRole(roleData) {
             cspRoleName: roleData.cspRoleName,
             description: roleData.description,
             cspType: roleData.cspType,
+            authMethod: roleData.authMethod,
             idpIdentifier: roleData.idpIdentifier,
             iamIdentifier: roleData.iamIdentifier,
             iamRoleId: roleData.iamRoleId,
             path: roleData.path,
+            cspIdpConfigId: roleData.cspIdpConfigId,
             tags: roleData.tags || []
         }
     };
@@ -49,7 +61,36 @@ export async function createCspRole(roleData) {
         const errMsg = errData?.responseData?.error || errData?.status?.message || 'Failed to create CSP Role';
         throw new Error(errMsg);
     }
-    return response.data.responseData;
+    return normalizeCspRole(response.data.responseData);
+}
+
+// CSP Role 수정
+export async function updateCspRole(roleId, roleData) {
+    // mc-iam-manager 레지스트리의 "updateCspRole" 액션명은 잘못된 경로(/api/roles/csp-roles/id/{roleId},
+    // 실제 미존재 라우트)를 가리켜 대소문자 무관 이름 매칭 시 그 정의로 덮어써짐(405 유발) — 충돌 회피용 별도 이름
+    const controller = "/api/mc-iam-manager/UpdateCspRoleRecord";
+    const data = {
+        pathParams: {
+            roleId: roleId.toString()
+        },
+        Request: {
+            cspRoleName: roleData.cspRoleName,
+            description: roleData.description,
+            authMethod: roleData.authMethod,
+            idpIdentifier: roleData.idpIdentifier,
+            iamIdentifier: roleData.iamIdentifier,
+            iamRoleId: roleData.iamRoleId,
+            path: roleData.path,
+            cspIdpConfigId: roleData.cspIdpConfigId,
+        }
+    };
+    const response = await webconsolejs["common/api/http"].commonAPIPost(controller, data);
+    if (response?.response) {
+        const errData = response.response.data;
+        const errMsg = errData?.responseData?.error || errData?.status?.message || 'Failed to update CSP Role';
+        throw new Error(errMsg);
+    }
+    return normalizeCspRole(response.data.responseData);
 }
 
 // CSP Role 삭제

--- a/front/assets/js/common/api/services/csproles_api.js
+++ b/front/assets/js/common/api/services/csproles_api.js
@@ -66,9 +66,7 @@ export async function createCspRole(roleData) {
 
 // CSP Role 수정
 export async function updateCspRole(roleId, roleData) {
-    // mc-iam-manager 레지스트리의 "updateCspRole" 액션명은 잘못된 경로(/api/roles/csp-roles/id/{roleId},
-    // 실제 미존재 라우트)를 가리켜 대소문자 무관 이름 매칭 시 그 정의로 덮어써짐(405 유발) — 충돌 회피용 별도 이름
-    const controller = "/api/mc-iam-manager/UpdateCspRoleRecord";
+    const controller = "/api/mc-iam-manager/UpdateCspRole";
     const data = {
         pathParams: {
             roleId: roleId.toString()

--- a/front/assets/js/pages/operation/workspace/csproles.js
+++ b/front/assets/js/pages/operation/workspace/csproles.js
@@ -39,6 +39,7 @@ function initCspRolesTable() {
     {
       title: "Id",
       field: "id",
+      sorter: "number",
       vertAlign: "middle",
       hozAlign: "center",
       width: 300,
@@ -161,6 +162,8 @@ function setCspRolesTabulator(
     pagination,
     paginationSize,
     paginationSizeSelector,
+    // 신규 생성 role이 페이지네이션 뒷페이지에 가려 "목록에 없다"고 오인되지 않도록 최신순 기본 정렬
+    initialSort: [{ column: "id", dir: "desc" }],
     movableColumns,
     columnHeaderVertAlign,
     paginationCounter,
@@ -1334,16 +1337,10 @@ async function editCSPRole() {
     // 편집 모달의 폼에 현재 데이터 채우기
     document.getElementById('editCspRoleName').value = cspRole.name || '';
     document.getElementById('editCspRoleDescription').value = cspRole.description || '';
-
-    // Trust Policy를 JSON 문자열로 변환하여 표시
-    if (cspRole.trust_policy) {
-      const trustPolicyText = typeof cspRole.trust_policy === 'string'
-        ? cspRole.trust_policy
-        : JSON.stringify(cspRole.trust_policy, null, 2);
-      document.getElementById('editCspRoleTrustPolicy').value = trustPolicyText;
-    } else {
-      document.getElementById('editCspRoleTrustPolicy').value = '';
-    }
+    document.getElementById('editCspIdpIdentifier').value = cspRole.idp_identifier || cspRole.idpIdentifier || '';
+    document.getElementById('editCspIamIdentifier').value = cspRole.iam_identifier || cspRole.iamIdentifier || '';
+    document.getElementById('editCspIamRoleId').value = cspRole.iam_role_id || cspRole.iamRoleId || '';
+    document.getElementById('editCspPath').value = cspRole.path || '';
 
     // 편집 모달 열기
     const editModal = new bootstrap.Modal(document.getElementById('editCspRoleModal'));
@@ -1358,28 +1355,25 @@ async function editCSPRole() {
 // 편집된 CSP Role 저장
 async function saveEditedCspRole() {
   const description = document.getElementById('editCspRoleDescription').value.trim();
-  const trustPolicyText = document.getElementById('editCspRoleTrustPolicy').value.trim();
+  const idpIdentifier = document.getElementById('editCspIdpIdentifier').value.trim();
+  const iamIdentifier = document.getElementById('editCspIamIdentifier').value.trim();
+  const iamRoleId = document.getElementById('editCspIamRoleId').value.trim();
+  const path = document.getElementById('editCspPath').value.trim();
 
   // 필수 필드 검증
-  if (!description || !trustPolicyText) {
+  if (!description) {
     alert('Please fill in all required fields');
     return;
   }
 
   try {
-    // Trust Policy JSON 파싱 검증
-    let trustPolicy;
-    try {
-      trustPolicy = JSON.parse(trustPolicyText);
-    } catch (error) {
-      alert('Invalid JSON format in Trust Policy. Please check your JSON syntax.');
-      return;
-    }
-
-    // API 요구사항에 맞는 데이터 구조 (name 제외)
+    // API 요구사항(CreateCspRoleRequest 스키마)에 맞는 데이터 구조 (name 제외 — 편집 불가)
     const roleData = {
       description: description,
-      trust_policy: trustPolicy
+      idpIdentifier: idpIdentifier,
+      iamIdentifier: iamIdentifier,
+      iamRoleId: iamRoleId,
+      path: path,
     };
 
     const result = await window.webconsolejs["common/api/services/csproles_api"].updateCspRole(currentCspRoleId, roleData);

--- a/front/templates/pages/operations/manage/workspaces/csproles.html
+++ b/front/templates/pages/operations/manage/workspaces/csproles.html
@@ -1362,30 +1362,53 @@
             ></textarea>
           </div>
 
-          <div class="mb-3">
-            <label class="form-label required">Trust Policy</label>
-            <textarea
-              class="form-control"
-              id="editCspRoleTrustPolicy"
-              rows="8"
-              placeholder='Enter trust policy JSON, e.g.:
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": ["ec2.amazonaws.com"]
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}'
-              required
-            ></textarea>
-            <div class="form-hint">
-              Enter a valid JSON trust policy. This defines which services can
-              assume this role.
+          <div class="row">
+            <div class="col-md-6">
+              <div class="mb-3">
+                <label class="form-label">IDP Identifier</label>
+                <input
+                  type="text"
+                  class="form-control"
+                  id="editCspIdpIdentifier"
+                  placeholder="Enter IDP identifier"
+                />
+              </div>
+            </div>
+            <div class="col-md-6">
+              <div class="mb-3">
+                <label class="form-label">IAM Identifier</label>
+                <input
+                  type="text"
+                  class="form-control"
+                  id="editCspIamIdentifier"
+                  placeholder="Enter IAM identifier"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-md-6">
+              <div class="mb-3">
+                <label class="form-label">IAM Role ID</label>
+                <input
+                  type="text"
+                  class="form-control"
+                  id="editCspIamRoleId"
+                  placeholder="Enter IAM role ID"
+                />
+              </div>
+            </div>
+            <div class="col-md-6">
+              <div class="mb-3">
+                <label class="form-label">Path</label>
+                <input
+                  type="text"
+                  class="form-control"
+                  id="editCspPath"
+                  placeholder="e.g. /"
+                />
+              </div>
             </div>
           </div>
         </form>


### PR DESCRIPTION
## Summary
- CSP Role Edit 저장버그 수리 (`UpdateCspRole` 액션 신규 + API 함수 추가)
- Edit 모달에 Add 모달과 동등한 IDP Identifier/IAM Identifier/IAM Role ID/Path 필드 추가, Trust Policy 필드 제거
- 목록 Provider 컬럼이 필드명 불일치(`provider` vs 실제 응답 `csp_type`)로 항상 빈 값 표시 — 정규화 헬퍼로 수정
- id 컬럼이 문자열로 정렬되어(`"9" > "19"`) 신규 생성 role이 뒷페이지에 가려 "목록에 없다"고 오인되던 문제 — 숫자 정렬 + 최신순 기본 정렬로 수정
