### PR TITLE
fix: iframe 메뉴 시드 메타 3종 추가 + generic loader opts 우선순위 수정

### DIFF
--- a/conf/webconsole_menu_resources.yaml
+++ b/conf/webconsole_menu_resources.yaml
@@ -351,6 +351,9 @@ menus:
     isaction: true
     priority: 2
     menunumber: 1998
+    viewtype: iframe
+    frameworkservice: mc-workflow-manager-fe
+    path: /web/workflow/list
 
   - id: swcatalogs
     parentid: manage
@@ -359,6 +362,9 @@ menus:
     isaction: true
     priority: 2
     menunumber: 1998
+    viewtype: iframe
+    frameworkservice: mc-application-manager-fe
+    path: /web/softwareCatalog
 
   - id: datamigrations
     parentid: manage
@@ -367,6 +373,9 @@ menus:
     isaction: true
     priority: 2
     menunumber: 1998
+    viewtype: iframe
+    frameworkservice: mc-data-manager-fe
+    path: /
 
   - id: analytics
     parentid: operations
@@ -463,6 +472,9 @@ menus:
     isaction: true
     priority: 2
     menunumber: 1998
+    viewtype: iframe
+    frameworkservice: mc-cost-optimizer-fe
+    path: /
 
   - id: observability
     parentid: analytics
@@ -471,3 +483,6 @@ menus:
     isaction: true
     priority: 3
     menunumber: 1999
+    viewtype: iframe
+    frameworkservice: mc-observability-fe
+    path: /

--- a/front/assets/js/pages/operation/plugins/genericMenuLoader.js
+++ b/front/assets/js/pages/operation/plugins/genericMenuLoader.js
@@ -84,9 +84,10 @@ export async function loadByMenuId(menuId, targetDivId, opts = {}) {
 
   const tree = webconsolejs['common/storage/localstorage'].getMenuLocalStorage() || [];
   const menu = findMenuInTree(tree, menuId) || {};
+  // opts는 페이지가 전달하는 known-good 메타(WEB-BUG-037) — 메뉴 시드 DB 기본값보다 우선한다.
   const frameworkService =
-    menu.frameworkService || opts.frameworkService || '';
-  const path = menu.path != null && menu.path !== '' ? menu.path : (opts.path ?? '/');
+    opts.frameworkService || menu.frameworkService || '';
+  const path = opts.path ?? (menu.path != null && menu.path !== '' ? menu.path : '/');
 
   if (!frameworkService) {
     targetDiv.innerHTML =


### PR DESCRIPTION
## 변경 요약
- `webconsole_menu_resources.yaml`에 iframe형 메뉴 5종(workflows/costanalysis/datamigrations/observability/swcatalogs)의 `frameworkservice`/`path`/`viewtype: iframe` 메타 추가 — 시드 원본에 이 필드들이 없어 DB 기본값(`view_type=local`, `framework_service=mc-web-console-front`)으로 시드되고, 클린 설치·재시드마다 잘못된 host/route로 향하던 문제
- `genericMenuLoader.js`의 `frameworkService`/`path` 결정 우선순위를 DB 우선(`menu.frameworkService || opts.frameworkService`)에서 opts 우선으로 변경 — 각 페이지가 전달하는 known-good 값이 DB 기본값에 덮이지 않도록 함
