### PR TITLE
fix: Cloud Resources 4개 화면의 Import 버튼 제거

### DIFF
--- a/front/templates/pages/settings/environment/cloudresources/disks.html
+++ b/front/templates/pages/settings/environment/cloudresources/disks.html
@@ -6,17 +6,6 @@
           <div class="card-header">
             <h3 class="card-title">Data Disk List</h3>
             <div class="card-options ms-auto d-flex gap-2">
-              <!-- Import DataDisk -->
-              <a class="btn-action" type="button" title="Import Unmanaged DataDisks from CSP"
-                onclick="webconsolejs['pages/settings/environment/cloudresources/disks'].openImportDiskModal()">
-                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
-                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-                  <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2"/>
-                  <path d="M7 11l5 5l5 -5"/>
-                  <path d="M12 4l0 12"/>
-                </svg>
-              </a>
               <!-- Attach selected -->
               <a class="btn-action" type="button" title="Attach selected Data Disk"
                 onclick="webconsolejs['pages/settings/environment/cloudresources/disks'].openAttachFromList()">

--- a/front/templates/pages/settings/environment/cloudresources/networks.html
+++ b/front/templates/pages/settings/environment/cloudresources/networks.html
@@ -6,17 +6,6 @@
           <div class="card-header">
             <h3 class="card-title">Network (VPC) List</h3>
             <div class="card-options ms-auto d-flex gap-2">
-              <!-- Import VNet -->
-              <a class="btn-action" type="button" title="Import Unmanaged VNets from CSP"
-                onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].openImportVNetModal()">
-                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
-                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-                  <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2"/>
-                  <path d="M7 11l5 5l5 -5"/>
-                  <path d="M12 4l0 12"/>
-                </svg>
-              </a>
               <!-- Edit selected -->
               <a class="btn-action" type="button" title="Edit selected"
                 onclick="webconsolejs['pages/settings/environment/cloudresources/networks'].triggerEditSelected()">

--- a/front/templates/pages/settings/environment/cloudresources/securitygroups.html
+++ b/front/templates/pages/settings/environment/cloudresources/securitygroups.html
@@ -6,17 +6,6 @@
           <div class="card-header">
             <h3 class="card-title">SecurityGroup List</h3>
             <div class="card-options ms-auto d-flex gap-2">
-              <!-- Import SG -->
-              <a class="btn-action" type="button" title="Import unregistered SecurityGroups from CSP"
-                onclick="webconsolejs['pages/settings/environment/cloudresources/securitygroups'].openImportSGModal()">
-                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
-                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-                  <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2"/>
-                  <path d="M7 11l5 5l5 -5"/>
-                  <path d="M12 4l0 12"/>
-                </svg>
-              </a>
               <!-- Edit selected -->
               <a class="btn-action" type="button" title="Edit selected"
                 onclick="webconsolejs['pages/settings/environment/cloudresources/securitygroups'].triggerEditSelected()">

--- a/front/templates/pages/settings/environment/cloudresources/sshkeys.html
+++ b/front/templates/pages/settings/environment/cloudresources/sshkeys.html
@@ -6,17 +6,6 @@
           <div class="card-header">
             <h3 class="card-title">SSH Key List</h3>
             <div class="card-options ms-auto d-flex gap-2">
-              <!-- Import SSH Key -->
-              <a class="btn-action" type="button" title="Import Unmanaged SSH Keys from CSP"
-                onclick="webconsolejs['pages/settings/environment/cloudresources/sshkeys'].openImportSshKeyModal()">
-                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
-                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-                  <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2"/>
-                  <path d="M7 11l5 5l5 -5"/>
-                  <path d="M12 4l0 12"/>
-                </svg>
-              </a>
               <!-- Delete selected -->
               <a class="btn-action" type="button" title="Delete selected"
                 onclick="webconsolejs['pages/settings/environment/cloudresources/sshkeys'].confirmBulkDelete()">


### PR DESCRIPTION
## Summary

- Networks/Security Groups/Disks/SSH Keys 4개 화면의 "Import" 아이콘 버튼 제거
- 이 버튼들은 CSP에 이미 존재하는 리소스를 시스템에 등록(Registration)하는 기능인데, `Settings > Cloud Resources > Resource Sync` 화면이 커넥션+리소스타입 단일 선택만으로도 동일하게, 더 넓은 범위로, 올바른 API(`cspimport_api.js` → `RegisterCspNativeResources`)로 이미 구현하고 있어 기능이 중복됨
- 카드 헤더 툴바의 Import 버튼(`<a class="btn-action" onclick="...openImportXxxModal()">`)만 제거. 모달 마크업 + 관련 JS 함수(`import_api.js` 포함)는 향후 재사용 가능하도록 그대로 둠 — 버튼이 없어져 호출되지 않을 뿐 코드는 안 건드림
