### PR TITLE
feat: NLB 운영 기능 정비 — Infra 탭 노드 Assign/UnAssign 전환 + NLBs 화면 단일 조회·Edit·Health Checker 입력

### DIFF
--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -2304,6 +2304,10 @@ serviceActions:
       method: get
       resourcePath: /ns/{nsId}/infra/{infraId}/nlb/{nlbId}/healthz
       description: Get NLB Health
+    GetNLBSupport:
+      method: get
+      resourcePath: /nlb/support
+      description: Get per-CSP support for custom NLB health checker fields
     GetNs:
       method: get
       resourcePath: /ns/{nsId}

--- a/conf/api.yaml
+++ b/conf/api.yaml
@@ -2032,6 +2032,10 @@ serviceActions:
       method: get
       resourcePath: /ns/{nsId}/infra/{infraId}/nlb
       description: List all NLBs or NLBs' ID
+    GetAllNLBInNs:
+      method: get
+      resourcePath: /ns/{nsId}/resources/nlb
+      description: List all NLBs in a namespace (each item carries infraId)
     GetAllNs:
       method: get
       resourcePath: /ns

--- a/front/assets/css/application.scss
+++ b/front/assets/css/application.scss
@@ -277,3 +277,12 @@
   border-radius: 10px;
   overflow: hidden;
 }
+
+// NLB Detail 등 잘린(ellipsis) 값의 hover 툴팁 — 긴 DNS/ARN이 한눈에 보이도록 폭 확장 + 강제 줄바꿈
+.nlb-full-text-tooltip .tooltip-inner {
+  max-width: 560px;
+  text-align: left;
+  word-break: break-all;
+  font-family: var(--tblr-font-monospace, monospace);
+  font-size: 0.8125rem;
+}

--- a/front/assets/js/common/api/services/nlb_api.js
+++ b/front/assets/js/common/api/services/nlb_api.js
@@ -44,6 +44,26 @@ export async function getNLBHealth(nsId, infraId, nlbId) {
   return response?.data?.responseData;
 }
 
