### PR TITLE
feat(roles): CSP Role Mapping에 Auth Method 선택 추가

### DIFF
--- a/front/assets/js/pages/operation/workspace/roles.js
+++ b/front/assets/js/pages/operation/workspace/roles.js
@@ -2220,7 +2220,7 @@ function initCspRoleMappingTable() {
             title: "CSP",
             field: "csp_type",
             headerSort: false,
-            width: "40%",
+            width: "30%",
             formatter: function (cell) {
               const cspType = cell.getValue();
               if (!cspType) return "N/A";
@@ -2231,7 +2231,16 @@ function initCspRoleMappingTable() {
             title: "Role Name",
             field: "name",
             headerSort: false,
-            width: "60%"
+            width: "45%"
+          },
+          {
+            title: "Auth Method",
+            field: "auth_method",
+            headerSort: false,
+            width: "25%",
+            formatter: function (cell) {
+              return cell.getValue() || "OIDC";
+            }
           }
         ]
       });
@@ -2276,7 +2285,7 @@ function initCspRoleMappingEditTable(roleId) {
             title: "CSP",
             field: "csp_type",
             headerSort: false,
-            width: "30%",
+            width: "25%",
             formatter: function (cell) {
               const cspType = cell.getValue();
               if (!cspType) return "N/A";
@@ -2287,12 +2296,21 @@ function initCspRoleMappingEditTable(roleId) {
             title: "Role Name",
             field: "name",
             headerSort: false,
-            width: "50%"
+            width: "35%"
+          },
+          {
+            title: "Auth Method",
+            field: "auth_method",
+            headerSort: false,
+            width: "20%",
+            formatter: function (cell) {
+              return cell.getValue() || "OIDC";
+            }
           },
           {
             title: "Actions",
             headerSort: false,
-            width: "30%",
+            width: "20%",
             formatter: function (cell) {
               const rowData = cell.getRow().getData();
               return '<button class="btn btn-sm btn-outline-primary me-1" onclick="viewEditCspRolePolicies(' + rowData.id + ', \'' + rowData.csp_type + '\', \'' + rowData.name + '\')">View</button>' +
@@ -2615,7 +2633,7 @@ async function initCreateCspRoleMappingTable() {
             title: "CSP",
             field: "csp_type",
             headerSort: false,
-            width: "25%",
+            width: "20%",
             formatter: function (cell) {
               const cspType = cell.getValue();
               if (!cspType) return "N/A";
@@ -2626,7 +2644,16 @@ async function initCreateCspRoleMappingTable() {
             title: "Role Name",
             field: "name",
             headerSort: false,
-            width: "50%"
+            width: "35%"
+          },
+          {
+            title: "Auth Method",
+            field: "auth_method",
+            headerSort: false,
+            width: "20%",
+            formatter: function (cell) {
+              return cell.getValue() || "OIDC";
+            }
           },
           {
             title: "Actions",
@@ -2693,10 +2720,12 @@ function handleAddCspRole() {
   }
 
   // 새 CSP Role 추가
+  const authMethodSelect = document.getElementById('csp-auth-method-select');
   const newCspRole = {
     id: Date.now(), // 임시 ID
     csp_type: cspProvider,
-    name: cspRoleName.trim()
+    name: cspRoleName.trim(),
+    auth_method: authMethodSelect ? authMethodSelect.value : 'OIDC'
   };
 
   AppState.cspRoleMappings.create.push(newCspRole);
@@ -2796,6 +2825,7 @@ async function saveRole() {
         formData.cspSelection.cspRoles.map(cspRole => ({
           roleName: cspRole.name,
           cspType: cspRole.csp_type,
+          authMethod: cspRole.auth_method || "OIDC",
           idpIdentifier: "", // 향후 확장 가능
           iamIdentifier: "", // 향후 확장 가능
           iamRoleId: cspRole.name,
@@ -3116,10 +3146,12 @@ function handleAddCspMapping() {
   }
 
   // 새로운 CSP 매핑을 테이블에 추가
+  const editAuthMethodSelect = document.getElementById('edit-csp-auth-method-select');
   const newMapping = {
     id: Date.now(), // 임시 ID
     csp_type: cspProvider,
-    name: cspRoleName.trim()
+    name: cspRoleName.trim(),
+    auth_method: editAuthMethodSelect ? editAuthMethodSelect.value : 'OIDC'
   };
 
   if (AppState.tables.cspRoleMappingEditTable) {
@@ -3194,6 +3226,7 @@ async function updateRole() {
     const cspRoles = cspRolesRaw.map(cspRole => ({
       roleName: cspRole.name,
       cspType: cspRole.csp_type,
+      authMethod: cspRole.auth_method || "OIDC",
       idpIdentifier: cspRole.idp_identifier || "",
       iamIdentifier: cspRole.iam_identifier || "",
       iamRoleId: cspRole.name,

--- a/front/templates/pages/operations/manage/workspaces/roles.html
+++ b/front/templates/pages/operations/manage/workspaces/roles.html
@@ -471,15 +471,27 @@
                             </div>
                           </div>
                         </div>
+                        <div class="row">
+                          <div class="col-md-4">
+                            <div class="mb-3">
+                              <label class="form-label required">Auth Method</label>
+                              <select class="form-select" id="csp-auth-method-select" name="csp-auth-method" required>
+                                <option value="OIDC">OIDC</option>
+                                <option value="SAML">SAML</option>
+                                <option value="SECRET_KEY">Secret Key</option>
+                              </select>
+                            </div>
+                          </div>
+                        </div>
                       </form>
-                      
+
                       <!-- CSP Role Mapping 테이블 -->
                       <div class="mt-3">
                         <div id="create-csp-role-mapping-table"></div>
                       </div>
                     </div>
                   </div>
-                  
+
                   <!-- Save/Cancel 버튼 -->
                   <div class="d-flex justify-content-end mt-3">
                     <button class="btn me-2" id="cancel-create-role-btn">
@@ -627,8 +639,20 @@
                               </div>
                             </div>
                           </div>
+                          <div class="row">
+                            <div class="col-md-4">
+                              <div class="mb-3">
+                                <label class="form-label required">Auth Method</label>
+                                <select class="form-select" id="edit-csp-auth-method-select" name="edit-csp-auth-method" required>
+                                  <option value="OIDC">OIDC</option>
+                                  <option value="SAML">SAML</option>
+                                  <option value="SECRET_KEY">Secret Key</option>
+                                </select>
+                              </div>
+                            </div>
+                          </div>
                         </form>
-                      
+
                       <!-- CSP Role Mapping 테이블 -->
                       <div class="mt-3">
                         <div id="csp-role-mapping-edit-table"></div>


### PR DESCRIPTION
## Summary
- Role 관리 화면(Roles)의 CSP Role Mapping 카드(생성/수정 양쪽)에 인증방식(Auth Method) 선택 요소가 없어, 매핑을 추가할 때 항상 OIDC로 백엔드에 전송되고 있었음
- mc-iam-manager 백엔드는 최근 `CreateRole`/`UpdateRole`이 요청의 `authMethod`를 올바르게 반영하도록 수정됐지만, 프론트가 애초에 값을 안 보내 여전히 저장할 때마다 매핑이 OIDC로 기본 반영되는 문제가 남아있었음 — **역할을 수정(저장)할 때마다 기존 SAML/Secret Key 매핑이 조용히 OIDC로 손상되는 실사용 데이터 손실 버그**
- Create/Edit 카드에 Auth Method 셀렉트(기본값 OIDC) 추가, `handleAddCspRole`/`handleAddCspMapping`이 선택값을 매핑 데이터에 포함하도록 수정, `saveRole`/`updateRole`의 `cspRoles` 페이로드에 `authMethod` 반영
- View/Create/Edit 3개 매핑 테이블 모두에 Auth Method 컬럼 추가(기존에 응답을 받아놓고도 표시하지 않던 필드를 노출)
