### PR TITLE
feat: Infra 배포 시 custom label 설정 추가 (Infra/Node label + Node Password 편집)

### DIFF
--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -284,7 +284,7 @@ export async function getCustomImageList(nsId) {
   return response.data;
 }
 
-export async function mciDynamicReview(mciName, mciDesc, Express_Server_Config_Arr, nsId) {
+export async function mciDynamicReview(mciName, mciDesc, Express_Server_Config_Arr, nsId, labels) {
 
   // 새로운 인터페이스에 맞게 데이터 변환 (mciDynamic과 동일)
   const nodeGroups = Express_Server_Config_Arr.map(config => ({
@@ -316,7 +316,7 @@ export async function mciDynamicReview(mciName, mciDesc, Express_Server_Config_A
       "name": mciName,
       "description": mciDesc,
       "installMonAgent": "no",
-      "label": {},
+      "label": labels || {},
       "policyOnPartialFailure": "continue",
       "postCommand": {
         "command": command,
@@ -336,7 +336,7 @@ export async function mciDynamicReview(mciName, mciDesc, Express_Server_Config_A
   return response;
 }
 
-export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, nsId, policyOnPartialFailure) {
+export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, nsId, policyOnPartialFailure, labels) {
 
   // 새로운 인터페이스에 맞게 데이터 변환
   const nodeGroups = Express_Server_Config_Arr.map(config => ({
@@ -367,6 +367,7 @@ export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, ns
     Request: {
       "name": mciName,
       "description": mciDesc,
+      "label": labels || {},
       "nodeGroups": nodeGroups,
       "policyOnPartialFailure": policyOnPartialFailure,
       "postCommand": {

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -337,6 +337,8 @@ export async function displayNewServerForm() {
 
     // 신규 모드 — 직전 편집(template li)의 carry-through 값 잔상 제거 (빈 필드로 초기화)
     renderCarryThroughSection(null);
+    setNodeLabels(null);
+    $("#ep_node_user_password").val("");
 
     var div = document.getElementById("server_configuration");
     webconsolejs["partials/layout/navigatePages"].toggleSubElement(div)
@@ -468,6 +470,10 @@ export async function expressDone_btn() {
   express_form["imageId"] = $("#p_imageId").val(); // imageId 추가
   express_form["specId"] = $("#p_specId").val(); // specId 추가
   express_form["command"] = $("#p_command").val();
+  // Node Labels 편집기 상태 반영 — 빈 객체면 수정 모드 merge에서 기존 label 제거(사용자가 비운 것) 의도 유지
+  express_form["label"] = { ...nodeCustomLabels };
+  // Node User Password — 빈 값이면 payload에서 omit, 수정 모드에서 비우면 제거 (trim하지 않음)
+  express_form["nodeUserPassword"] = $("#ep_node_user_password").val() || "";
 
   // 3. Done 시점 NodeGroup 단건 사전 검증 — Error면 목록에 담지 않고 폼 유지 (spec/image 재선택 유도)
   var precheckAllowed = await precheckNodeGroup(express_form);
@@ -503,7 +509,9 @@ export async function expressDone_btn() {
   $("#ep_vm_add_cnt").val("1"); // 기본값 1로 설정
   $("#ep_data_disk").val("");
   $("#ep_command").val("");
-  
+  setNodeLabels(null);
+  $("#ep_node_user_password").val("");
+
   // 모달들 초기화
   resetModals();
 }
@@ -562,6 +570,125 @@ function showPrecheckAlertModal(title, content) {
   });
 }
 
+// ─── Infra 배포 Labels ───
+// 기본 label 2종은 배포 시 코드에서 자동 주입 — UI에는 read-only 뱃지로만 표시 (수정·삭제 불가)
+var DEFAULT_INFRA_LABELS = { "project": "mcmp", "framework": "mc-web-console" };
+var infraCustomLabels = {};
+
+// labelSelector 파싱 예약 문자(, = !)·공백을 배제한 안전 문자셋
+var LABEL_TOKEN_RE = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+
+// label 입력 공통 검증 — 통과 시 null, 실패 시 사유(영문) 반환
+function validateLabelInput(key, value, existing, reservedKeys) {
+  if (!key || !value) {
+    return "Label key and value are required";
+  }
+  if (!LABEL_TOKEN_RE.test(key) || !LABEL_TOKEN_RE.test(value)) {
+    return "Only letters, digits, '-', '_', '.', '/' are allowed (must start with a letter or digit)";
+  }
+  if (key.indexOf("sys.") === 0) {
+    return "'sys.' prefix is reserved for system labels";
+  }
+  if (reservedKeys && Object.prototype.hasOwnProperty.call(reservedKeys, key)) {
+    return "'" + key + "' is a default label and cannot be overridden";
+  }
+  if (Object.prototype.hasOwnProperty.call(existing, key)) {
+    return "Label key '" + key + "' already exists";
+  }
+  return null;
+}
+
+// label 목록 렌더 — textContent 할당(HTML 해석 방지)
+function renderLabelList(containerId, labelsObj, removeFn) {
+  var list = document.getElementById(containerId);
+  if (!list) return;
+  list.innerHTML = "";
+  Object.keys(labelsObj).forEach(function (key) {
+    var row = document.createElement("div");
+    row.className = "d-flex align-items-center mb-1";
+    var badge = document.createElement("span");
+    badge.className = "badge badge-outline text-blue fw-normal me-2";
+    badge.textContent = key + "=" + labelsObj[key];
+    var btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "btn btn-sm btn-ghost-danger";
+    btn.textContent = "Remove";
+    btn.onclick = function () { removeFn(key); };
+    row.appendChild(badge);
+    row.appendChild(btn);
+    list.appendChild(row);
+  });
+}
+
+export function addInfraLabel() {
+  var toast = webconsolejs["common/utils/toast"];
+  var key = ($("#mci_label_key").val() || "").trim();
+  var value = ($("#mci_label_value").val() || "").trim();
+
+  var err = validateLabelInput(key, value, infraCustomLabels, DEFAULT_INFRA_LABELS);
+  if (err) {
+    toast.showToast(toast.TOAST_TYPES.ERROR, err);
+    return;
+  }
+
+  infraCustomLabels[key] = value;
+  $("#mci_label_key").val("");
+  $("#mci_label_value").val("");
+  renderInfraLabelList();
+}
+
+export function removeInfraLabel(key) {
+  delete infraCustomLabels[key];
+  renderInfraLabelList();
+}
+
+function renderInfraLabelList() {
+  renderLabelList("mci_label_list", infraCustomLabels, removeInfraLabel);
+}
+
+// ─── Node(NodeGroup) Labels — express 폼 단위 (Create/Extend 공유) ───
+// CreateNodeGroupDynamicReq.label로 전송 — 기본 label 자동 주입은 Infra top-level 전용(여긴 없음)
+var nodeCustomLabels = {};
+
+export function addNodeLabel() {
+  var toast = webconsolejs["common/utils/toast"];
+  var key = ($("#ep_label_key").val() || "").trim();
+  var value = ($("#ep_label_value").val() || "").trim();
+
+  var err = validateLabelInput(key, value, nodeCustomLabels, null);
+  if (err) {
+    toast.showToast(toast.TOAST_TYPES.ERROR, err);
+    return;
+  }
+
+  nodeCustomLabels[key] = value;
+  $("#ep_label_key").val("");
+  $("#ep_label_value").val("");
+  renderNodeLabelList();
+}
+
+export function removeNodeLabel(key) {
+  delete nodeCustomLabels[key];
+  renderNodeLabelList();
+}
+
+function renderNodeLabelList() {
+  renderLabelList("ep_label_list", nodeCustomLabels, removeNodeLabel);
+}
+
+// 수정 모드 진입 시 기존 label 로드 / 신규·초기화 시 빈 상태
+function setNodeLabels(labels) {
+  nodeCustomLabels = { ...(labels || {}) };
+  renderNodeLabelList();
+  $("#ep_label_key").val("");
+  $("#ep_label_value").val("");
+}
+
+// 배포 페이로드용 label — 사용자 label 위에 기본 label을 마지막으로 merge (기본 키 보존 이중 방어)
+function getInfraDeployLabels() {
+  return { ...infraCustomLabels, ...DEFAULT_INFRA_LABELS };
+}
+
 // Done 시점 NodeGroup 단건 사전 검증. 결과는 공용 모달로 표시.
 // Error → alert형 모달 후 차단 / Warning·검증 불능 → confirm형 모달로 추가 여부 사용자 선택.
 // Deploy 시점 전체 review는 현행 유지되므로 최종 안전망은 유지된다.
@@ -599,7 +726,8 @@ async function precheckNodeGroup(express_form) {
         mciName = "precheck-" + Math.random().toString(36).slice(2, 8);
       }
       var mciDesc = $("#mci_desc").val() || "precheck";
-      var mciResp = await webconsolejs["common/api/services/mci_api"].mciDynamicReview(mciName, mciDesc, [express_form], nsId);
+      // labels도 Deploy review와 동일하게 전달 (계약 대칭 — review는 label을 검증하지 않음)
+      var mciResp = await webconsolejs["common/api/services/mci_api"].mciDynamicReview(mciName, mciDesc, [express_form], nsId, getInfraDeployLabels());
       var mciData = mciResp && mciResp.status === 200 ? mciResp.data.responseData : null;
       review = mciData && mciData.nodeReviews && mciData.nodeReviews.length > 0 ? mciData.nodeReviews[0] : null;
     }
@@ -758,7 +886,12 @@ export function view_express(cnt) {
   $("#p_subGroupSize").val(select_form_data.subGroupSize || "1");
   $("#p_vm_cnt").val(select_form_data.subGroupSize || "1");
   
-  // template carry-through 필드 read-only 표시 (5필드 항상, 값 없으면 빈 칸)
+  // 기존 label을 Node Labels 편집기로 로드 (template carry-through label 포함 — 편집 가능)
+  setNodeLabels(select_form_data.label);
+  // Node User Password 로드 — password 타입 입력으로 마스킹 표시
+  $("#ep_node_user_password").val(select_form_data.nodeUserPassword || "");
+
+  // template carry-through 필드 read-only 표시 (값 없으면 빈 칸 — label은 편집기로 이동)
   renderCarryThroughSection(select_form_data);
 
   // 서버 입력 폼 표시
@@ -768,9 +901,9 @@ export function view_express(cnt) {
   }
 }
 
-// template Add NodeGroup carry-through 필드(zone/nodeUserPassword/label/vNetTemplateId/sgTemplateId)를
-// 편집 폼에 read-only로 표시 — 5필드 모두 항상 렌더, 값이 없으면 빈 입력으로 표시.
-// nodeUserPassword는 값이 있을 때만 마스킹 표시하고 평문을 노출하지 않는다.
+// template Add NodeGroup carry-through 필드(zone/vNetTemplateId/sgTemplateId)를
+// 편집 폼에 read-only로 표시 — template 유래 값이 하나라도 있을 때만 섹션 표시.
+// nodeUserPassword·label은 일반 입력(모든 모드)으로 전환되어 여기서 제외.
 function renderCarryThroughSection(data) {
   var section = document.getElementById("carry_through_section");
   var fields = document.getElementById("carry_through_fields");
@@ -778,14 +911,17 @@ function renderCarryThroughSection(data) {
 
   var items = [
     ["zone", "Zone", (data && data.zone) || ""],
-    ["nodeUserPassword", "Node User Password", data && data.nodeUserPassword ? "••••••" : ""],
-    ["label", "Label",
-      data && data.label && Object.keys(data.label).length > 0
-        ? Object.keys(data.label).map(function (k) { return k + "=" + data.label[k]; }).join(", ")
-        : ""],
     ["vNetTemplateId", "vNet Template ID", (data && data.vNetTemplateId) || ""],
     ["sgTemplateId", "SG Template ID", (data && data.sgTemplateId) || ""],
   ];
+
+  // template 유래 값이 없으면(express 직접 생성 등) 섹션 숨김
+  var hasValue = items.some(function (item) { return item[2] !== ""; });
+  if (!hasValue) {
+    fields.innerHTML = "";
+    section.classList.add("d-none");
+    return;
+  }
 
   fields.innerHTML = "";
   items.forEach(function (item) {
@@ -975,10 +1111,13 @@ export async function createMciDynamic() {
 		mciDesc = "Made in CB-TB"
 	}
 
+	// 기본 label 자동 주입 + 사용자 label merge — review/deploy 동일 객체 전송
+	const deployLabels = getInfraDeployLabels();
+
 	// MCI 생성 전 검증 API 호출
 	try {
 		const validationResult = await webconsolejs["common/api/services/mci_api"].mciDynamicReview(
-			mciName, mciDesc, Express_Server_Config_Arr, selectedNsId
+			mciName, mciDesc, Express_Server_Config_Arr, selectedNsId, deployLabels
 		);
 		
 		
@@ -1018,12 +1157,12 @@ export async function createMciDynamic() {
 			if (reviewData.creationViable) {
 				if (reviewData.overallStatus === "Ready") {
 					// 검증 성공 - 실제 MCI 생성 진행
-					webconsolejs["common/api/services/mci_api"].mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, selectedNsId, policyOnPartialFailure);
+					webconsolejs["common/api/services/mci_api"].mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, selectedNsId, policyOnPartialFailure, deployLabels);
 				} else if (reviewData.overallStatus === "Warning") {
 					// 경고가 있지만 생성 가능 - 사용자 확인 후 진행
 					const confirmMessage = `Warnings found:\n${reviewData.overallMessage}\n\nEstimated cost: ${reviewData.estimatedCost}\n\nContinue anyway?`;
 					if (confirm(confirmMessage)) {
-						webconsolejs["common/api/services/mci_api"].mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, selectedNsId, policyOnPartialFailure);
+						webconsolejs["common/api/services/mci_api"].mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, selectedNsId, policyOnPartialFailure, deployLabels);
 					}
 				}
 			}
@@ -1052,6 +1191,11 @@ export async function createVmDynamic() {
 export function addNewMci() {
 	isVm = false
 	Express_Server_Config_Arr = new Array();
+	// Labels 입력 상태 초기화 (기본 label은 상수 — UI 뱃지 고정)
+	infraCustomLabels = {};
+	renderInfraLabelList();
+	$("#mci_label_key").val("");
+	$("#mci_label_value").val("");
 }
 
 // ////////////// VM Handling ///////////
@@ -1294,7 +1438,9 @@ export function clearExpressForm() {
 	$("#ep_vm_add_cnt").val("1"); // 기본값 1로 설정
 	$("#ep_data_disk").val("");
 	$("#ep_command").val("");
-	
+	setNodeLabels(null);
+	$("#ep_node_user_password").val("");
+
 	// 4. 수정 모드 플래그 초기화
 	window.currentEditIndex = undefined;
 	

--- a/front/templates/pages/operations/manage/workloads/mciworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/mciworkloads.html
@@ -679,6 +679,33 @@
                 </div>
               </div>
 
+              <div class="mb-3">
+                <label class="form-label">Infra Labels</label>
+                <div class="input-group mb-2">
+                  <input
+                    type="text"
+                    class="form-control"
+                    id="mci_label_key"
+                    placeholder="key"
+                  />
+                  <input
+                    type="text"
+                    class="form-control"
+                    id="mci_label_value"
+                    placeholder="value"
+                  />
+                  <button
+                    type="button"
+                    class="btn"
+                    id="mci_label_add_btn"
+                    onclick="webconsolejs['partials/operation/manage/mcicreate'].addInfraLabel()"
+                  >
+                    Add
+                  </button>
+                </div>
+                <div id="mci_label_list"></div>
+              </div>
+
               <div class="card">
                 <div class="card-body">
                   <div class="row row-cards">

--- a/front/templates/partials/operation/manage/_mcicreate.html
+++ b/front/templates/partials/operation/manage/_mcicreate.html
@@ -189,7 +189,17 @@
                     </div>
                   </div>
                 </div>
-              </div>              
+              </div>
+              <div class="form-group mb-2">
+                <label class="form-label">Node User Password</label>
+                <input
+                  type="password"
+                  class="form-control"
+                  id="ep_node_user_password"
+                  autocomplete="new-password"
+                  placeholder="optional"
+                />
+              </div>
             </div>
             <div class="col-md-6">
               <div class="form-group mb-2">
@@ -211,6 +221,32 @@
                   rows="3"
                   placeholder="client_ip=$(echo $SSH_CLIENT | awk '{print $1}'); echo SSH client IP is: $client_ip"
                 ></textarea>
+              </div>
+              <div class="form-group mb-2">
+                <label class="form-label">Node Labels</label>
+                <div class="input-group mb-2">
+                  <input
+                    type="text"
+                    class="form-control"
+                    id="ep_label_key"
+                    placeholder="key"
+                  />
+                  <input
+                    type="text"
+                    class="form-control"
+                    id="ep_label_value"
+                    placeholder="value"
+                  />
+                  <button
+                    type="button"
+                    class="btn"
+                    id="ep_label_add_btn"
+                    onclick="webconsolejs['partials/operation/manage/mcicreate'].addNodeLabel()"
+                  >
+                    Add
+                  </button>
+                </div>
+                <div id="ep_label_list"></div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Create Infra 카드에 **Infra Labels** 입력 블록 추가 — 기본 2종(`project=mcmp`, `framework=mc-web-console`)은 배포 시 코드에서 자동 주입되며, 생성 화면에는 표시하지 않고 배포 후 Infra detail의 Labels 탭에서 확인한다. 사용자 label(key=value)은 Add/Remove로 관리
- NodeGroup 폼에 **Node Labels** 입력 블록 추가 — `CreateNodeGroupDynamicReq.label`로 전송(Create/Extend 폼 공유), 수정 모드 진입 시 기존 label을 편집기에 로드
- **Node User Password**를 모든 모드에서 입력 가능한 일반 password 필드로 전환 (기존엔 template 유래일 때만 read-only 표시)
- carry-through 섹션(Zone/vNet Template/SG Template)은 template 유래 값이 있을 때만 표시하도록 조건부 전환 — password·label이 일반 입력으로 빠지며 상시 노출할 이유가 사라진 나머지 3필드만 대상
- 입력 검증: `sys.` prefix(백엔드가 시스템 label 덮어쓰기를 막지 않음 — 소스 확인)·기본 label 키(Infra 전용)·중복 키·labelSelector 예약 문자(`,` `=` `!`) 차단
- `mciDynamic`/`mciDynamicReview`에 `labels` 파라미터 추가, Request top-level `label` 대칭 전송 — Done 단건 precheck(#242) 호출부 포함 3곳 모두 동일 전달

## 회귀 대응

Node User Password/Labels가 read-only carry-through에서 일반 입력으로 바뀌며 기존 spec 3종의 전제가 깨져 개정했습니다. 그 과정에서 `web-tech-019`/`web-tech-018` spec이 이미 develop에 있는 Done 단건 precheck(#242)의 review mock을 구 계약(`vmReviews`)으로 갖고 있어 "검증 불능" 취급되어 Done 편집이 조용히 막히던 선행 결함도 함께 발견해 보강했습니다(이번 변경으로 생긴 문제 아님 — #242 머지 이후 두 spec이 갱신되지 않아 잠재해 있던 것).

## Gate 결과

| Gate | 결과 |
|------|------|
| feature:backend | SKIP (변경 없음) |
| feature:frontend.vet / test / bundle | PASS |
| security:secrets | PASS |
| security:deps | SKIP (의존성 변경 없음) |
| cost | PASS (인프라 변경 없음) |

## 테스트

- Playwright UI 테스트 — 관련 spec 5종 **28/28 PASS** (route mock, 실자원 미생성)
  - `web-tech-038-deploy-labels`: Infra/Node Labels 입력·검증·페이로드 merge 전송 (7 TC)
  - `web-tech-037-done-precheck`: 회귀 없음 (6 TC)
  - `web-tech-020-carry-through-readonly`: 재설계된 조건부 표시 검증 (9 TC)
  - `web-tech-019-nodegroup-payload-mapping` / `web-tech-018-add-nodegroup`: 회귀 없음 (3+4 TC)
- 실서버 배포로 사용자 확인 완료 (Infra Labels 자동 주입 + Node Password 반영 실측)