+/** 기존 NLB 타겟에 노드 추가 (Assign) */
+export async function addNLBNodes(nsId, infraId, nlbId, nodes) {
+  const controller = '/api/mc-infra-manager/AddNLBVMs';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId, infraId, nlbId },
+    request: { targetGroup: { nodes } }
+  });
+  return response?.data;
+}
+
+/** NLB 타겟에서 노드 해제 (UnAssign) */
+export async function removeNLBNodes(nsId, infraId, nlbId, nodes) {
+  const controller = '/api/mc-infra-manager/RemoveNLBVMs';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId, infraId, nlbId },
+    request: { targetGroup: { nodes } }
+  });
+  return response?.data;
+}
+
 /** infra의 NodeGroup(subGroup) id 목록 — Create NLB 대상 선택용 */
 export async function getInfraNodeGroupIds(nsId, infraId) {
   const controller = '/api/mc-infra-manager/GetInfraGroupIds';

--- a/front/assets/js/common/api/services/nlb_api.js
+++ b/front/assets/js/common/api/services/nlb_api.js
@@ -11,6 +11,15 @@ export async function getAllNLB(nsId, infraId) {
   return response?.data?.responseData;
 }
 
+/** namespace 전체 NLB 목록 (Infra 무관, 각 항목에 infraId 포함) — Infra별 N+1 조회 대체 */
+export async function getAllNLBInNs(nsId) {
+  const controller = '/api/mc-infra-manager/GetAllNLBInNs';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    pathParams: { nsId }
+  });
+  return response?.data?.responseData;
+}
+
 export async function getNLB(nsId, infraId, nlbId) {
   const controller = '/api/mc-infra-manager/GetNLB';
   const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {

--- a/front/assets/js/common/api/services/nlb_api.js
+++ b/front/assets/js/common/api/services/nlb_api.js
@@ -20,6 +20,15 @@ export async function getAllNLBInNs(nsId) {
   return response?.data?.responseData;
 }
 
+/** CSP별 healthChecker 커스텀 필드(interval/timeout/threshold) 지원 여부 — cspType 생략 시 전체 */
+export async function getNLBSupport(cspType) {
+  const controller = '/api/mc-infra-manager/GetNLBSupport';
+  const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {
+    queryParams: cspType ? { cspType } : undefined
+  });
+  return response?.data?.responseData;
+}
+
 export async function getNLB(nsId, infraId, nlbId) {
   const controller = '/api/mc-infra-manager/GetNLB';
   const response = await webconsolejs['common/api/http'].commonAPIPost(controller, {

--- a/front/assets/js/pages/settings/environment/cloudresources/nlbs.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/nlbs.js
@@ -23,7 +23,7 @@ $('#select-current-project').on('change', async function () {
   AppState.ns = project?.NsId || '';
   hideDetail();
   if (AppState.tables.nlbTable) AppState.tables.nlbTable.replaceData([]);
-  if (AppState.ns) await loadNlbList();
+  if (AppState.ns) await loadNlbInNsList();
 });
 
 document.addEventListener('DOMContentLoaded', async function () {
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', async function () {
   initTable([]);
 
   if (selectedWorkspaceProject.projectId !== '') {
-    await loadNlbList();
+    await loadNlbInNsList();
   }
 });
 
@@ -88,10 +88,55 @@ async function getInfraList() {
 }
 
 // ─── NLB 목록 로드 ────────────────────────────────────────────────────────
-// Infra는 NLB 조회 API(nsId+infraId 필요)의 필수 경로 파라미터라 목록 화면
-// 자체를 특정 Infra 선택으로 가둘 수 없다. 대신 namespace의 전체 Infra
-// 목록을 먼저 조회한 뒤, Infra별로 NLB를 조회해 하나의 테이블에 합친다.
 
+// 배포 백엔드(cb-tumblebug NLBInfo)는 Type/Scope/CreatedTime에 json 태그가 없어 대문자 키로 내려오고,
+// targetGroup의 노드 그룹 필드는 nodeGroupId(구계약 subGroupId), 노드 목록은 nodes(구계약 vms)다.
+// 화면 전역에서 이 편차를 흡수하는 접근자.
+const nlbType = (d) => d?.type ?? d?.Type ?? '-';
+const nlbScope = (d) => d?.scope ?? d?.Scope ?? '-';
+const nodeGroupOf = (d) => d?.targetGroup?.nodeGroupId || d?.targetGroup?.subGroupId || '-';
+const assignedNodes = (d) => d?.targetGroup?.nodes || d?.targetGroup?.vms || [];
+
+function _enrichNlbItem(v, infraId) {
+  return {
+    ...v,
+    _infraId: infraId,
+    _provider: getProvider(v),
+    _region: getRegion(v),
+    _type: nlbType(v),
+    _scope: nlbScope(v),
+  };
+}
+
+function _applyNlbItems(items) {
+  AppState.resources.all = items;
+  populateProviderFilterOptions(items, 'filter-provider');
+  populateRegionFilterOptions(items, 'filter-provider', 'filter-region');
+  if (AppState.tables.nlbTable) {
+    AppState.tables.nlbTable.replaceData(items);
+  } else {
+    initTable(items);
+  }
+}
+
+// namespace 전체 NLB를 단일 호출(GetAllNLBInNs, cb-tumblebug#2658)로 조회한다.
+// 각 항목이 infraId를 들고 오므로 Infra별 N+1 조회 없이 하나의 테이블에 바로 싣는다.
+export async function loadNlbInNsList() {
+  if (!AppState.ns) return;
+  try {
+    const data = await nlbApi().getAllNLBInNs(AppState.ns);
+    const rawItems = data?.nlb || (Array.isArray(data) ? data : []);
+    const items = rawItems.map((v) => _enrichNlbItem(v, v.infraId || v._infraId || '-'));
+    _applyNlbItems(items);
+  } catch (err) {
+    console.error('NLB 목록(namespace) 조회 실패:', err);
+    showToast(TOAST_TYPES.ERROR, 'Failed to load NLB list.');
+  }
+}
+
+// [legacy] Infra별 N+1 집계 방식 — GetAllNLBInNs 미지원 백엔드용 폴백으로 유지(현재 미호출).
+// Infra는 NLB 조회 API(nsId+infraId 필요)의 필수 경로 파라미터라 namespace의 전체 Infra
+// 목록을 먼저 조회한 뒤, Infra별로 NLB를 조회해 하나의 테이블에 합친다.
 export async function loadNlbList() {
   if (!AppState.ns) return;
   const infras = await getInfraList();
@@ -109,17 +154,10 @@ export async function loadNlbList() {
       if (result.status !== 'fulfilled') return;
       const rawItems = result.value?.nlb || (Array.isArray(result.value) ? result.value : []);
       for (const v of rawItems) {
-        items.push({ ...v, _infraId: infras[idx].id, _provider: getProvider(v), _region: getRegion(v) });
+        items.push(_enrichNlbItem(v, infras[idx].id));
       }
     });
-    AppState.resources.all = items;
-    populateProviderFilterOptions(items, 'filter-provider');
-    populateRegionFilterOptions(items, 'filter-provider', 'filter-region');
-    if (AppState.tables.nlbTable) {
-      AppState.tables.nlbTable.replaceData(items);
-    } else {
-      initTable(items);
-    }
+    _applyNlbItems(items);
   } catch (err) {
     console.error('NLB 목록 조회 실패:', err);
     showToast(TOAST_TYPES.ERROR, 'Failed to load NLB list.');
@@ -150,8 +188,8 @@ function initTable(items) {
       { title: 'Infra', field: '_infraId', widthGrow: 1, sorter: 'string' },
       { title: 'Provider', field: '_provider', widthGrow: 1, sorter: 'string' },
       { title: 'Region', field: '_region', widthGrow: 1, sorter: 'string' },
-      { title: 'Type', field: 'type', width: 100 },
-      { title: 'Scope', field: 'scope', width: 100 },
+      { title: 'Type', field: '_type', width: 100 },
+      { title: 'Scope', field: '_scope', width: 100 },
       {
         title: 'Listener',
         field: 'listener',
@@ -165,7 +203,15 @@ function initTable(items) {
         title: 'Target NodeGroup',
         field: 'targetGroup',
         widthGrow: 1,
-        formatter: (cell) => cell.getValue()?.subGroupId || '-',
+        formatter: (cell) => nodeGroupOf(cell.getRow().getData()),
+      },
+      {
+        title: 'Assigned Nodes',
+        field: 'targetGroup',
+        width: 130,
+        hozAlign: 'center',
+        formatter: (cell) => String(assignedNodes(cell.getRow().getData()).length),
+        sorter: (a, b, aRow, bRow) => assignedNodes(aRow.getData()).length - assignedNodes(bRow.getData()).length,
       },
       {
         title: 'DNS Name',
@@ -215,15 +261,21 @@ function renderDetail(data) {
   document.getElementById('detail-nlb-infra').textContent = data._infraId || '-';
   document.getElementById('detail-nlb-provider').textContent = getProvider(data);
   document.getElementById('detail-nlb-region').textContent = getRegion(data);
-  document.getElementById('detail-nlb-type').textContent = data.type || '-';
-  document.getElementById('detail-nlb-scope').textContent = data.scope || '-';
+  document.getElementById('detail-nlb-type').textContent = nlbType(data);
+  document.getElementById('detail-nlb-scope').textContent = nlbScope(data);
   document.getElementById('detail-nlb-listener').textContent =
     listener.protocol || listener.port ? `${listener.protocol || ''}:${listener.port || ''}` : '-';
   renderTruncatableCopyable('detail-nlb-endpoint', listener.dnsName || listener.ip || '-');
-  document.getElementById('detail-nlb-nodegroup').textContent = target.subGroupId || '-';
+  document.getElementById('detail-nlb-nodegroup').textContent = nodeGroupOf(data);
+  const nodes = assignedNodes(data);
+  document.getElementById('detail-nlb-nodes').innerHTML = nodes.length
+    ? nodes.map((n) => `<span class="badge bg-blue-lt me-1">${n}</span>`).join('')
+    : '-';
   document.getElementById('detail-nlb-target-port').textContent = target.port || '-';
   document.getElementById('detail-nlb-healthchecker').textContent =
-    hc.protocol || hc.port ? `${hc.protocol || ''}:${hc.port || ''} (interval ${hc.interval || '-'}, threshold ${hc.threshold || '-'})` : '-';
+    hc.protocol || hc.port
+      ? `${hc.protocol || ''}:${hc.port || ''} (interval ${hc.interval || '-'}, timeout ${hc.timeout || '-'}, threshold ${hc.threshold || '-'})`
+      : '-';
   renderTruncatableCopyable('detail-nlb-csp-id', data.cspResourceId || '-');
   document.getElementById('detail-nlb-description').textContent = data.description || '-';
   document.getElementById('detail-nlb-health').textContent = '-';
@@ -378,7 +430,170 @@ export async function executeBulkDelete() {
   AppState.resources.bulkSelected = [];
   AppState.tables.nlbTable?.deselectRow();
   hideDetail();
-  await loadNlbList();
+  await loadNlbInNsList();
+}
+
+// ─── Edit (노드 Assign/UnAssign) ─────────────────────────────────────────
+// tumblebug에 NLB update API가 없어(RestPutNLB 미구현) Listener/HealthChecker는 생성 후 변경 불가.
+// 콘솔의 "Edit"는 타겟 노드 추가(AddNLBVMs)/해제(RemoveNLBVMs)만을 의미한다.
+// Infra Info NLB 탭(partials/operation/manage/mcinlb.js)의 Assign/UnAssign 로직을 이 화면 컨텍스트
+// (AppState.ns + 선택 행의 _infraId)에 맞춰 단일 Edit 모달로 구성.
+
+// 편집 대상 스냅샷 { id, infraId, assigned:[nodeId] } — 모달 오픈~저장 사이에만 유효
+let _editTarget = null;
+
+export async function triggerEditSelected() {
+  const table = AppState.tables.nlbTable;
+  const selected = table ? table.getSelectedData() : [];
+  if (selected.length !== 1) {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal(
+      'Validation',
+      selected.length === 0 ? 'Please select an NLB to edit.' : 'Please select only one NLB to edit.'
+    );
+    return;
+  }
+  const row = selected[0];
+  _editTarget = { id: nlbId(row), infraId: row._infraId, assigned: assignedNodes(row) };
+  document.getElementById('nlb-edit-nlb-name').textContent = _editTarget.id;
+  document.getElementById('nlb-edit-assigned-list').innerHTML = '<div class="text-secondary">Loading...</div>';
+  document.getElementById('nlb-edit-candidate-list').innerHTML = '<div class="text-secondary">Loading...</div>';
+  document.getElementById('nlb-edit-node-status').textContent = '';
+  new bootstrap.Modal(document.getElementById('nlb-edit-modal')).show();
+  await _loadEditNodes();
+}
+
+async function _loadEditNodes() {
+  if (!_editTarget) return;
+  const { id, infraId } = _editTarget;
+
+  // 목록 캐시가 오래됐을 수 있어 상세를 새로 조회해 할당 노드를 확정한다.
+  try {
+    const detail = await nlbApi().getNLB(AppState.ns, infraId, id);
+    if (detail) _editTarget.assigned = assignedNodes(detail);
+  } catch (err) {
+    console.error('NLB 상세 조회 실패:', err);
+  }
+  const statusByGroup = await getNodeStatusesByGroup(AppState.ns, infraId);
+  _renderEditLists(statusByGroup);
+}
+
+// 좌: 할당된 노드(체크=해제 대상) / 우: 미할당 노드(체크=추가 대상, 비Running은 비활성).
+// 백엔드 Add는 중복 검증 없이 append하므로 기할당 노드 제외는 프론트가 책임진다.
+function _renderEditLists(statusByGroup) {
+  const assignedEl = document.getElementById('nlb-edit-assigned-list');
+  const candidateEl = document.getElementById('nlb-edit-candidate-list');
+  const statusEl = document.getElementById('nlb-edit-node-status');
+  const assigned = new Set(_editTarget?.assigned || []);
+
+  assignedEl.innerHTML = assigned.size
+    ? Array.from(assigned)
+        .map(
+          (n) => `
+        <label class="form-check mb-1">
+          <input class="form-check-input nlb-edit-unassign-check" type="checkbox" value="${n}">
+          <span class="form-check-label">${n}</span>
+        </label>`
+        )
+        .join('')
+    : '<div class="text-secondary">No nodes are assigned to this NLB.</div>';
+
+  const candidates = [];
+  for (const [groupId, nodes] of Object.entries(statusByGroup || {})) {
+    for (const n of nodes) {
+      if (assigned.has(n.id)) continue;
+      candidates.push({ ...n, groupId });
+    }
+  }
+  if (candidates.length === 0) {
+    candidateEl.innerHTML = '<div class="text-secondary">No assignable nodes. All nodes of this Infra are already assigned.</div>';
+    statusEl.textContent = '';
+    return;
+  }
+  candidateEl.innerHTML = candidates
+    .map((n) => {
+      const running = n.status === 'Running';
+      return `
+        <label class="form-check mb-1">
+          <input class="form-check-input nlb-edit-assign-check" type="checkbox" value="${n.id}" ${running ? '' : 'disabled'}>
+          <span class="form-check-label">${n.id} <span class="text-secondary">(${n.groupId})</span>
+            <span class="badge ${running ? 'bg-success' : 'bg-warning'} ms-1">${n.status || 'Unknown'}</span></span>
+        </label>`;
+    })
+    .join('');
+  const notRunning = candidates.filter((n) => n.status !== 'Running').length;
+  statusEl.textContent = notRunning > 0 ? `${notRunning} node(s) not in Running state cannot be assigned.` : '';
+}
+
+export async function executeEditNlbNodes() {
+  if (!_editTarget) return;
+  const { id, infraId } = _editTarget;
+  const toAdd = Array.from(document.querySelectorAll('.nlb-edit-assign-check:checked')).map((el) => el.value);
+  const toRemove = Array.from(document.querySelectorAll('.nlb-edit-unassign-check:checked')).map((el) => el.value);
+  if (toAdd.length === 0 && toRemove.length === 0) {
+    showToast(TOAST_TYPES.WARNING, 'Select nodes to assign or unassign.');
+    return;
+  }
+
+  const spinner = document.getElementById('nlb-edit-spinner');
+  const btn = document.getElementById('nlb-edit-execute-btn');
+  spinner.classList.remove('d-none');
+  btn.disabled = true;
+
+  // CSP 측 동시 변경 오류를 피하려고 add → remove 순차 호출. 하나가 실패해도 다른 하나는 시도한다.
+  const failures = [];
+  let added = 0;
+  let removed = 0;
+  if (toAdd.length > 0) {
+    try {
+      await nlbApi().addNLBNodes(AppState.ns, infraId, id, toAdd);
+      added = toAdd.length;
+    } catch (err) {
+      console.error('NLB 노드 Assign 실패:', err);
+      failures.push(`assign: ${_errMsg(err)}`);
+    }
+  }
+  if (toRemove.length > 0) {
+    try {
+      await nlbApi().removeNLBNodes(AppState.ns, infraId, id, toRemove);
+      removed = toRemove.length;
+    } catch (err) {
+      console.error('NLB 노드 UnAssign 실패:', err);
+      failures.push(`unassign: ${_errMsg(err)}`);
+    }
+  }
+
+  spinner.classList.add('d-none');
+  btn.disabled = false;
+
+  if (failures.length === 0) {
+    showToast(TOAST_TYPES.SUCCESS, `Assigned ${added}, unassigned ${removed} node(s) for "${id}"`);
+    bootstrap.Modal.getInstance(document.getElementById('nlb-edit-modal'))?.hide();
+  } else {
+    showToast(
+      added + removed > 0 ? TOAST_TYPES.WARNING : TOAST_TYPES.ERROR,
+      `Edit NLB "${id}" — ${failures.join('; ')}`
+    );
+    if (added + removed > 0) bootstrap.Modal.getInstance(document.getElementById('nlb-edit-modal'))?.hide();
+  }
+  AppState.tables.nlbTable?.deselectRow();
+  await _reloadAndRefreshDetail(id);
+}
+
+function _errMsg(err) {
+  return err?.response?.data?.responseData?.message || err?.response?.data?.message || err?.message || 'unknown error';
+}
+
+// 편집 후 목록 재조회 + 열려 있는 Detail이 대상 NLB면 갱신
+async function _reloadAndRefreshDetail(targetId) {
+  await loadNlbInNsList();
+  const shown = AppState.resources.selected;
+  if (shown && nlbId(shown) === targetId) {
+    const fresh = AppState.resources.all.find((it) => nlbId(it) === targetId && it._infraId === shown._infraId);
+    if (fresh) {
+      AppState.resources.selected = fresh;
+      renderDetail(fresh);
+    }
+  }
 }
 
 // ─── Filter ───────────────────────────────────────────────────────────────
@@ -455,7 +670,6 @@ async function _loadCreateInfraOptions() {
 document.getElementById('create-nlb-infra')?.addEventListener('change', function () {
   _loadNodeGroupOptions(this.value);
 });
-
 document.getElementById('create-nlb-nodegroup')?.addEventListener('change', _updateNodeGroupStatus);
 
 // nodeGroupId -> [{ id, status }] — NLB 생성 전 대상 노드가 실제로 Running인지 확인하기 위한 캐시.
@@ -581,7 +795,7 @@ export async function executeCreateNlb() {
     await nlbApi().postNLB(AppState.ns, infraId, body);
     showToast(TOAST_TYPES.SUCCESS, `NLB for "${subGroupId}" created successfully`);
     bootstrap.Modal.getInstance(document.getElementById('create-nlb-modal'))?.hide();
-    await loadNlbList();
+    await loadNlbInNsList();
   } catch (err) {
     console.error('NLB 생성 실패:', err);
     showToast(TOAST_TYPES.ERROR, 'Failed to create NLB: ' + (err.message || ''));
@@ -594,11 +808,14 @@ export async function executeCreateNlb() {
 // ─── webconsolejs 등록 ────────────────────────────────────────────────────
 if (typeof webconsolejs === 'undefined') { window.webconsolejs = {}; }
 webconsolejs['pages/settings/environment/cloudresources/nlbs'] = {
+  loadNlbInNsList,
   loadNlbList,
   hideDetail,
   checkSelectedNlbHealth,
   confirmBulkDelete,
   executeBulkDelete,
+  triggerEditSelected,
+  executeEditNlbNodes,
   openCreateNlbModal,
   executeCreateNlb,
 };

--- a/front/assets/js/pages/settings/environment/cloudresources/nlbs.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/nlbs.js
@@ -293,6 +293,10 @@ function renderDetail(data) {
 function renderTruncatableCopyable(targetId, fullText) {
   const target = document.getElementById(targetId);
   if (!target) return;
+  // 이전 렌더의 툴팁 인스턴스가 body에 남지 않도록 정리
+  if (window.bootstrap?.Tooltip) {
+    target.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((el) => bootstrap.Tooltip.getInstance(el)?.dispose());
+  }
   target.innerHTML = '';
 
   if (!fullText || fullText === '-') {
@@ -307,11 +311,19 @@ function renderTruncatableCopyable(targetId, fullText) {
 
   const span = document.createElement('span');
   span.textContent = fullText;
-  span.title = fullText;
   span.style.maxWidth = '240px';
   span.style.overflow = 'hidden';
   span.style.textOverflow = 'ellipsis';
   span.style.whiteSpace = 'nowrap';
+  span.style.cursor = 'default';
+  // 잘린 값은 hover 시 Bootstrap 툴팁으로 전체 텍스트를 즉시 보여준다
+  // (브라우저 기본 title 툴팁은 지연·미표시 환경이 있어 대체). 값이 짧아 안 잘리면 툴팁 불필요.
+  span.setAttribute('data-bs-toggle', 'tooltip');
+  span.setAttribute('data-bs-placement', 'top');
+  span.setAttribute('title', fullText);
+  if (window.bootstrap?.Tooltip) {
+    new bootstrap.Tooltip(span, { container: 'body', trigger: 'hover focus', customClass: 'nlb-full-text-tooltip' });
+  }
 
   const copyBtn = document.createElement('a');
   copyBtn.href = '#';

--- a/front/assets/js/pages/settings/environment/cloudresources/nlbs.js
+++ b/front/assets/js/pages/settings/environment/cloudresources/nlbs.js
@@ -77,7 +77,12 @@ async function getInfraList() {
     return infras
       .map((infra) => {
         const id = infra.id || infra.name;
-        return id ? { id, label: formatInfraLabel(id, infra) } : null;
+        if (!id) return null;
+        const provider =
+          (infra.cluster || []).flatMap((c) => c.providerNames || [])[0] ||
+          (infra.node || [])[0]?.connectionConfig?.providerName ||
+          '';
+        return { id, label: formatInfraLabel(id, infra), provider: String(provider).toLowerCase() };
       })
       .filter(Boolean);
   } catch (err) {
@@ -649,6 +654,7 @@ export async function openCreateNlbModal() {
   document.getElementById('create-nlb-target-port').value = '80';
   document.getElementById('create-nlb-protocol').value = 'TCP';
   document.getElementById('create-nlb-description').value = '';
+  _resetHealthCheckerInputs();
   await _loadCreateInfraOptions();
   new bootstrap.Modal(document.getElementById('create-nlb-modal')).show();
 }
@@ -663,13 +669,103 @@ async function _loadCreateInfraOptions() {
     opt.textContent = infra.label;
     select.appendChild(opt);
   }
+  _createInfraCache = infras;
   if (infras.length === 1) select.value = infras[0].id;
-  await _loadNodeGroupOptions(select.value);
+  await Promise.all([_loadNodeGroupOptions(select.value), _applyHealthCheckerSupport(select.value)]);
 }
 
 document.getElementById('create-nlb-infra')?.addEventListener('change', function () {
   _loadNodeGroupOptions(this.value);
+  _applyHealthCheckerSupport(this.value);
 });
+
+// ─── Create NLB — HealthChecker 입력 (CSP별 커스텀 지원 여부는 GetNLBSupport로 결정) ──
+// tumblebug NLBHealthCheckerReq는 interval/timeout/threshold(int)만 받고 0이면 백엔드 기본값을 쓴다.
+// CSP에 따라 커스텀 값을 무시/거부하는 필드가 있어(예: AWS TCP NLB는 timeout 커스텀 불가)
+// GetNLBSupport 응답으로 해당 필드를 비활성화한다. 지원 정보 조회 실패는 생성 자체를 막지 않는다.
+
+const HC_FIELDS = [
+  { key: 'Interval', id: 'create-nlb-hc-interval', label: 'Interval' },
+  { key: 'Timeout', id: 'create-nlb-hc-timeout', label: 'Timeout' },
+  { key: 'Threshold', id: 'create-nlb-hc-threshold', label: 'Threshold' },
+];
+
+// Create 모달용 Infra 목록 캐시 [{ id, label, provider }] — provider→GetNLBSupport 매칭에 사용
+let _createInfraCache = [];
+// GetNLBSupport 응답의 supports 맵 캐시 (페이지 수명 동안 1회 조회)
+let _nlbSupportCache = null;
+
+async function _getNlbSupport() {
+  if (_nlbSupportCache) return _nlbSupportCache;
+  try {
+    const data = await nlbApi().getNLBSupport();
+    _nlbSupportCache = data?.supports || {};
+  } catch (err) {
+    console.warn('GetNLBSupport 조회 실패 — health checker 필드 전체 활성 유지:', err);
+    _nlbSupportCache = {};
+  }
+  return _nlbSupportCache;
+}
+
+function _resetHealthCheckerInputs() {
+  for (const f of HC_FIELDS) {
+    const el = document.getElementById(f.id);
+    if (!el) continue;
+    el.value = '0';
+    el.disabled = false;
+    el.title = '';
+  }
+  const note = document.getElementById('create-nlb-hc-support-note');
+  if (note) note.textContent = '';
+}
+
+async function _applyHealthCheckerSupport(infraId) {
+  const note = document.getElementById('create-nlb-hc-support-note');
+  const provider = (_createInfraCache.find((i) => i.id === infraId)?.provider || '').toLowerCase();
+  if (!provider) {
+    _resetHealthCheckerInputs();
+    return;
+  }
+  const supports = await _getNlbSupport();
+  const sup = supports[provider];
+  const unsupported = [];
+  for (const f of HC_FIELDS) {
+    const el = document.getElementById(f.id);
+    if (!el) continue;
+    const ok = sup ? sup[`customHealthChecker${f.key}`] !== false : true;
+    el.disabled = !ok;
+    if (!ok) {
+      el.value = '0';
+      el.title = `${f.label} is not configurable on ${provider.toUpperCase()}`;
+      unsupported.push(f.label);
+    } else {
+      el.title = '';
+    }
+  }
+  if (note) {
+    note.textContent = unsupported.length
+      ? `${unsupported.join(', ')} ${unsupported.length > 1 ? 'are' : 'is'} not configurable on ${provider.toUpperCase()} (provider default is used).`
+      : '';
+  }
+}
+
+// 입력값을 non-negative int로 읽는다. disabled 필드는 항상 0(=default). 잘못된 값이면 null.
+function _readHealthCheckerInputs() {
+  const out = {};
+  for (const f of HC_FIELDS) {
+    const el = document.getElementById(f.id);
+    if (!el || el.disabled) {
+      out[f.key.toLowerCase()] = 0;
+      continue;
+    }
+    const raw = String(el.value ?? '').trim();
+    const n = raw === '' ? 0 : Number(raw);
+    if (!Number.isInteger(n) || n < 0) return null;
+    out[f.key.toLowerCase()] = n;
+  }
+  return out;
+}
+
 document.getElementById('create-nlb-nodegroup')?.addEventListener('change', _updateNodeGroupStatus);
 
 // nodeGroupId -> [{ id, status }] — NLB 생성 전 대상 노드가 실제로 Running인지 확인하기 위한 캐시.
@@ -769,6 +865,12 @@ export async function executeCreateNlb() {
     return;
   }
 
+  const healthChecker = _readHealthCheckerInputs();
+  if (!healthChecker) {
+    showToast(TOAST_TYPES.WARNING, 'Health checker values must be non-negative integers (0 = provider default).');
+    return;
+  }
+
   const spinner = document.getElementById('create-nlb-spinner');
   const btn = document.getElementById('create-nlb-execute-btn');
   spinner.classList.remove('d-none');
@@ -783,11 +885,8 @@ export async function executeCreateNlb() {
     targetGroup: { protocol, port: String(targetPort), nodeGroupId: subGroupId },
     // model.NLBHealthCheckerReq는 interval/timeout/threshold만 받는 int 필드이며,
     // 0을 보내면 tumblebug가 자체 기본값을 적용한다("0 = use default").
-    healthChecker: {
-      interval: 0,
-      timeout: 0,
-      threshold: 0,
-    },
+    // CSP가 커스텀을 지원하지 않는 필드는 GetNLBSupport 기준으로 비활성화돼 0으로 전송된다.
+    healthChecker,
   };
   if (description) body.description = description;
 

--- a/front/assets/js/partials/operation/manage/mcinlb.js
+++ b/front/assets/js/partials/operation/manage/mcinlb.js
@@ -60,7 +60,7 @@ function initTable(items) {
   AppState.tables.nlbTable = new Tabulator('#mcinlb-list-table', {
     data: items,
     layout: 'fitColumns',
-    placeholder: 'No NLBs. Create one to get started.',
+    placeholder: 'No NLBs. Create one in Cloud Resources > NLBs.',
     pagination: 'local',
     paginationSize: 10,
     paginationSizeSelector: [10, 20, 50],
@@ -88,7 +88,17 @@ function initTable(items) {
         title: 'Target NodeGroup',
         field: 'targetGroup',
         widthGrow: 1,
-        formatter: (cell) => cell.getValue()?.subGroupId || '-',
+        formatter: (cell) => {
+          const tg = cell.getValue();
+          return tg?.nodeGroupId || tg?.subGroupId || '-';
+        },
+      },
+      {
+        title: 'Assigned Nodes',
+        field: 'targetGroup',
+        width: 130,
+        hozAlign: 'center',
+        formatter: (cell) => String(_assignedNodes({ targetGroup: cell.getValue() }).length),
       },
       {
         title: 'DNS Name',
@@ -134,7 +144,8 @@ function renderDetail(data) {
   document.getElementById('mcinlb-detail-nlb-listener').textContent =
     listener.protocol || listener.port ? `${listener.protocol || ''}:${listener.port || ''}` : '-';
   document.getElementById('mcinlb-detail-nlb-endpoint').textContent = listener.dnsName || listener.ip || '-';
-  document.getElementById('mcinlb-detail-nlb-nodegroup').textContent = target.subGroupId || '-';
+  document.getElementById('mcinlb-detail-nlb-nodegroup').textContent = target.nodeGroupId || target.subGroupId || '-';
+  document.getElementById('mcinlb-detail-nlb-nodes').textContent = _assignedNodes(data).join(', ') || '-';
   document.getElementById('mcinlb-detail-nlb-target-port').textContent = target.port || '-';
   document.getElementById('mcinlb-detail-nlb-healthchecker').textContent =
     hc.protocol || hc.port ? `${hc.protocol || ''}:${hc.port || ''} (interval ${hc.interval || '-'}, threshold ${hc.threshold || '-'})` : '-';
@@ -285,27 +296,20 @@ document.getElementById('mcinlb-filter-clear')?.addEventListener('click', functi
   if (AppState.tables.nlbTable) AppState.tables.nlbTable.clearFilter();
 });
 
-// ─── Create NLB 모달 (Infra는 이 탭의 window.currentMciId로 고정) ────────────
+// ─── Assign / UnAssign (기존 NLB에 노드 추가·해제 — 생성은 Cloud Resources > NLBs) ───
 
 // nodeGroupId -> [{ id, status }] — nlbs.js와 동일한 Running 상태 체크 캐시.
 let _nodeStatusByGroup = {};
 
-export async function openCreateMciNlbModal() {
-  const ns = window.currentNsId;
-  const infraId = window.currentMciId;
-  if (!ns || !infraId) {
-    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Validation', 'Please select an MCI first.');
-    return;
-  }
-  document.getElementById('mcinlb-create-nlb-listener-port').value = '80';
-  document.getElementById('mcinlb-create-nlb-target-port').value = '80';
-  document.getElementById('mcinlb-create-nlb-protocol').value = 'TCP';
-  document.getElementById('mcinlb-create-nlb-description').value = '';
-  await _loadNodeGroupOptions(infraId);
-  new bootstrap.Modal(document.getElementById('mcinlb-create-nlb-modal')).show();
+// 배포 백엔드 버전에 따라 targetGroup 노드 목록 필드가 nodes/vms로 다를 수 있어 폴백으로 읽는다.
+function _assignedNodes(item) {
+  const tg = item?.targetGroup || {};
+  return tg.nodes || tg.vms || [];
 }
 
-document.getElementById('mcinlb-create-nlb-nodegroup')?.addEventListener('change', _updateNodeGroupStatus);
+function _findNlbById(id) {
+  return AppState.resources.all.find((item) => nlbId(item) === id);
+}
 
 async function getNodeStatusesByGroup(ns, infraId) {
   try {
@@ -326,104 +330,197 @@ async function getNodeStatusesByGroup(ns, infraId) {
   }
 }
 
-function _updateNodeGroupStatus() {
-  const nodeGroupId = document.getElementById('mcinlb-create-nlb-nodegroup').value;
-  const statusEl = document.getElementById('mcinlb-create-nlb-nodegroup-status');
-  const btn = document.getElementById('mcinlb-create-nlb-execute-btn');
-  const nodes = nodeGroupId ? _nodeStatusByGroup[nodeGroupId] || [] : [];
+// ─── Assign 모달 ─────────────────────────────────────────────────────────
 
-  if (nodes.length === 0) {
-    statusEl.textContent = '';
-    statusEl.className = 'form-text';
-    if (btn) btn.disabled = false;
-    return;
-  }
-
-  const notRunning = nodes.filter((n) => n.status !== 'Running');
-  if (notRunning.length === 0) {
-    statusEl.textContent = `Node status: Running (${nodes.length}/${nodes.length})`;
-    statusEl.className = 'form-text text-success';
-    if (btn) btn.disabled = false;
-  } else {
-    statusEl.textContent =
-      `Node status: ${notRunning.map((n) => `${n.id}=${n.status}`).join(', ')} — ` +
-      'all nodes must be Running to create an NLB.';
-    statusEl.className = 'form-text text-danger';
-    if (btn) btn.disabled = true;
-  }
-}
-
-async function _loadNodeGroupOptions(infraId) {
-  const select = document.getElementById('mcinlb-create-nlb-nodegroup');
-  select.innerHTML = '<option value="">Select</option>';
-  _nodeStatusByGroup = {};
-  _updateNodeGroupStatus();
-  if (!infraId) return;
-  try {
-    const data = await nlbApi().getInfraNodeGroupIds(window.currentNsId, infraId);
-    const ids = data?.output || data?.subGroup || (Array.isArray(data) ? data : []);
-    for (const id of ids) {
-      const opt = document.createElement('option');
-      opt.value = typeof id === 'string' ? id : id?.id;
-      opt.textContent = opt.value;
-      select.appendChild(opt);
-    }
-  } catch (err) {
-    console.error('NodeGroup 목록 조회 실패:', err);
-  }
-  _nodeStatusByGroup = await getNodeStatusesByGroup(window.currentNsId, infraId);
-  _updateNodeGroupStatus();
-}
-
-export async function executeCreateMciNlb() {
+export async function openAssignNlbModal() {
   const ns = window.currentNsId;
   const infraId = window.currentMciId;
-  const subGroupId = document.getElementById('mcinlb-create-nlb-nodegroup').value;
-  const listenerPort = document.getElementById('mcinlb-create-nlb-listener-port').value.trim();
-  const targetPort = document.getElementById('mcinlb-create-nlb-target-port').value.trim();
-  const protocol = document.getElementById('mcinlb-create-nlb-protocol').value;
-  const description = document.getElementById('mcinlb-create-nlb-description').value.trim();
-
-  if (!infraId || !subGroupId || !listenerPort || !targetPort) {
-    showToast(TOAST_TYPES.WARNING, 'Target NodeGroup, listener port, and target port are required.');
+  if (!ns || !infraId) {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Validation', 'Please select an Infra first.');
     return;
   }
-
-  const notRunning = (_nodeStatusByGroup[subGroupId] || []).filter((n) => n.status !== 'Running');
-  if (notRunning.length > 0) {
-    showToast(
-      TOAST_TYPES.WARNING,
-      `Target NodeGroup has node(s) not in Running state (${notRunning.map((n) => `${n.id}=${n.status}`).join(', ')}). Start them before creating an NLB.`
+  if (AppState.resources.all.length === 0) {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal(
+      'No NLB',
+      'No NLB exists in this Infra. Create one in Cloud Resources > NLBs first.'
     );
     return;
   }
 
-  const spinner = document.getElementById('mcinlb-create-nlb-spinner');
-  const btn = document.getElementById('mcinlb-create-nlb-execute-btn');
+  const select = document.getElementById('mcinlb-assign-nlb-select');
+  select.innerHTML = '';
+  for (const item of AppState.resources.all) {
+    const opt = document.createElement('option');
+    opt.value = nlbId(item);
+    opt.textContent = nlbId(item);
+    select.appendChild(opt);
+  }
+  const selected = AppState.tables.nlbTable ? AppState.tables.nlbTable.getSelectedData() : [];
+  if (selected.length === 1) select.value = nlbId(selected[0]);
+
+  const listEl = document.getElementById('mcinlb-assign-node-list');
+  listEl.innerHTML = '<div class="text-secondary">Loading nodes...</div>';
+  new bootstrap.Modal(document.getElementById('mcinlb-assign-modal')).show();
+
+  _nodeStatusByGroup = await getNodeStatusesByGroup(ns, infraId);
+  _renderAssignNodeCandidates();
+}
+
+document.getElementById('mcinlb-assign-nlb-select')?.addEventListener('change', _renderAssignNodeCandidates);
+
+// Infra 전체 노드 중 선택된 NLB에 아직 할당되지 않은 노드만 후보로 렌더링.
+// 백엔드 Add는 중복 검증 없이 append하므로 기할당 노드 제외는 프론트가 책임진다.
+function _renderAssignNodeCandidates() {
+  const listEl = document.getElementById('mcinlb-assign-node-list');
+  const statusEl = document.getElementById('mcinlb-assign-node-status');
+  if (!listEl) return;
+  const selectedNlb = _findNlbById(document.getElementById('mcinlb-assign-nlb-select').value);
+  const assigned = new Set(_assignedNodes(selectedNlb));
+
+  const rows = [];
+  for (const [groupId, nodes] of Object.entries(_nodeStatusByGroup)) {
+    for (const n of nodes) {
+      if (assigned.has(n.id)) continue;
+      rows.push({ ...n, groupId });
+    }
+  }
+
+  if (rows.length === 0) {
+    listEl.innerHTML = '<div class="text-secondary">No assignable nodes. All nodes of this Infra are already assigned to the selected NLB.</div>';
+    if (statusEl) statusEl.textContent = '';
+    return;
+  }
+
+  listEl.innerHTML = rows
+    .map((n) => {
+      const running = n.status === 'Running';
+      const badge = running ? 'bg-success' : 'bg-warning';
+      return `
+        <label class="form-check mb-1">
+          <input class="form-check-input mcinlb-assign-node-check" type="checkbox" value="${n.id}" ${running ? '' : 'disabled'}>
+          <span class="form-check-label">${n.id} <span class="text-secondary">(${n.groupId})</span>
+            <span class="badge ${badge} ms-1">${n.status || 'Unknown'}</span></span>
+        </label>`;
+    })
+    .join('');
+  const notRunning = rows.filter((n) => n.status !== 'Running').length;
+  if (statusEl) {
+    statusEl.textContent = notRunning > 0 ? `${notRunning} node(s) not in Running state cannot be assigned.` : '';
+  }
+}
+
+export async function executeAssignNlbNodes() {
+  const ns = window.currentNsId;
+  const infraId = window.currentMciId;
+  const targetNlbId = document.getElementById('mcinlb-assign-nlb-select').value;
+  const nodes = Array.from(document.querySelectorAll('.mcinlb-assign-node-check:checked')).map((el) => el.value);
+  if (!targetNlbId || nodes.length === 0) {
+    showToast(TOAST_TYPES.WARNING, 'Select an NLB and at least one node to assign.');
+    return;
+  }
+
+  const spinner = document.getElementById('mcinlb-assign-spinner');
+  const btn = document.getElementById('mcinlb-assign-execute-btn');
   spinner.classList.remove('d-none');
   btn.disabled = true;
-
-  const body = {
-    type: 'PUBLIC',
-    scope: 'REGION',
-    listener: { protocol, port: String(listenerPort) },
-    targetGroup: { protocol, port: String(targetPort), nodeGroupId: subGroupId },
-    healthChecker: { interval: 0, timeout: 0, threshold: 0 },
-  };
-  if (description) body.description = description;
-
   try {
-    await nlbApi().postNLB(ns, infraId, body);
-    showToast(TOAST_TYPES.SUCCESS, `NLB for "${subGroupId}" created successfully`);
-    bootstrap.Modal.getInstance(document.getElementById('mcinlb-create-nlb-modal'))?.hide();
-    await loadMciNlbList(true);
+    await nlbApi().addNLBNodes(ns, infraId, targetNlbId, nodes);
+    showToast(TOAST_TYPES.SUCCESS, `${nodes.length} node(s) assigned to "${targetNlbId}"`);
+    bootstrap.Modal.getInstance(document.getElementById('mcinlb-assign-modal'))?.hide();
+    await _reloadAndRefreshDetail(targetNlbId);
   } catch (err) {
-    console.error('MCI NLB 생성 실패:', err);
+    console.error('NLB 노드 Assign 실패:', err);
     const msg = err?.response?.data?.responseData?.message || err?.message || '';
-    showToast(TOAST_TYPES.ERROR, 'Failed to create NLB: ' + msg);
+    showToast(TOAST_TYPES.ERROR, 'Failed to assign nodes: ' + msg);
   } finally {
     spinner.classList.add('d-none');
     btn.disabled = false;
+  }
+}
+
+// ─── UnAssign 모달 ───────────────────────────────────────────────────────
+
+export async function openUnassignNlbModal() {
+  const table = AppState.tables.nlbTable;
+  const selected = table ? table.getSelectedData() : [];
+  if (selected.length !== 1) {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal(
+      'Select One NLB',
+      'Please select exactly one NLB to unassign nodes from.'
+    );
+    return;
+  }
+  const item = selected[0];
+  const id = nlbId(item);
+  document.getElementById('mcinlb-unassign-nlb-name').textContent = id;
+
+  const listEl = document.getElementById('mcinlb-unassign-node-list');
+  listEl.innerHTML = '<div class="text-secondary">Loading assigned nodes...</div>';
+  new bootstrap.Modal(document.getElementById('mcinlb-unassign-modal')).show();
+
+  // 목록 캐시가 오래됐을 수 있어 상세를 새로 조회해 할당 노드를 확정한다.
+  let nodes = _assignedNodes(item);
+  try {
+    const detail = await nlbApi().getNLB(window.currentNsId, window.currentMciId, id);
+    if (detail) nodes = _assignedNodes(detail);
+  } catch (err) {
+    console.error('NLB 상세 조회 실패:', err);
+  }
+
+  if (nodes.length === 0) {
+    listEl.innerHTML = '<div class="text-secondary">No nodes are assigned to this NLB.</div>';
+    return;
+  }
+  listEl.innerHTML = nodes
+    .map(
+      (n) => `
+        <label class="form-check mb-1">
+          <input class="form-check-input mcinlb-unassign-node-check" type="checkbox" value="${n}">
+          <span class="form-check-label">${n}</span>
+        </label>`
+    )
+    .join('');
+}
+
+export async function executeUnassignNlbNodes() {
+  const ns = window.currentNsId;
+  const infraId = window.currentMciId;
+  const targetNlbId = document.getElementById('mcinlb-unassign-nlb-name').textContent;
+  const nodes = Array.from(document.querySelectorAll('.mcinlb-unassign-node-check:checked')).map((el) => el.value);
+  if (!targetNlbId || nodes.length === 0) {
+    showToast(TOAST_TYPES.WARNING, 'Select at least one node to unassign.');
+    return;
+  }
+
+  const spinner = document.getElementById('mcinlb-unassign-spinner');
+  const btn = document.getElementById('mcinlb-unassign-execute-btn');
+  spinner.classList.remove('d-none');
+  btn.disabled = true;
+  try {
+    await nlbApi().removeNLBNodes(ns, infraId, targetNlbId, nodes);
+    showToast(TOAST_TYPES.SUCCESS, `${nodes.length} node(s) unassigned from "${targetNlbId}"`);
+    bootstrap.Modal.getInstance(document.getElementById('mcinlb-unassign-modal'))?.hide();
+    await _reloadAndRefreshDetail(targetNlbId);
+  } catch (err) {
+    console.error('NLB 노드 UnAssign 실패:', err);
+    const msg = err?.response?.data?.responseData?.message || err?.message || '';
+    showToast(TOAST_TYPES.ERROR, 'Failed to unassign nodes: ' + msg);
+  } finally {
+    spinner.classList.add('d-none');
+    btn.disabled = false;
+  }
+}
+
+// Assign/UnAssign 후 목록 재조회 + 열려 있는 Detail이 대상 NLB면 갱신
+async function _reloadAndRefreshDetail(targetNlbId) {
+  await loadMciNlbList(true);
+  const shown = AppState.resources.selected;
+  if (shown && nlbId(shown) === targetNlbId) {
+    const fresh = _findNlbById(targetNlbId);
+    if (fresh) {
+      AppState.resources.selected = fresh;
+      renderDetail(fresh);
+    }
   }
 }
 
@@ -436,6 +533,8 @@ webconsolejs['partials/operation/manage/mcinlb'] = {
   checkSelectedMciNlbHealth,
   confirmMciNlbBulkDelete,
   executeMciNlbBulkDelete,
-  openCreateMciNlbModal,
-  executeCreateMciNlb,
+  openAssignNlbModal,
+  executeAssignNlbNodes,
+  openUnassignNlbModal,
+  executeUnassignNlbNodes,
 };

--- a/front/assets/js/partials/operation/manage/mcinlb.js
+++ b/front/assets/js/partials/operation/manage/mcinlb.js
@@ -19,18 +19,23 @@ function nlbId(data) {
 
 // ─── NLB 목록 로드 ────────────────────────────────────────────────────────
 
+// force=false는 "탭을 열 때"의 호출이다. 예전엔 같은 Infra면 재조회를 건너뛰었지만, 다른 화면
+// (Cloud Resources > NLBs의 Edit 등)에서 노드 할당이 바뀐 뒤 이 탭이 옛 목록을 계속 보여주는
+// 문제가 있어 탭을 열 때마다 재조회한다. 목록 1회 호출이라 비용은 미미하다.
 export async function loadMciNlbList(force) {
   const infraId = window.currentMciId;
   const ns = window.currentNsId;
   if (!infraId || !ns) return;
-  if (!force && AppState.loadedForMciId === infraId) return; // 이미 이 MCI로 로드됨 — 재조회 skip
 
   try {
     const data = await nlbApi().getAllNLB(ns, infraId);
+    // 배포 백엔드(cb-tumblebug NLBInfo)는 Type/Scope에 json 태그가 없어 대문자 키로 내려온다 — 정규화 필드로 흡수
     const items = (data?.nlb || (Array.isArray(data) ? data : [])).map((v) => ({
       ...v,
       _provider: getProvider(v),
       _region: getRegion(v),
+      _type: v.type ?? v.Type ?? '-',
+      _scope: v.scope ?? v.Scope ?? '-',
     }));
     AppState.resources.all = items;
     AppState.loadedForMciId = infraId;
@@ -73,8 +78,8 @@ function initTable(items) {
       { title: 'Id', field: 'id', widthGrow: 2, sorter: 'string' },
       { title: 'Provider', field: '_provider', widthGrow: 1, sorter: 'string' },
       { title: 'Region', field: '_region', widthGrow: 1, sorter: 'string' },
-      { title: 'Type', field: 'type', width: 100 },
-      { title: 'Scope', field: 'scope', width: 100 },
+      { title: 'Type', field: '_type', width: 100 },
+      { title: 'Scope', field: '_scope', width: 100 },
       {
         title: 'Listener',
         field: 'listener',
@@ -139,8 +144,8 @@ function renderDetail(data) {
   document.getElementById('mcinlb-detail-nlb-id').textContent = nlbId(data) || '-';
   document.getElementById('mcinlb-detail-nlb-provider').textContent = getProvider(data);
   document.getElementById('mcinlb-detail-nlb-region').textContent = getRegion(data);
-  document.getElementById('mcinlb-detail-nlb-type').textContent = data.type || '-';
-  document.getElementById('mcinlb-detail-nlb-scope').textContent = data.scope || '-';
+  document.getElementById('mcinlb-detail-nlb-type').textContent = data.type ?? data.Type ?? '-';
+  document.getElementById('mcinlb-detail-nlb-scope').textContent = data.scope ?? data.Scope ?? '-';
   document.getElementById('mcinlb-detail-nlb-listener').textContent =
     listener.protocol || listener.port ? `${listener.protocol || ''}:${listener.port || ''}` : '-';
   document.getElementById('mcinlb-detail-nlb-endpoint').textContent = listener.dnsName || listener.ip || '-';

--- a/front/assets/js/partials/operation/manage/mcinlb.js
+++ b/front/assets/js/partials/operation/manage/mcinlb.js
@@ -148,15 +148,75 @@ function renderDetail(data) {
   document.getElementById('mcinlb-detail-nlb-scope').textContent = data.scope ?? data.Scope ?? '-';
   document.getElementById('mcinlb-detail-nlb-listener').textContent =
     listener.protocol || listener.port ? `${listener.protocol || ''}:${listener.port || ''}` : '-';
-  document.getElementById('mcinlb-detail-nlb-endpoint').textContent = listener.dnsName || listener.ip || '-';
+  renderTruncatableCopyable('mcinlb-detail-nlb-endpoint', listener.dnsName || listener.ip || '-');
   document.getElementById('mcinlb-detail-nlb-nodegroup').textContent = target.nodeGroupId || target.subGroupId || '-';
   document.getElementById('mcinlb-detail-nlb-nodes').textContent = _assignedNodes(data).join(', ') || '-';
   document.getElementById('mcinlb-detail-nlb-target-port').textContent = target.port || '-';
   document.getElementById('mcinlb-detail-nlb-healthchecker').textContent =
     hc.protocol || hc.port ? `${hc.protocol || ''}:${hc.port || ''} (interval ${hc.interval || '-'}, threshold ${hc.threshold || '-'})` : '-';
-  document.getElementById('mcinlb-detail-nlb-csp-id').textContent = data.cspResourceId || '-';
+  renderTruncatableCopyable('mcinlb-detail-nlb-csp-id', data.cspResourceId || '-');
   document.getElementById('mcinlb-detail-nlb-description').textContent = data.description || '-';
   document.getElementById('mcinlb-detail-nlb-health').textContent = '-';
+}
+
+// 길어서 "..."으로 잘리는 값(Listener IP/DNS, CSP Resource ID)을 hover 툴팁(전체 텍스트) +
+// 클립보드 복사 버튼과 함께 렌더링한다. nlbs.js의 renderTruncatableCopyable과 동일 구현
+// (페이지 간 공통 모듈화는 회귀 위험으로 보류 — 세 번째 소비처 생기면 재검토).
+function renderTruncatableCopyable(targetId, fullText) {
+  const target = document.getElementById(targetId);
+  if (!target) return;
+  // 이전 렌더의 툴팁 인스턴스가 body에 남지 않도록 정리
+  if (window.bootstrap?.Tooltip) {
+    target.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((el) => bootstrap.Tooltip.getInstance(el)?.dispose());
+  }
+  target.innerHTML = '';
+
+  if (!fullText || fullText === '-') {
+    target.textContent = '-';
+    return;
+  }
+
+  target.style.display = 'inline-flex';
+  target.style.alignItems = 'center';
+  target.style.gap = '4px';
+  target.style.maxWidth = '100%';
+
+  const span = document.createElement('span');
+  span.textContent = fullText;
+  span.style.maxWidth = '240px';
+  span.style.overflow = 'hidden';
+  span.style.textOverflow = 'ellipsis';
+  span.style.whiteSpace = 'nowrap';
+  span.style.cursor = 'default';
+  // 잘린 값은 hover 시 Bootstrap 툴팁으로 전체 텍스트를 즉시 보여준다
+  span.setAttribute('data-bs-toggle', 'tooltip');
+  span.setAttribute('data-bs-placement', 'top');
+  span.setAttribute('title', fullText);
+  if (window.bootstrap?.Tooltip) {
+    new bootstrap.Tooltip(span, { container: 'body', trigger: 'hover focus', customClass: 'nlb-full-text-tooltip' });
+  }
+
+  const copyBtn = document.createElement('a');
+  copyBtn.href = '#';
+  copyBtn.className = 'copy-icon-btn flex-shrink-0';
+  copyBtn.title = 'Copy to clipboard';
+  copyBtn.innerHTML =
+    '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-sm" width="16" height="16" viewBox="0 0 24 24" ' +
+    'stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">' +
+    '<path stroke="none" d="M0 0h24v24H0z" fill="none"/>' +
+    '<path d="M8 8m0 2a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v8a2 2 0 0 1 -2 2h-8a2 2 0 0 1 -2 -2z"/>' +
+    '<path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2"/>' +
+    '</svg>';
+  copyBtn.addEventListener('click', function (e) {
+    e.preventDefault();
+    navigator.clipboard
+      .writeText(fullText)
+      .then(() => showToast(TOAST_TYPES.SUCCESS, 'Copied to clipboard'))
+      .catch(() => showToast(TOAST_TYPES.ERROR, 'Failed to copy'));
+  });
+
+  target.appendChild(span);
+  target.appendChild(copyBtn);
 }
 
 function showDetail() {

--- a/front/templates/pages/settings/environment/cloudresources/nlbs.html
+++ b/front/templates/pages/settings/environment/cloudresources/nlbs.html
@@ -15,6 +15,17 @@
                   <path d="M3 12h4l3 8l4 -16l3 8h4"/>
                 </svg>
               </a>
+              <!-- Edit selected (assign / unassign nodes) -->
+              <a class="btn-action" type="button" title="Edit selected (assign / unassign nodes)"
+                onclick="webconsolejs['pages/settings/environment/cloudresources/nlbs'].triggerEditSelected()">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                  stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                  <path d="M7 7h-1a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-1"/>
+                  <path d="M20.385 6.585a2.1 2.1 0 0 0 -2.97 -2.97l-8.415 8.385v3h3l8.385 -8.415z"/>
+                  <path d="M16 5l3 3"/>
+                </svg>
+              </a>
               <!-- Delete selected -->
               <a class="btn-action" type="button" title="Delete selected"
                 onclick="webconsolejs['pages/settings/environment/cloudresources/nlbs'].confirmBulkDelete()">
@@ -63,8 +74,8 @@
                     <option value="">-- select --</option>
                     <option value="id">Id</option>
                     <option value="_infraId">Infra</option>
-                    <option value="type">Type</option>
-                    <option value="scope">Scope</option>
+                    <option value="_type">Type</option>
+                    <option value="_scope">Scope</option>
                   </select>
                 </div>
                 <div class="col-auto">
@@ -150,6 +161,10 @@
                   <div class="datagrid-content" id="detail-nlb-nodegroup">-</div>
                 </div>
                 <div class="datagrid-item">
+                  <div class="datagrid-title">Assigned Nodes</div>
+                  <div class="datagrid-content" id="detail-nlb-nodes">-</div>
+                </div>
+                <div class="datagrid-item">
                   <div class="datagrid-title">Target Port</div>
                   <div class="datagrid-content" id="detail-nlb-target-port">-</div>
                 </div>
@@ -176,6 +191,42 @@
       </div>
     </div>
 
+  </div>
+</div>
+
+<!-- Edit NLB 모달 — 타겟 노드 Assign/UnAssign (Listener/HealthChecker는 생성 후 변경 불가) -->
+<div class="modal modal-blur fade" id="nlb-edit-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Edit NLB — <span id="nlb-edit-nlb-name" class="text-primary"></span></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="alert alert-info mb-3">
+          Add or remove target nodes of this NLB. Listener and health checker cannot be changed after creation.
+        </div>
+        <div class="row">
+          <div class="col-6">
+            <label class="form-label">Assigned Nodes <span class="text-secondary">(check to unassign)</span></label>
+            <div id="nlb-edit-assigned-list" class="border rounded p-2" style="max-height: 260px; overflow-y: auto;"></div>
+            <div class="form-text">Removing all nodes may be rejected by some CSPs.</div>
+          </div>
+          <div class="col-6">
+            <label class="form-label">Available Nodes <span class="text-secondary">(check to assign)</span></label>
+            <div id="nlb-edit-candidate-list" class="border rounded p-2" style="max-height: 260px; overflow-y: auto;"></div>
+            <div class="form-text text-warning" id="nlb-edit-node-status"></div>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="nlb-edit-execute-btn"
+          onclick="webconsolejs['pages/settings/environment/cloudresources/nlbs'].executeEditNlbNodes()">
+          <span id="nlb-edit-spinner" class="spinner-border spinner-border-sm d-none me-1" role="status"></span>Save
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/front/templates/pages/settings/environment/cloudresources/nlbs.html
+++ b/front/templates/pages/settings/environment/cloudresources/nlbs.html
@@ -274,6 +274,25 @@
             <input type="text" class="form-control" value="PUBLIC / REGION" readonly>
           </div>
         </div>
+        <!-- Health Checker: 0 = provider default. CSP별 커스텀 미지원 필드는 GetNLBSupport 기준으로 비활성화 -->
+        <div class="mb-3">
+          <label class="form-label">Health Checker <span class="text-secondary">(0 = provider default)</span></label>
+          <div class="row g-2">
+            <div class="col-4">
+              <label class="form-label mb-1 small">Interval (sec)</label>
+              <input type="number" class="form-control" id="create-nlb-hc-interval" min="0" step="1" value="0">
+            </div>
+            <div class="col-4">
+              <label class="form-label mb-1 small">Timeout (sec)</label>
+              <input type="number" class="form-control" id="create-nlb-hc-timeout" min="0" step="1" value="0">
+            </div>
+            <div class="col-4">
+              <label class="form-label mb-1 small">Threshold</label>
+              <input type="number" class="form-control" id="create-nlb-hc-threshold" min="0" step="1" value="0">
+            </div>
+          </div>
+          <div class="form-text text-warning" id="create-nlb-hc-support-note"></div>
+        </div>
         <div class="mb-2">
           <label class="form-label">Description</label>
           <input type="text" class="form-control" id="create-nlb-description" placeholder="optional">

--- a/front/templates/partials/operation/manage/_mcinlb.html
+++ b/front/templates/partials/operation/manage/_mcinlb.html
@@ -4,13 +4,22 @@
       <div class="card-header">
         <h3 class="card-title">NLB</h3>
         <div class="card-options ms-auto d-flex gap-2">
-          <!-- Create NLB -->
-          <a class="btn-action" type="button" title="Create NLB"
-            onclick="webconsolejs['partials/operation/manage/mcinlb'].openCreateMciNlbModal()">
+          <!-- Assign nodes to NLB -->
+          <a class="btn-action" type="button" title="Assign nodes to NLB"
+            onclick="webconsolejs['partials/operation/manage/mcinlb'].openAssignNlbModal()">
             <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
               stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
               <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
               <path d="M12 5l0 14"/><path d="M5 12l14 0"/>
+            </svg>
+          </a>
+          <!-- Unassign nodes from selected NLB -->
+          <a class="btn-action" type="button" title="Unassign nodes from selected NLB"
+            onclick="webconsolejs['partials/operation/manage/mcinlb'].openUnassignNlbModal()">
+            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+              stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+              <path d="M5 12l14 0"/>
             </svg>
           </a>
           <!-- Check Health (selected) -->
@@ -152,6 +161,10 @@
               <div class="datagrid-content" id="mcinlb-detail-nlb-nodegroup">-</div>
             </div>
             <div class="datagrid-item">
+              <div class="datagrid-title">Assigned Nodes</div>
+              <div class="datagrid-content" id="mcinlb-detail-nlb-nodes">-</div>
+            </div>
+            <div class="datagrid-item">
               <div class="datagrid-title">Target Port</div>
               <div class="datagrid-content" id="mcinlb-detail-nlb-target-port">-</div>
             </div>
@@ -178,56 +191,58 @@
   </div>
 </div>
 
-<!-- Create NLB 모달 (이 탭의 MCI로 Infra 고정) -->
-<div class="modal modal-blur fade" id="mcinlb-create-nlb-modal" tabindex="-1" role="dialog" aria-hidden="true">
+<!-- Assign 모달 — 기존 NLB에 노드 추가 (생성은 Cloud Resources > NLBs) -->
+<div class="modal modal-blur fade" id="mcinlb-assign-modal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Create NLB</h5>
+        <h5 class="modal-title">Assign Nodes to NLB</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
         <div class="alert alert-info mb-3">
-          NLB is created per target NodeGroup of this Infra. The NLB id follows the NodeGroup id.
+          Add nodes of this Infra to an existing NLB. To create a new NLB, use Cloud Resources &gt; NLBs.
         </div>
         <div class="mb-3">
-          <label class="form-label required">Target NodeGroup</label>
-          <select class="form-select" id="mcinlb-create-nlb-nodegroup"></select>
-          <div class="form-text" id="mcinlb-create-nlb-nodegroup-status"></div>
-        </div>
-        <div class="row">
-          <div class="col-6 mb-3">
-            <label class="form-label required">Listener Port</label>
-            <input type="number" class="form-control" id="mcinlb-create-nlb-listener-port" min="1" max="65535" value="80">
-          </div>
-          <div class="col-6 mb-3">
-            <label class="form-label required">Target Port</label>
-            <input type="number" class="form-control" id="mcinlb-create-nlb-target-port" min="1" max="65535" value="80">
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-6 mb-3">
-            <label class="form-label">Protocol</label>
-            <select class="form-select" id="mcinlb-create-nlb-protocol">
-              <option value="TCP" selected>TCP</option>
-              <option value="UDP">UDP</option>
-            </select>
-          </div>
-          <div class="col-6 mb-3">
-            <label class="form-label">Type / Scope</label>
-            <input type="text" class="form-control" value="PUBLIC / REGION" readonly>
-          </div>
+          <label class="form-label required">NLB</label>
+          <select class="form-select" id="mcinlb-assign-nlb-select"></select>
         </div>
         <div class="mb-2">
-          <label class="form-label">Description</label>
-          <input type="text" class="form-control" id="mcinlb-create-nlb-description" placeholder="optional">
+          <label class="form-label required">Nodes</label>
+          <div id="mcinlb-assign-node-list" class="border rounded p-2" style="max-height: 240px; overflow-y: auto;"></div>
+          <div class="form-text text-warning" id="mcinlb-assign-node-status"></div>
         </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary" id="mcinlb-create-nlb-execute-btn"
-          onclick="webconsolejs['partials/operation/manage/mcinlb'].executeCreateMciNlb()">
-          <span id="mcinlb-create-nlb-spinner" class="spinner-border spinner-border-sm d-none me-1" role="status"></span>Create
+        <button type="button" class="btn btn-primary" id="mcinlb-assign-execute-btn"
+          onclick="webconsolejs['partials/operation/manage/mcinlb'].executeAssignNlbNodes()">
+          <span id="mcinlb-assign-spinner" class="spinner-border spinner-border-sm d-none me-1" role="status"></span>Assign
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- UnAssign 모달 — 선택한 NLB에서 노드 해제 -->
+<div class="modal modal-blur fade" id="mcinlb-unassign-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Unassign Nodes — <span id="mcinlb-unassign-nlb-name" class="text-primary"></span></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-2">
+          <label class="form-label required">Assigned Nodes</label>
+          <div id="mcinlb-unassign-node-list" class="border rounded p-2" style="max-height: 240px; overflow-y: auto;"></div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger" id="mcinlb-unassign-execute-btn"
+          onclick="webconsolejs['partials/operation/manage/mcinlb'].executeUnassignNlbNodes()">
+          <span id="mcinlb-unassign-spinner" class="spinner-border spinner-border-sm d-none me-1" role="status"></span>Unassign
         </button>
       </div>
     </div>

--- a/front/templates/partials/operation/manage/_mcinlb.html
+++ b/front/templates/partials/operation/manage/_mcinlb.html
@@ -78,8 +78,8 @@
               <select id="mcinlb-filter-field" class="form-select form-select-sm">
                 <option value="">-- select --</option>
                 <option value="id">Id</option>
-                <option value="type">Type</option>
-                <option value="scope">Scope</option>
+                <option value="_type">Type</option>
+                <option value="_scope">Scope</option>
               </select>
             </div>
             <div class="col-auto">


### PR DESCRIPTION
## Summary

**Infra Info > NLB 탭 — Create를 노드 Assign/UnAssign으로 전환**
- 탭의 `+`(Create NLB)는 Cloud Resources > NLBs 화면의 Create와 완전 중복이라 제거하고, 생성 경로를 NLBs 화면으로 일원화
- 대신 **Assign**(기존 NLB에 이 Infra의 노드 추가)·**UnAssign**(할당 노드 해제) 버튼 신설 — 백엔드 `AddNLBVMs`/`RemoveNLBVMs`는 api.yaml에 기등록돼 있었으나 호출하는 UI가 없어 사장돼 있던 것을 활성화
- 기할당 노드는 Assign 후보에서 제외(백엔드 Add는 무검증 append), 비Running 노드는 비활성 표시
- 탭을 열 때마다 목록 재조회 — 같은 Infra면 재조회를 건너뛰던 캐시 때문에 다른 화면에서 바뀐 할당이 반영되지 않던 문제 수정

**Cloud Resources > NLBs 화면**
- 목록을 `GetAllNLBInNs`(namespace 전체, 항목에 infraId 포함 — cloud-barista/cb-tumblebug#2658로 요청해 업스트림 구현됨) **단일 호출로 전환** (`loadNlbInNsList()` 신설). 기존 Infra별 N+1 집계(`loadNlbList()`)는 폴백용으로 유지
- **Edit selected** 신설 — 정확히 1개 선택 후 모달에서 할당 노드 해제/미할당 노드 추가 (add→remove 순차 호출)
- **필드명 버그 수정**: 배포 백엔드(NLBInfo)가 `Type`/`Scope`를 대문자 키로, 타겟 그룹을 `nodeGroupId`/`nodes`로 내려주는데 소문자 `type/scope`·구계약 `subGroupId`를 읽어 **Type/Scope/Target NodeGroup 컬럼이 항상 '-'로 표시되던 문제**를 폴백 접근자(`_type/_scope`, `nodeGroupId||subGroupId`, `nodes||vms`)로 수정 (Infra 탭 동일 적용)
- 목록에 Assigned Nodes(count) 컬럼, Detail에 Assigned Nodes 뱃지 추가
- **Create 모달 Health Checker 입력** — interval/timeout/threshold(0 = provider default) 입력 신설(기존 0/0/0 하드코딩 대체). Infra 선택 시 `GetNLBSupport`로 CSP별 커스텀 미지원 필드를 비활성+안내(예: AWS timeout). 지원정보 조회 실패 시 전 필드 활성 폴백으로 생성을 차단하지 않음
- Detail의 Listener IP/DNS·CSP Resource ID 잘린 값에 hover 전체 텍스트 툴팁 + 복사 버튼 (Infra 탭 Detail에도 동일 적용)
