### PR TITLE
feat: 노드 MyImage 생성 및 이미지 조회 popup MyImage 소스 추가

### DIFF
--- a/api/internal/service/async_track.go
+++ b/api/internal/service/async_track.go
@@ -13,6 +13,7 @@ var AsyncTrackOperationIDs = map[string]struct{}{
 	"Postk8snodegroup":             {},
 	"GetControlInfra":              {},
 	"GetControlInfraNode":          {},
+	"PostInfraNodeSnapshot":        {},
 	"DelInfra":                     {},
 	"DelInfraNode":                 {},
 	"Deletek8scluster":             {},

--- a/front/assets/js/common/api/requestId.js
+++ b/front/assets/js/common/api/requestId.js
@@ -20,6 +20,7 @@ export const ASYNC_TRACK_OPERATION_IDS = Object.freeze([
   // Phase 2 — control
   'GetControlInfra',
   'GetControlInfraNode',
+  'PostInfraNodeSnapshot',
   // Phase 2 — delete
   'DelInfra',
   'DelInfraNode',

--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -242,6 +242,48 @@ export function vmLifeCycle(type, mciId, nsId, vmid) {
   return response;
 }
 
+// 노드 스냅샷 → MyImage(customImage) 생성
+export function createNodeSnapshot(nsId, infraId, nodeId, name, description) {
+  const data = {
+    pathParams: {
+      nsId: nsId,
+      infraId: infraId,
+      nodeId: nodeId
+    },
+    request: {
+      name: name,
+      ...(description ? { description: description } : {})
+    }
+  };
+  const controller = "/api/" + "mc-infra-manager/" + "PostInfraNodeSnapshot";
+  const tracked = webconsolejs['common/api/requestId'].beginTrackedRequest(
+    'PostInfraNodeSnapshot',
+    'Create MyImage: ' + name + ' (from ' + nodeId + ')'
+  );
+  const response = webconsolejs["common/api/http"].commonAPIPost(
+    controller,
+    data,
+    false,
+    tracked.httpOptions
+  );
+  return response;
+}
+
+// 워크스페이스 ns의 MyImage(customImage) 목록 조회
+export async function getCustomImageList(nsId) {
+  const data = {
+    pathParams: {
+      nsId: nsId
+    }
+  };
+  const controller = "/api/" + "mc-infra-manager/" + "GetAllCustomImage";
+  const response = await webconsolejs["common/api/http"].commonAPIPost(
+    controller,
+    data
+  );
+  return response.data;
+}
+
 export async function mciDynamicReview(mciName, mciDesc, Express_Server_Config_Arr, nsId) {
 
   // 새로운 인터페이스에 맞게 데이터 변환 (mciDynamic과 동일)

--- a/front/assets/js/pages/operation/manage/mci.js
+++ b/front/assets/js/pages/operation/manage/mci.js
@@ -673,6 +673,25 @@ export function openCreateNodeMyImageModal() {
     webconsolejs['partials/layout/modal'].commonShowDefaultModal('Validation', 'Please select a Node')
     return;
   }
+
+  // 일부 CSP는 Running 노드에서만 스냅샷 가능(커버리지 실증: IBM) — 안내 후 진행/취소 선택
+  const SNAPSHOT_REQUIRES_RUNNING = ["ibm"];
+  const infra = (window.totalMciListObj || []).find(m => m.id === window.currentMciId);
+  const node = ((infra && infra.node) || []).find(n => n.id === selectedVmId);
+  if (node) {
+    const provider = (node.connectionConfig && node.connectionConfig.providerName) ||
+      String(node.connectionName || "").split("-")[0];
+    if (SNAPSHOT_REQUIRES_RUNNING.includes(String(provider).toLowerCase()) &&
+        !String(node.status || "").includes("Running")) {
+      const proceed = confirm(
+        provider.toUpperCase() + " requires the node to be running to create a MyImage.\n" +
+        "The current node is not running, so the request may fail.\n" +
+        "Continue anyway?"
+      );
+      if (!proceed) return;
+    }
+  }
+
   $("#node-myimage-name").val("");
   $("#node-myimage-desc").val("");
   const modal = new bootstrap.Modal(document.getElementById("node-myimage-modal"));

--- a/front/assets/js/pages/operation/manage/mci.js
+++ b/front/assets/js/pages/operation/manage/mci.js
@@ -667,6 +667,42 @@ export function changeVmLifeCycle(type) {
   }
 }
 
+// 노드 스냅샷 → MyImage 생성 모달 오픈
+export function openCreateNodeMyImageModal() {
+  if (currentVmId == undefined || currentVmId == "") {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Validation', 'Please select a Node')
+    return;
+  }
+  $("#node-myimage-name").val("");
+  $("#node-myimage-desc").val("");
+  const modal = new bootstrap.Modal(document.getElementById("node-myimage-modal"));
+  modal.show();
+}
+
+// Create MyImage 모달 Create 버튼 콜백
+export function createNodeMyImage() {
+  const imageName = ($("#node-myimage-name").val() || "").trim();
+  if (!imageName) {
+    webconsolejs["common/utils/toast"].showToast(
+      webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR,
+      "Please enter a MyImage name"
+    );
+    return;
+  }
+  if (!selectedVmId) {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Validation', 'Please select a Node')
+    return;
+  }
+  const description = ($("#node-myimage-desc").val() || "").trim();
+  bootstrap.Modal.getInstance(document.getElementById("node-myimage-modal"))?.hide();
+  // 산출물은 customImage — 노드 목록 갱신 불필요, 완료/실패는 알림센터로 통지
+  executeTrackedRequest(
+    () => webconsolejs["common/api/services/mci_api"].createNodeSnapshot(
+      window.currentNsId, window.currentMciId, selectedVmId, imageName, description),
+    `Create MyImage failed`
+  );
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('checkScalePolicy');
   if (!btn) return;

--- a/front/assets/js/partials/layout/modal.js
+++ b/front/assets/js/partials/layout/modal.js
@@ -76,7 +76,6 @@ function commonConfirmOpen(targetAction, caller) {
     //  [ id , 문구]
     let confirmModalTextMap = new Map(
         [
-            ["CreateSnapshot", "Would you like to Create Snapshot?"],
             ["DeleteDataDisk", "Would you like to Delete Disk?"],
             ["DeleteMyImage", "Would you like to Delete MyImage?"],
             ["Logout", "Would you like to logout?"],
@@ -395,10 +394,6 @@ function commonConfirmOk() {
     } else if (targetAction == "DeleteMyImage") {
         deleteMyImageDisk();
 
-    } else if (targetAction == "CreateSnapshot") {
-        commonPromptOk
-        createSnapshot();
-
     } else if (targetAction == "DeleteNlb") {
         deleteNlb();
     } else if (targetAction == "AddNewPmk") {
@@ -576,8 +571,6 @@ function commonPromptOk() {
     } else if (targetAction == 'AddNewMciDynamic') {
         $("#mci_name").val(targetValue)
         dynamicMci()
-    } else if (targetAction == 'CreateSnapshot') {
-        createSnapshot(targetValue);
     }
 
 

--- a/front/assets/js/partials/operation/manage/imagerecommendation.js
+++ b/front/assets/js/partials/operation/manage/imagerecommendation.js
@@ -220,6 +220,14 @@ function initRecommendImageTable() {
 			headerSort: true,
 		},
 		{
+			title: "STATUS",
+			field: "imageStatus",
+			vertAlign: "middle",
+			hozAlign: "center",
+			maxWidth: 110,
+			headerSort: true,
+		},
+		{
 			title: "GPU",
 			field: "isGPUImage",
 			vertAlign: "middle",
@@ -443,6 +451,17 @@ export async function applyImageInfo() {
 	}
 
 	var selectedImage = recommendImages[0]; // 첫 번째 선택된 이미지 사용
+
+	// 준비되지 않은 MyImage(Creating 등)로 배포 시 실패 가능(커버리지 실증: Tencent/NHN) — 안내 후 진행/취소 선택
+	if (selectedImage.resourceType === "customImage" &&
+		selectedImage.imageStatus && selectedImage.imageStatus !== "Available") {
+		var proceed = confirm(
+			"This MyImage is not ready yet (status: " + selectedImage.imageStatus + ").\n" +
+			"Deploying with an unprepared image may fail.\n" +
+			"Continue anyway?"
+		);
+		if (!proceed) return;
+	}
 
 	// 콜백 함수가 설정되어 있으면 먼저 호출
 	if (imageSelectionCallback) {

--- a/front/assets/js/partials/operation/manage/imagerecommendation.js
+++ b/front/assets/js/partials/operation/manage/imagerecommendation.js
@@ -6,6 +6,7 @@ var imageSelectionCallback;// 이미지 선택 시 호출될 콜백 함수
 
 var recommendImageListObj = new Object();
 var selectedSpecInfo = null; // 선택된 spec 정보
+var imageSource = 'public'; // 조회 소스: 'public'(SearchImage, ns=system) | 'myimage'(GetAllCustomImage, 선택 ns)
 
 export function initImageRecommendation(callbackfunction) {
 	initRecommendImageTable();
@@ -27,6 +28,97 @@ export function initImageModal() {
 	
 	// 초기 테이블 초기화만 수행 (필드 설정은 Apply 시점에 미리 완료됨)
 	initRecommendImageTable();
+
+	// 조회 소스를 Public으로 리셋 + 모달이 열릴 때마다 리셋 (항상 기본 소스로 시작)
+	resetImageSource();
+	if (!imageModal.dataset.sourceResetBound) {
+		imageModal.addEventListener('show.bs.modal', function () {
+			resetImageSource();
+			recommendImageListObj = [];
+			safeSetTableData([]);
+		});
+		imageModal.dataset.sourceResetBound = "true";
+	}
+}
+
+// 조회 소스 리셋 (Public 기본)
+function resetImageSource() {
+	imageSource = 'public';
+	var publicRadio = document.getElementById('image-source-public');
+	if (publicRadio) {
+		publicRadio.checked = true;
+	}
+	togglePublicFilterRow(true);
+}
+
+// Public 전용 필터 행(OS Type/GPU/Search) 표시 토글
+function togglePublicFilterRow(visible) {
+	var filterRow = document.getElementById('image-public-filter-row');
+	if (filterRow) {
+		filterRow.style.display = visible ? '' : 'none';
+	}
+}
+
+// 조회 소스 라디오 변경 핸들러
+export async function onImageSourceChange(source) {
+	imageSource = source;
+	togglePublicFilterRow(source === 'public');
+	safeSetTableData([]);
+	recommendImageListObj = [];
+	if (source === 'myimage') {
+		await loadMyImageList();
+	}
+	// public: 기존 Search 버튼 흐름 유지 (사용자가 조건 입력 후 검색)
+}
+
+// 워크스페이스 ns의 MyImage(customImage) 목록 로딩
+async function loadMyImageList() {
+	try {
+		var selectedWorkspaceProject = await webconsolejs["partials/layout/navbar"].workspaceProjectInit();
+		var nsId = selectedWorkspaceProject.nsId;
+
+		var response = await webconsolejs["common/api/services/mci_api"].getCustomImageList(nsId);
+
+		if (!(response.status && response.status.code === 200)) {
+			console.error("MyImage list API call failed:", response);
+			webconsolejs["common/util"].showToast("Failed to load MyImage list. Switching back to Public Image.", 'warning', 5000);
+			fallbackToPublicSource();
+			return;
+		}
+
+		var imageList = (response.responseData && response.responseData.customImage) || [];
+
+		// spec 매칭 정합: 선택 spec의 connectionName 기준 클라이언트 필터
+		var connectionName = window.selectedSpecInfo && window.selectedSpecInfo.connectionName;
+		if (connectionName) {
+			imageList = imageList.filter(function (image) {
+				return image.connectionName === connectionName;
+			});
+		}
+
+		if (imageList.length === 0) {
+			webconsolejs["common/util"].showToast("No MyImage found for the selected connection. Create one from a node first.", 'warning', 5000);
+			safeSetTableData([]);
+			return;
+		}
+
+		var processedImageList = imageList.map(function (image) {
+			return mapImageInfoToRow(image);
+		});
+		recommendImageListObj = processedImageList;
+		safeSetTableData(processedImageList);
+	} catch (error) {
+		console.error("Error in loadMyImageList:", error);
+		webconsolejs["common/util"].showToast("Error loading MyImage list. Switching back to Public Image.", 'warning', 5000);
+		fallbackToPublicSource();
+	}
+}
+
+// 조회 실패 시 Public 소스로 폴백
+function fallbackToPublicSource() {
+	resetImageSource();
+	safeSetTableData([]);
+	recommendImageListObj = [];
 }
 
 // 이 함수는 더 이상 사용하지 않음 (PMK와 동일한 방식으로 단순화)
@@ -170,6 +262,33 @@ export function setImageSelectionCallback(callback) {
 	imageSelectionCallback = callback;
 }
 
+// tumblebug ImageInfo → 테이블 행 매핑 (Public/MyImage 공용 — 동일 통합 모델)
+function mapImageInfoToRow(image, fallback) {
+	fallback = fallback || {};
+	return {
+		namespace: image.namespace || fallback.namespace || "system",
+		providerName: image.providerName || fallback.provider || "",
+		cspImageName: image.cspImageName || image.name || "",
+		regionList: image.regionList || (fallback.region ? [fallback.region] : []),
+		id: image.id || image.name || "",
+		name: image.name || "",
+		connectionName: image.connectionName || fallback.connectionName || "",
+		fetchedTime: image.fetchedTime || new Date().toLocaleString(),
+		creationDate: image.creationDate || new Date().toISOString(),
+		osType: image.osType || fallback.osType || "",
+		osArchitecture: image.osArchitecture,
+		osPlatform: image.osPlatform || "Linux/UNIX",
+		osDistribution: image.osDistribution || "",
+		osDiskType: image.osDiskType || "ebs",
+		osDiskSizeGB: image.osDiskSizeGB || -1,
+		imageStatus: image.imageStatus || "Available",
+		description: image.description || image.name,
+		isBasicImage: image.isBasicImage || false,
+		isGPUImage: image.isGPUImage || false,
+		resourceType: image.resourceType || "" // "customImage"면 MyImage — root disk 안내에 사용
+	};
+}
+
 // recommened Image 조회
 export async function getRecommendImageInfo() {
 
@@ -254,27 +373,12 @@ export async function getRecommendImageInfo() {
 			
 			// API 응답을 테이블 형식에 맞게 변환
 			var processedImageList = imageList.map(function(image) {
-				return {
-					namespace: image.namespace || "system",
-					providerName: image.providerName || provider,
-					cspImageName: image.cspImageName || image.name || "",
-					regionList: image.regionList || [region],
-					id: image.id || image.name || "",
-					name: image.name || "",
-					connectionName: image.connectionName || connectionName,
-					fetchedTime: image.fetchedTime || new Date().toLocaleString(),
-					creationDate: image.creationDate || new Date().toISOString(),
-					osType: image.osType || osType,
-					osArchitecture: image.osArchitecture,
-					osPlatform: image.osPlatform || "Linux/UNIX",
-					osDistribution: image.osDistribution || "",
-				osDiskType: image.osDiskType || "ebs",
-				osDiskSizeGB: image.osDiskSizeGB || -1,
-				imageStatus: image.imageStatus || "Available",
-				description: image.description || image.name,
-				isBasicImage: image.isBasicImage || false,
-				isGPUImage: image.isGPUImage || false
-			};
+				return mapImageInfoToRow(image, {
+					provider: provider,
+					region: region,
+					osType: osType,
+					connectionName: connectionName
+				});
 			});
 
 			recommendImageListObj = processedImageList;

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -72,17 +72,21 @@ export async function callbackServerRecommendation(vmSpec) {
 // 이미지 선택 콜백 함수
 export function callbackImageRecommendation(selectedImage) {
 	// MCI 이미지 선택 콜백 함수
-	
+
 	// 부모 폼의 input 필드에 이미지 정보 설정
 	$("#ep_imageId_input").val(selectedImage.name || selectedImage.cspImageName || "");
 	$("#ep_imageId").val(selectedImage.id || selectedImage.name || "");
 	$("#ep_commonImageId").val(selectedImage.id || selectedImage.name || "");
-	
+
 	// policy_ep_* 필드들도 함께 설정 (mciworkloads.html용)
 	$("#policy_ep_imageId_input").val(selectedImage.name || selectedImage.cspImageName || "");
 	$("#policy_ep_commonImageId").val(selectedImage.id || selectedImage.name || "");
-	
 
+	// MyImage(customImage) 선택 시 root disk 입력이 서버에서 무시됨을 안내 (입력은 활성 유지)
+	var notice = document.getElementById("ep_root_disk_myimage_notice");
+	if (notice) {
+		notice.style.display = (selectedImage.resourceType === "customImage") ? "" : "none";
+	}
 }
 
 var DISK_SIZE = [];
@@ -908,9 +912,6 @@ export async function createVmDynamic() {
 
     alert("Node creation request completed")
     window.location = `/webconsole/operations/manage/workloads/mciworkloads`;
-
-    await webconsolejs["pages/operation/manage/mci"].refreshRowData(mciId, checked_array);
-
 }
 
 export function addNewMci() {

--- a/front/templates/pages/operations/manage/workloads/mciworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/mciworkloads.html
@@ -1379,8 +1379,7 @@
 
 <!-- add server : spec-search -->
 {{ partial("partials/operation/manage/serverrecommendation.html") | raw }}
-<!-- add server : image-search -->
-{{ partial("partials/operation/manage/imagerecommendation.html") | raw }}
+<!-- image-search 모달은 mcicreate.html partial이 이미 포함 — 직접 include 시 #image-search 중복 렌더링됨 -->
 <!-- add server : cspimagelist -->
 {{ partial("partials/operation/manage/cspimagelist.html") | raw }}
 <!-- add server : cspspeclist -->

--- a/front/templates/partials/operation/manage/_imagerecommendation.html
+++ b/front/templates/partials/operation/manage/_imagerecommendation.html
@@ -20,6 +20,36 @@
 
       <div class="modal-body">
         <div class="row">
+          <div class="form-group mb-2" id="image-source-group">
+            <label class="form-label">Image Source</label>
+            <div>
+              <label class="form-check form-check-inline">
+                <input
+                  class="form-check-input"
+                  type="radio"
+                  name="image-source"
+                  id="image-source-public"
+                  value="public"
+                  checked
+                  onchange="webconsolejs['partials/operation/manage/imagerecommendation'].onImageSourceChange('public')"
+                />
+                <span class="form-check-label">Public Image</span>
+              </label>
+              <label class="form-check form-check-inline">
+                <input
+                  class="form-check-input"
+                  type="radio"
+                  name="image-source"
+                  id="image-source-myimage"
+                  value="myimage"
+                  onchange="webconsolejs['partials/operation/manage/imagerecommendation'].onImageSourceChange('myimage')"
+                />
+                <span class="form-check-label">MyImage</span>
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="row">
           <div class="form-group mb-2">
             <label class="form-label">Spec Information</label>
             <input type="hidden" id="matched_spec_id" value="" />
@@ -56,7 +86,7 @@
             </div>
           </div>
         </div>
-        <div class="row">
+        <div class="row" id="image-public-filter-row">
           <div class="form-group mb-2">
             <div class="row g-2">
               <div class="col-md-4">

--- a/front/templates/partials/operation/manage/_mcicreate.html
+++ b/front/templates/partials/operation/manage/_mcicreate.html
@@ -163,6 +163,14 @@
                     />
                   </div>
                 </div>
+                <div
+                  class="text-muted small mt-1"
+                  id="ep_root_disk_myimage_notice"
+                  style="display: none"
+                >
+                  Root disk type/size follow the MyImage; values entered here
+                  will not be applied.
+                </div>
               </div>
               <div class="form-group mb-2">
                 <label class="form-label">NodeGroup Size</label>

--- a/front/templates/partials/operation/manage/_serverlist_status.html
+++ b/front/templates/partials/operation/manage/_serverlist_status.html
@@ -230,6 +230,30 @@
             </svg>
             Terminate
           </a>
+          <a
+            class="dropdown-item"
+            onclick="webconsolejs['pages/operation/manage/mci'].openCreateNodeMyImageModal()"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="icon dropdown-item-icon"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              stroke-width="2"
+              stroke="currentColor"
+              fill="none"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+              <path d="M15 8h.01"></path>
+              <path d="M3 6a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3z"></path>
+              <path d="M3 16l5 -5c.928 -.893 2.072 -.893 3 0l5 5"></path>
+              <path d="M14 14l1 -1c.928 -.893 2.072 -.893 3 0l3 3"></path>
+            </svg>
+            Create MyImage
+          </a>
 
           <div class="dropdown-divider"></div>
 
@@ -366,6 +390,36 @@
     <div class="row p-2">
       <div class="col-12">
         {{ partial("partials/operation/manage/serverinfo.html") | raw }}
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Create MyImage modal (node snapshot) -->
+<div class="modal modal-blur fade" id="node-myimage-modal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Create MyImage</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-2">
+          <label class="form-label required">MyImage Name</label>
+          <input type="text" class="form-control" id="node-myimage-name" placeholder="e.g. golden-web-01" />
+        </div>
+        <div class="mb-2">
+          <label class="form-label">Description</label>
+          <input type="text" class="form-control" id="node-myimage-desc" placeholder="(optional)" />
+        </div>
+        <div class="text-muted small">
+          A snapshot of the selected node will be created as a MyImage.
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-link link-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="node-myimage-submit-btn"
+          onclick="webconsolejs['pages/operation/manage/mci'].createNodeMyImage()">Create</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 변경 사항

노드에서 MyImage(커스텀 이미지)를 생성하고, 생성한 MyImage로 Infra/노드를 배포하는 순환 흐름을 콘솔에서 완결.

**1부 — 노드 action에서 MyImage 생성**
- Infra Workloads 노드 action 드롭다운에 **Create MyImage** 추가 — 이미지명/설명 입력 모달(`node-myimage-modal`) → `PostInfraNodeSnapshot` 호출
- requestId 비동기 알림 연동: front 허용목록(`requestId.js`) + **api 서버 allowlist**(`async_track.go`) 동시 등록 — 진행/완료/실패가 알림센터에 표시
- `modal.js`의 미정의 `createSnapshot()` 참조 dead hook 3곳 제거

**2부 — recommend image popup에 MyImage 조회/사용**
- 이미지 popup에 **Image Source 라디오** (Public Image / MyImage): Public은 기존 `SearchImage`(ns=system) 유지, MyImage는 `GetAllCustomImage`(선택 워크스페이스 ns) 조회 + spec connection 기준 클라이언트 필터
- 선택 시 기존 콜백으로 imageId 반영 → Dynamic 배포 payload 전달 (tumblebug이 customImage 자동 감지)
- MyImage 선택 시 root disk 입력이 서버에서 무시됨을 영문 안내 문구로 표시 (입력은 활성 유지)
- 모달 재오픈 시 Public으로 리셋, 목록 0건/조회 실패 시 안내 후 Public 폴백
- ImageInfo→행 매핑을 공용 함수로 추출 (두 소스 공유)

**기존 버그 수정 2건**
- `mciworkloads.html`이 image-search 모달 partial을 이중 include(직접 + mcicreate partial 경유) → 동일 id 모달 2개 렌더링·스크립트 2회 로딩 — 직접 include 제거
- `createVmDynamic()`이 페이지 이동 후 실행 불가한 dead code에서 미정의 `checked_array` 참조 — 제거

** 참고
- CSP별 특성 기록: IBM은 Running 노드에서만 스냅샷 가능, Tencent/NHN은 이미지 준비(Available) 대기 필요


**CSP 특성 가드 (커버리지 실증 기반 추가 — f07e0a85)**
- Create MyImage 진입 시 Running 노드가 필요한 CSP(IBM)에서 노드가 미기동이면 confirm 안내 후 진행/취소 선택
- 이미지 popup 테이블에 STATUS 컬럼 추가, `Available`이 아닌 MyImage Apply 시 confirm 안내 후 진행/취소 선택 (Tencent/NHN 등 이미지 준비 지연 대응)
