### PR TITLE
fix: PMK Add NodeGroup/Dynamic NodeGroup Root Disk Type 조회 연결

### DIFF
--- a/front/assets/js/pages/operation/manage/pmk.js
+++ b/front/assets/js/pages/operation/manage/pmk.js
@@ -118,7 +118,7 @@ var pmkListTable;// div로 선언한 pmk table
 var checked_array = [];
 var currentPmkId = "";
 var currentNodeGroupName = ""
-var currentProvider = ""
+export var currentProvider = ""
 
 initPmkTable(); // init tabulator
 
@@ -1546,8 +1546,48 @@ export async function changeCloudConnectionDynamic(connectionName) {
     // 동적 생성에서는 VPC, Subnet, Security Group 선택이 필요 없음
     // Cloud Connection만 설정하고 추가 API 호출 없이 처리
     if (!connectionName) {
+        resetNodeGroupRootDiskTypeDynamic();
         return;
     }
+
+    const provider = $("#cluster_provider_dynamic").val();
+    if (!provider) {
+        resetNodeGroupRootDiskTypeDynamic();
+        return;
+    }
+
+    try {
+        const diskResp = await webconsolejs["common/api/services/disk_api"]
+            .getCommonLookupDiskInfo(provider, connectionName);
+        applyNodeGroupRootDiskTypeDynamic(provider, diskResp);
+    } catch (error) {
+        console.error("Failed to look up disk types:", error);
+        resetNodeGroupRootDiskTypeDynamic();
+    }
+}
+
+// provider/connectionName에 맞는 Root Disk Type 옵션으로 드롭다운을 채운다
+function applyNodeGroupRootDiskTypeDynamic(provider, diskInfoList) {
+    const providerId = provider.toUpperCase();
+    const matched = Array.isArray(diskInfoList)
+        ? diskInfoList.find(item => item.providerId === providerId)
+        : null;
+
+    let html = '<option value="">Select Root Disk Type</option><option value="default">default</option>';
+    if (matched && Array.isArray(matched.rootdisktype)) {
+        matched.rootdisktype.forEach(type => {
+            html += `<option value="${type}">${type}</option>`;
+        });
+    }
+
+    $("#nodegroup_rootdisk_dynamic").empty().append(html);
+}
+
+// Root Disk Type 드롭다운을 기본 상태로 되돌린다
+function resetNodeGroupRootDiskTypeDynamic() {
+    $("#nodegroup_rootdisk_dynamic").empty().append(
+        '<option value="">Select Root Disk Type</option><option value="default">default</option>'
+    );
 }
 
 // Dynamic 폼용 Provider 변경 이벤트

