### PR TITLE
fix(workspace): project 목록 조회 403 시 project 셀렉터가 멈추는 문제 수정 (IAM-BUG-022)

### DIFF
--- a/front/assets/js/common/api/services/workspace_api.js
+++ b/front/assets/js/common/api/services/workspace_api.js
@@ -99,13 +99,22 @@ export async function getProjectListByWorkspaceId(workspaceId) {
     }
   }
   let projectList = [];
-  const response = await webconsolejs["common/api/http"].commonAPIPost('/api/mc-iam-manager/listUserProjectsByWorkspace', requestObject)
-  let data = response.data.responseData.projects
-  console.debug("GetWPmappingListByWorkspaceId data :", data)
-  data.forEach(item => {
-    console.debug(item)
-    projectList.push(item);
-  });
+  try {
+    const response = await webconsolejs["common/api/http"].commonAPIPost('/api/mc-iam-manager/listUserProjectsByWorkspace', requestObject)
+    let data = response.data.responseData.projects
+    console.debug("GetWPmappingListByWorkspaceId data :", data)
+    data.forEach(item => {
+      console.debug(item)
+      projectList.push(item);
+    });
+  } catch (error) {
+    // commonAPIPost는 403(권한 부족) 등 에러 응답을 throw로 전파한다.
+    // 여기서 잡지 않으면 project select box 갱신 로직 전체가 중단되어
+    // "원인 불명의 빈 project 셀렉터"로 보이므로, 빈 목록으로 조용히 복구한다.
+    // (403은 commonAPIPost가 이미 토스트로 안내하므로 중복 알림하지 않는다.)
+    console.warn("Failed to fetch project list for workspace:", workspaceId, error);
+    return [];
+  }
 
   return projectList;
 }


### PR DESCRIPTION
## 배경

`getProjectListByWorkspaceId`(`workspace_api.js`)가 403 등 에러 응답을 처리하지 않아, 호출부(`navbar.js` `setPrjSelectBox`)의 project select box 갱신 로직 전체가 처리되지 않은 rejection으로 중단된다. 사용자에게는 원인 불명의 빈 project 셀렉터로 보인다.

`commonAPIPost`(`common/api/http.js`)는 403 등 에러를 캐치해 토스트 안내 후 `throw error`로 재전파하는데, `getProjectListByWorkspaceId`에는 이를 잡는 처리가 없었다.

mc-iam-manager 쪽 핵심 수정(platformAdmin이 정상적으로 200을 받도록 하는 API 수정, [MZC-CSC/mc-iam-manager#159](https://github.com/MZC-CSC/mc-iam-manager/pull/159))과 함께, 멤버십 없는 일반 사용자의 정상적인 403 응답에서도 동일한 크래시가 발생하므로 독립적으로 방어 처리한다.

## 변경 사항

- `getProjectListByWorkspaceId`를 try/catch로 감싸 에러 시 빈 배열을 반환하도록 수정 (403은 `commonAPIPost`가 이미 토스트로 안내하므로 중복 알림 없음)
