### PR TITLE
feat: Infra 생성 Done 시점 NodeGroup 사전 검증 추가

### DIFF
--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -353,6 +353,40 @@ export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, ns
   window.location = "/webconsole/operations/manage/workloads/mciworkloads"
 }
 
+// Add NodeGroup(Extend VM) Done 시점 단건 사전 검증.
+// 핸들러가 infra 존재를 선검증하므로 기존 infra에만 사용 가능 — 신규 Create 플로우는 mciDynamicReview(단건 배열) 사용.
+// 응답 responseData는 review 단건 객체(infra 래퍼 없음).
+export async function vmDynamicReview(mciId, nsId, config) {
+  const data = {
+    pathParams: {
+      nsId: nsId,
+      infraId: mciId,
+    },
+    request: {
+      "imageId": config.commonImage,
+      "specId": config.commonSpec,
+      "connectionName": config.connectionName,
+      "description": config.description,
+      "name": config.name,
+      "nodeGroupSize": parseInt(config.subGroupSize) || 1,
+      "rootDiskSize": (config.rootDiskSize !== "" && config.rootDiskSize !== undefined) ? parseInt(config.rootDiskSize) : 0,
+      "rootDiskType": config.rootDiskType,
+      ...(config.zone ? { zone: config.zone } : {}),
+      ...(config.nodeUserPassword ? { nodeUserPassword: config.nodeUserPassword } : {}),
+      ...(config.label && Object.keys(config.label).length > 0 ? { label: config.label } : {}),
+      ...(config.vNetTemplateId ? { vNetTemplateId: config.vNetTemplateId } : {}),
+      ...(config.sgTemplateId ? { sgTemplateId: config.sgTemplateId } : {})
+    }
+  }
+
+  var controller = "/api/" + "mc-infra-manager/" + "PostInfraDynamicNodeGroupNodeReview";
+  const response = await webconsolejs["common/api/http"].commonAPIPost(
+    controller,
+    data
+  );
+  return response;
+}
+
 export async function vmDynamic(mciId, nsId, Express_Server_Config_Arr) {
 
   // 서버 body가 단일 CreateNodeGroupDynamicReq이므로 nodeGroup별로 순차 호출

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -403,7 +403,7 @@ export async function displayNewServerForm() {
 
 // express모드 -> Done버튼 클릭 시
 
-export function expressDone_btn() {
+export async function expressDone_btn() {
   // 1. 필수 필드 검증
   var requiredFields = [
     { id: '#ep_name', message: 'NodeGroup name is required' },
@@ -465,6 +465,12 @@ export function expressDone_btn() {
   express_form["specId"] = $("#p_specId").val(); // specId 추가
   express_form["command"] = $("#p_command").val();
 
+  // 3. Done 시점 NodeGroup 단건 사전 검증 — Error면 목록에 담지 않고 폼 유지 (spec/image 재선택 유도)
+  var precheckAllowed = await precheckNodeGroup(express_form);
+  if (!precheckAllowed) {
+    return;
+  }
+
   addServerConfigToList(express_form);
 
   // 서버 입력 폼 숨기기
@@ -496,6 +502,136 @@ export function expressDone_btn() {
   
   // 모달들 초기화
   resetModals();
+}
+
+var isDonePrecheckRunning = false;
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// review 사유 목록을 modal용 텍스트로 변환 (white-space: pre-line로 줄바꿈 표시)
+function reviewReasonLines(msgs) {
+  return (msgs || []).filter(Boolean).map(function (m) { return "- " + m; }).join("\n");
+}
+
+// 검증 결과 표시 — workspace 선택 확인(checkWorkspaceSelection)과 동일한
+// 공용 모달(partials/layout/_modal.html) 스타일 재사용.
+// confirm형(#commonDefaultModal, Cancel/Confirm): resolve(true=Confirm, false=Cancel/닫힘)
+function showPrecheckConfirmModal(title, content) {
+  return new Promise(function (resolve) {
+    var modalEl = document.getElementById("commonDefaultModal");
+    if (!modalEl) {
+      resolve(confirm(title + "\n\n" + content));
+      return;
+    }
+    document.getElementById("commonDefaultModal-title").innerText = title;
+    var contentEl = document.getElementById("commonDefaultModal-content");
+    contentEl.style.whiteSpace = "pre-line";
+    contentEl.innerText = content;
+    var confirmed = false;
+    document.getElementById("commonDefaultModal-confirm-btn").onclick = function () { confirmed = true; };
+    modalEl.addEventListener("hidden.bs.modal", function () { resolve(confirmed); }, { once: true });
+    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+  });
+}
+
+// alert형(#commonAlertModal, Close만): 닫힘 시 resolve
+function showPrecheckAlertModal(title, content) {
+  return new Promise(function (resolve) {
+    var modalEl = document.getElementById("commonAlertModal");
+    if (!modalEl) {
+      alert(title + "\n\n" + content);
+      resolve();
+      return;
+    }
+    document.getElementById("commonAlertModal-title").innerText = title;
+    var contentEl = document.getElementById("commonAlertModal-content");
+    contentEl.style.whiteSpace = "pre-line";
+    contentEl.innerText = content;
+    modalEl.addEventListener("hidden.bs.modal", function () { resolve(); }, { once: true });
+    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+  });
+}
+
+// Done 시점 NodeGroup 단건 사전 검증. 결과는 공용 모달로 표시.
+// Error → alert형 모달 후 차단 / Warning·검증 불능 → confirm형 모달로 추가 여부 사용자 선택.
+// Deploy 시점 전체 review는 현행 유지되므로 최종 안전망은 유지된다.
+// 반환: true = 목록 추가 진행, false = 차단(폼 유지)
+async function precheckNodeGroup(express_form) {
+  if (isDonePrecheckRunning) {
+    return false;
+  }
+  isDonePrecheckRunning = true;
+
+  var btn = document.getElementById("express_done_btn");
+  var btnOrigHtml;
+  if (btn) {
+    btnOrigHtml = btn.innerHTML;
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span>Validating...';
+  }
+
+  try {
+    var selectedWorkspaceProject = await webconsolejs["partials/layout/navbar"].workspaceProjectInit();
+    var nsId = selectedWorkspaceProject.nsId;
+
+    var review = null;
+    if (isVm) {
+      // Extend VM(Add NodeGroup): infra 존재를 전제로 하는 단건 review API 사용
+      var vmResp = await webconsolejs["common/api/services/mci_api"].vmDynamicReview(window.currentMciId, nsId, express_form);
+      var vmData = vmResp && vmResp.status === 200 ? vmResp.data.responseData : null;
+      // 응답은 review 단건 객체 — 방어적으로 infra 래퍼(nodeReviews[])도 허용
+      review = vmData && vmData.nodeReviews ? (vmData.nodeReviews[0] || null) : vmData;
+    } else {
+      // Create Infra: 전체 review API를 단건 배열로 호출 (Deploy 시점 review와 계약 동일)
+      var mciName = $("#mci_name").val();
+      if (!mciName || !mciName.trim()) {
+        // 빈 name은 HTTP 400 — 검증용 더미 고유명 사용, name 중복 최종 검사는 Deploy review가 수행
+        mciName = "precheck-" + Math.random().toString(36).slice(2, 8);
+      }
+      var mciDesc = $("#mci_desc").val() || "precheck";
+      var mciResp = await webconsolejs["common/api/services/mci_api"].mciDynamicReview(mciName, mciDesc, [express_form], nsId);
+      var mciData = mciResp && mciResp.status === 200 ? mciResp.data.responseData : null;
+      review = mciData && mciData.nodeReviews && mciData.nodeReviews.length > 0 ? mciData.nodeReviews[0] : null;
+    }
+
+    if (!review) {
+      return await showPrecheckConfirmModal("NodeGroup Validation",
+        "NodeGroup validation could not be performed.\nIt will be validated again at Deploy.\n\nAdd to the list anyway?");
+    }
+
+    var errors = review.errors || [];
+    var warnings = review.warnings || [];
+
+    if (review.status === "Error" || review.canCreate === false) {
+      await showPrecheckAlertModal("NodeGroup Validation Failed",
+        "Not added to the list. Please reselect spec/image.\n\n"
+        + reviewReasonLines(errors.length ? errors : [review.message]));
+      return false;
+    }
+
+    if (review.status === "Warning" || warnings.length > 0) {
+      return await showPrecheckConfirmModal("NodeGroup Validation Warning",
+        reviewReasonLines(warnings.length ? warnings : [review.message])
+        + "\n\nAdd to the list anyway?");
+    }
+    return true;
+  } catch (e) {
+    console.error("NodeGroup precheck failed:", e);
+    return await showPrecheckConfirmModal("NodeGroup Validation",
+      "NodeGroup validation could not be performed.\nIt will be validated again at Deploy.\n\nAdd to the list anyway?");
+  } finally {
+    isDonePrecheckRunning = false;
+    if (btn) {
+      btn.disabled = false;
+      btn.innerHTML = btnOrigHtml;
+    }
+  }
 }
 
 // express_form을 Express_Server_Config_Arr에 반영(신규 push 또는 수정 모드 갱신) + <li> 렌더
@@ -847,31 +983,30 @@ export async function createMciDynamic() {
 			
 			// overallStatus 우선 체크 - Error 상태 처리
 			if (reviewData.overallStatus === "Error" || !reviewData.creationViable) {
-				// 오류 정보 수집
-				let errorMessage = `Infra 생성 오류\n\n${reviewData.overallMessage}\n\n`;
-				
-				if (reviewData.vmReviews && reviewData.vmReviews.length > 0) {
-					reviewData.vmReviews.forEach(vm => {
-						if (vm.status === "Error" && vm.errors) {
-							errorMessage += `Node: ${vm.vmName} (NodeGroup Size: ${vm.subGroupSize})\n`;
-							errorMessage += `Provider: ${vm.providerName}\n`;
-							errorMessage += `Region: ${vm.regionName}\n`;
-							
-							if (vm.imageValidation && vm.imageValidation.resourceId) {
-								errorMessage += `Image: ${vm.imageValidation.resourceId}\n`;
+				// 노드별 오류 상세 수집 — 배포 백엔드 계약은 nodeReviews[]/nodeName/nodeGroupSize
+				var errorLines = ["Infra creation blocked: " + (reviewData.overallMessage || "review failed")];
+
+				if (reviewData.nodeReviews && reviewData.nodeReviews.length > 0) {
+					reviewData.nodeReviews.forEach(node => {
+						if (node.status === "Error" && node.errors) {
+							var head = "Node: " + node.nodeName + " (NodeGroup Size: " + node.nodeGroupSize + ")";
+							if (node.providerName) head += " / Provider: " + node.providerName;
+							if (node.regionName) head += " / Region: " + node.regionName;
+							if (node.imageValidation && node.imageValidation.resourceId) {
+								head += " / Image: " + node.imageValidation.resourceId;
 							}
-							
-							errorMessage += `\n오류:\n`;
-							vm.errors.forEach(err => {
-								errorMessage += `- ${err}\n`;
+							errorLines.push(head);
+							node.errors.forEach(err => {
+								errorLines.push("- " + err);
 							});
-							errorMessage += `\n`;
 						}
 					});
 				}
-				
-				// Toast로 표시
-				webconsolejs["common/util"].showToast(errorMessage, 'error', 8000);
+
+				webconsolejs["common/utils/toast"].showToast(
+					webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR,
+					errorLines.map(escapeHtml).join("<br>"),
+					{ delay: 10000, closeButton: true });
 				return;
 			}
 			
@@ -882,7 +1017,7 @@ export async function createMciDynamic() {
 					webconsolejs["common/api/services/mci_api"].mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, selectedNsId, policyOnPartialFailure);
 				} else if (reviewData.overallStatus === "Warning") {
 					// 경고가 있지만 생성 가능 - 사용자 확인 후 진행
-					const confirmMessage = `경고가 있습니다:\n${reviewData.overallMessage}\n\n예상 비용: ${reviewData.estimatedCost}\n\n계속 진행하시겠습니까?`;
+					const confirmMessage = `Warnings found:\n${reviewData.overallMessage}\n\nEstimated cost: ${reviewData.estimatedCost}\n\nContinue anyway?`;
 					if (confirm(confirmMessage)) {
 						webconsolejs["common/api/services/mci_api"].mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, selectedNsId, policyOnPartialFailure);
 					}
@@ -890,12 +1025,12 @@ export async function createMciDynamic() {
 			}
 		} else {
 			// API 호출 실패
-			console.error("검증 API 호출 실패:", validationResult);
-			alert("Infra 생성 검증 중 오류가 발생했습니다.");
+			console.error("Infra review API call failed:", validationResult);
+			alert("An error occurred while validating the Infra creation request.");
 		}
 	} catch (error) {
-		console.error("MCI 검증 중 오류:", error);
-		alert("Infra 검증 중 오류가 발생했습니다: " + error.message);
+		console.error("Infra review error:", error);
+		alert("An error occurred while validating the Infra: " + error.message);
 	}
 }
 

--- a/front/templates/partials/operation/manage/_mcicreate.html
+++ b/front/templates/partials/operation/manage/_mcicreate.html
@@ -218,6 +218,7 @@
             <button
               type="submit"
               class="btn btn-info"
+              id="express_done_btn"
               onclick="webconsolejs['partials/operation/manage/mcicreate'].expressDone_btn()"
             >
               Done


### PR DESCRIPTION
## Summary

- Create Infra에서 Done 클릭 시 해당 NodeGroup **단건**을 `PostInfraDynamicReview`(단건 배열)로 사전 검증. 기존에는 Deploy 클릭 시에만 전체 config가 일괄 검증되어 n개 중 1개만 실패해도 전체가 차단되고 원인 파악이 늦었음 — 이제 spec 매진·이전 실패 이력·image 불가 등의 사유를 목록에 담기 전에 즉시 확인하고 다른 spec/image를 재선택할 수 있음
- 검증 결과는 공용 모달로 표시: **Error**는 `#commonAlertModal`로 사유 표시 후 목록 추가 차단(폼·입력값 유지), **Warning·검증 불능(network/5xx)**은 `#commonDefaultModal`(Cancel/Confirm)로 추가 여부 선택 — 검증 기능 장애가 생성 기능을 차단하지 않도록 graceful degradation
- Infra Name 미입력 상태의 Done도 동작하도록 검증용 더미명(`precheck-*`) 사용 (빈 name은 review API가 400 — name 중복 최종 검사는 Deploy 전체 review가 수행)
- **Extend VM(Add NodeGroup)의 Done에도 동일 검증 적용** — `PostInfraDynamicNodeGroupNodeReview` 사용(`vmDynamicReview` 신설). 기존 Extend 배포는 review를 전혀 호출하지 않아 사전 검증 공백이 더 컸음
- 검증 중 Done 버튼 로딩(스피너) 표시 + 이중 클릭 방지
- **회귀 수정**: Deploy 시점 전체 review Error에서 노드별 오류 상세가 표시되지 않던 문제 — 응답 소비부가 구 계약(`vmReviews`/`vmName`/`subGroupSize`)을 참조하고 있어 `nodeReviews`/`nodeName`/`nodeGroupSize`로 정정, 사유는 escape 처리 후 toast 렌더
