### PR TITLE
feat(csp-roles): CSP Role 생성 시 Auth Method 선택 추가

### DIFF
--- a/front/assets/js/pages/operation/workspace/csproles.js
+++ b/front/assets/js/pages/operation/workspace/csproles.js
@@ -25,7 +25,10 @@ export async function refreshCspRolesList() {
 
 // Tabulator 테이블 초기화
 function initCspRolesTable() {
-  var tableObjParams = {};
+  // Tabulator 자체에 height를 지정해야 헤더/페이지네이션 footer는 고정되고
+  // 데이터 영역만 내부적으로 스크롤된다(외부 div에 overflow를 거는 방식은
+  // 헤더·footer까지 통째로 스크롤되어 버림).
+  var tableObjParams = { height: "400px" };
   var columns = [
     {
       formatter: "rowSelection",
@@ -124,6 +127,7 @@ function setCspRolesTabulator(
   var columnHeaderVertAlign = "middle";
   var paginationCounter = "rows";
   var layout = "fitColumns";
+  var height = undefined;
 
   if (tableObjParamMap.hasOwnProperty("placeholder")) {
     placeholder = tableObjParamMap.placeholder;
@@ -157,6 +161,10 @@ function setCspRolesTabulator(
     layout = tableObjParamMap.layout;
   }
 
+  if (tableObjParamMap.hasOwnProperty("height")) {
+    height = tableObjParamMap.height;
+  }
+
   var tabulatorTable = new Tabulator("#" + tableObjId, {
     placeholder,
     pagination,
@@ -168,6 +176,7 @@ function setCspRolesTabulator(
     columnHeaderVertAlign,
     paginationCounter,
     layout,
+    height,
     columns: columnsParams,
     selectableRows: isMultiSelect == false ? 1 : true,
   });

--- a/front/assets/js/pages/operation/workspace/csproles.js
+++ b/front/assets/js/pages/operation/workspace/csproles.js
@@ -1411,6 +1411,7 @@ async function saveEditedCspRole() {
 async function addSelectedCspRole() {
   const cspType = document.getElementById('addCspType').value.trim();
   const cspRoleName = document.getElementById('addCspRoleName').value.trim();
+  const authMethod = document.getElementById('addCspAuthMethod').value.trim();
   const description = document.getElementById('addCspRoleDescription').value.trim();
   const idpIdentifier = document.getElementById('addCspIdpIdentifier').value.trim();
   const iamIdentifier = document.getElementById('addCspIamIdentifier').value.trim();
@@ -1428,6 +1429,7 @@ async function addSelectedCspRole() {
       cspRoleName: cspRoleName,
       description: description,
       cspType: cspType,
+      authMethod: authMethod,
       idpIdentifier: idpIdentifier,
       iamIdentifier: iamIdentifier,
       iamRoleId: iamRoleId,

--- a/front/templates/pages/operations/manage/workspaces/csproles.html
+++ b/front/templates/pages/operations/manage/workspaces/csproles.html
@@ -405,10 +405,7 @@
                   </div>
                 </div>
 
-                <div
-                  class="card-table table-responsive"
-                  style="max-height: 400px; overflow-y: auto"
-                >
+                <div class="card-table table-responsive">
                   <div
                     id="csp-roles-table"
                     class="csp-roles-table-container"

--- a/front/templates/pages/operations/manage/workspaces/csproles.html
+++ b/front/templates/pages/operations/manage/workspaces/csproles.html
@@ -1238,6 +1238,22 @@
             </div>
           </div>
 
+          <div class="row">
+            <div class="col-md-6">
+              <div class="mb-3">
+                <label class="form-label required">Auth Method</label>
+                <select class="form-select" id="addCspAuthMethod" required>
+                  <option value="OIDC">OIDC</option>
+                  <option value="SAML">SAML</option>
+                  <option value="SECRET_KEY">Secret Key</option>
+                </select>
+                <div class="form-hint">
+                  대상 CSP에 생성될 실제 신뢰 정책(trust policy) 종류를 결정합니다. 생성 후에는 변경할 수 없습니다.
+                </div>
+              </div>
+            </div>
+          </div>
+
           <div class="mb-3">
             <label class="form-label">Description</label>
             <textarea

--- a/front/templates/pages/operations/manage/workspaces/csproles.html
+++ b/front/templates/pages/operations/manage/workspaces/csproles.html
@@ -407,7 +407,7 @@
 
                 <div
                   class="card-table table-responsive"
-                  style="max-height: 400px; overflow: hidden"
+                  style="max-height: 400px; overflow-y: auto"
                 >
                   <div
                     id="csp-roles-table"


### PR DESCRIPTION
## Summary
- CSP Roles 화면의 "Add CSP Role" 모달에 Auth Method(OIDC/SAML/Secret Key) 셀렉트가 없어, 콘솔로 생성하는 CSP 역할은 항상 OIDC 신뢰 정책(trust policy)으로만 생성되고 있었음 — SAML 신뢰 정책을 가진 역할은 API 직접 호출로만 만들 수 있었음
- API 서비스 레이어(`csproles_api.js`)는 이미 `authMethod` 필드를 요청에 포함하도록 구현되어 있었으나, UI에 값을 채울 방법이 없어 항상 빈 값(백엔드 기본값 OIDC)으로 전송됨
- Auth Method 셀렉트(기본값 OIDC) 추가 + 생성 요청 페이로드에 반영
- Edit 모달에는 추가하지 않음 — 수정 API가 신뢰 정책을 재생성하지 않아 authMethod 변경이 실제 효과가 없음(생성 시에만 의미 있는 값)
- `#csp-roles-table`을 감싸는 컨테이너가 `max-height: 400px; overflow: hidden`으로 고정되어 있어, Page Size를 5보다 크게(예: 20) 늘리면 넘치는 행과 페이지네이션 footer가 스크롤 없이 잘려서 안 보이던 문제 발견
- 1차로 외부 컨테이너에 `overflow-y: auto`를 걸었으나, 이 방식은 헤더·데이터·페이지네이션 footer가 통째로 스크롤되어 버려 사용성이 나빴음(사용자 피드백)
- 최종적으로 Tabulator 자체에 `height: "400px"`를 지정해, 헤더와 페이지네이션 footer는 고정되고 데이터 영역만 내부적으로 스크롤되도록 수정(외부 div의 overflow 제약은 제거)