--- a/front/assets/js/partials/operation/manage/clustercreate.js
+++ b/front/assets/js/partials/operation/manage/clustercreate.js
@@ -369,12 +369,28 @@ export async function displayNewNodeForm() {
 	var selectedNsId = selectedWorkspaceProject.nsId;
 	
 	// Get selected cluster's provider information for SSH Key filtering
+	// selectedPmkObj는 체크박스 선택(rowSelectionChanged) 시에만 갱신되어 비어있을 수 있으므로,
+	// 행 클릭마다 항상 갱신되는 currentProvider를 우선 사용한다
 	var selectedCluster = webconsolejs["pages/operation/manage/pmk"].selectedPmkObj;
-	var clusterProvider = null;
+	var clusterProvider = webconsolejs["pages/operation/manage/pmk"].currentProvider || null;
+	var clusterConnection = null;
 	if (selectedCluster && selectedCluster.length > 0) {
-		clusterProvider = selectedCluster[0].provider; // e.g., "aws", "azure", "gcp"
+		clusterProvider = clusterProvider || selectedCluster[0].provider; // e.g., "aws", "azure", "gcp"
+		clusterConnection = selectedCluster[0].connectionName;
 	}
-	
+
+	// Root Disk Type 옵션을 provider/connection 기준으로 동적 조회 (이미 알려진 값 사용)
+	// ssh key 조회보다 먼저 실행해, 이후 블록의 예외와 무관하게 항상 호출되도록 한다
+	if (clusterProvider) {
+		try {
+			const diskResp = await webconsolejs["common/api/services/disk_api"]
+				.getCommonLookupDiskInfo(clusterProvider, clusterConnection);
+			applyNodeRootDiskTypeOptions(clusterProvider, diskResp);
+		} catch (error) {
+			console.error("Failed to look up disk types:", error);
+		}
+	}
+
 	// getSSHKEY with provider filter
 	var sshKeyList = await webconsolejs["common/api/services/pmk_api"].getSshKey(selectedNsId, clusterProvider);
 	var mysshKeyList = sshKeyList.data.responseData.sshKey;
@@ -576,7 +592,9 @@ export async function addNewNodeGroup() {
 
 	var cluster_name = selectedCluster[0].name;
 	var cluster_desc = selectedCluster[0].description;
-	var cluster_provider = selectedCluster[0].provider;
+	// selectedPmkObj는 체크박스 선택 시에만 갱신되어 값이 비어있을 수 있으므로,
+	// 행 클릭마다 항상 갱신되는 currentProvider를 우선 사용한다
+	var cluster_provider = webconsolejs["pages/operation/manage/pmk"].currentProvider || selectedCluster[0].provider;
 	var cluster_connection = selectedCluster[0].connectionName;
 	var cluster_vpc = selectedCluster[0].vpc;
 	var cluster_subnet = selectedCluster[0].subnet;
@@ -585,6 +603,17 @@ export async function addNewNodeGroup() {
 
 	// Extract region from connectionName
 	var cluster_region = extractRegionFromConnection(cluster_connection, cluster_provider);
+
+	// Root Disk Type 옵션을 provider/connection 기준으로 동적 조회 (이후 DOM 조작 코드의 예외와 무관하게 먼저 실행)
+	if (cluster_provider) {
+		try {
+			const diskResp = await webconsolejs["common/api/services/disk_api"]
+				.getCommonLookupDiskInfo(cluster_provider, cluster_connection);
+			applyNodeRootDiskTypeOptions(cluster_provider, diskResp);
+		} catch (error) {
+			console.error("Failed to look up disk types:", error);
+		}
+	}
 
 	// Set basic cluster information
 	$("#node_cluster_name").val(cluster_name);
@@ -637,6 +666,23 @@ export async function addNewNodeGroup() {
 	window.location.hash = "#addnode";
 
 	isNodeGroup = true;
+}
+
+// provider에 맞는 Root Disk Type 옵션으로 #node_rootdisk 드롭다운을 채운다
+function applyNodeRootDiskTypeOptions(provider, diskInfoList) {
+	const providerId = (provider || "").toUpperCase();
+	const matched = Array.isArray(diskInfoList)
+		? diskInfoList.find(item => item.providerId === providerId)
+		: null;
+
+	let html = '<option value="">Select Root Disk Type</option><option value="default">default</option>';
+	if (matched && Array.isArray(matched.rootdisktype)) {
+		matched.rootdisktype.forEach(type => {
+			html += '<option value="' + type + '">' + type + '</option>';
+		});
+	}
+
+	$("#node_rootdisk").empty().append(html);
 }
 
 export async function addNewPmk() {

--- a/front/templates/partials/operation/manage/_clustercreate.html
+++ b/front/templates/partials/operation/manage/_clustercreate.html
@@ -274,4 +274,4 @@
     </div>
   </div>
 </div>
-{{ javascriptTag("partials/operation/manage/clustercreate.js") | raw }} {{ javascriptTag("common/api/services/pmk_api.js") | raw }}<!--API 호출-->
+{{ javascriptTag("partials/operation/manage/clustercreate.js") | raw }} {{ javascriptTag("common/api/services/pmk_api.js") | raw }} {{ javascriptTag("common/api/services/disk_api.js") | raw }}<!--API 호출-->


### PR DESCRIPTION
## 변경 사항
CSP/리전에 따라 "default"가 유효하지 않으면 배포 실패로 이어질 수 있어 수정.
**Add NodeGroup**(`#node_rootdisk`)과 **Dynamic NodeGroup 생성**(`#nodegroup_rootdisk_dynamic`) 두 화면은 조회 호출이 없어 항상 정적 옵션("" / "default")만 노출되던 문제.

- `pmk.js` `changeCloudConnectionDynamic()` — Dynamic NodeGroup 생성 폼에서 provider/connection 기준으로 disk lookup 호출 후 `#nodegroup_rootdisk_dynamic` 채움 (`applyNodeGroupRootDiskTypeDynamic`/`resetNodeGroupRootDiskTypeDynamic` 헬퍼 추가)
- `clustercreate.js` `displayNewNodeForm()` / `addNewNodeGroup()` — Add NodeGroup 폼에서 동일한 방식으로 `#node_rootdisk` 채움 (`applyNodeRootDiskTypeOptions` 헬퍼 추가)
- `_clustercreate.html` — **근본 원인**: PMK 페이지에 `disk_api.js` 스크립트 태그 자체가 로드되지 않아 위 두 조회 호출이 (try/catch에 의해 조용히) 항상 실패하던 문제 — 스크립트 태그 추가로 해결

