### PR TITLE
feat: Groups 화면에 Platform Role 배정 UI 추가

### DIFF
--- a/front/assets/js/common/api/services/groups_api.js
+++ b/front/assets/js/common/api/services/groups_api.js
@@ -125,3 +125,24 @@ export async function listUsers() {
     const response = await webconsolejs["common/api/http"].commonAPIPost(controller);
     return response.data.responseData || [];
 }
+
+// 그룹에 할당된 Platform Role 목록
+export async function getGroupPlatformRoles(groupId) {
+    const controller = "/api/mc-iam-manager/getGroupPlatformRoles";
+    const data = {
+        pathParams: { groupId: groupId.toString() }
+    };
+    const response = await webconsolejs["common/api/http"].commonAPIPost(controller, data);
+    return unwrapResponse(response) || [];
+}
+
+// 그룹에 Platform Role 할당 — 그룹 소속 사용자 전원이 상속받음
+export async function assignGroupPlatformRole(groupId, roleId) {
+    const controller = "/api/mc-iam-manager/assignGroupPlatformRole";
+    const data = {
+        pathParams: { groupId: groupId.toString() },
+        request: { role_id: parseInt(roleId, 10) }
+    };
+    const response = await webconsolejs["common/api/http"].commonAPIPost(controller, data);
+    return unwrapResponse(response);
+}

--- a/front/assets/js/pages/settings/accountnaccess/groups/groups.js
+++ b/front/assets/js/pages/settings/accountnaccess/groups/groups.js
@@ -74,7 +74,12 @@ const GroupManager = {
             UIManager.showGroupPlatformRoles([]);
             if (webconsolejs && webconsolejs['common/util'] && webconsolejs['common/util'].showToast) {
                 const d = error.response && error.response.data;
-                const msg = (d && (d.status && d.status.message)) || (d && d.message) || error.message || 'Platform role load failed.';
+                const rd = d && d.responseData;
+                const msg = (rd && (rd.error || rd.message))
+                    || (d && d.message)
+                    || (d && d.status && d.status.message)
+                    || error.message
+                    || 'Platform role load failed.';
                 webconsolejs['common/util'].showToast('Platform role query error: ' + msg, 'error');
             }
         }
@@ -92,7 +97,16 @@ const GroupManager = {
             console.error("Error assigning platform role:", error);
             const status = error.response && error.response.status;
             const d = error.response && error.response.data;
-            const msg = (d && (d.status && d.status.message)) || (d && d.error) || (d && d.message) || error.message || "Unknown error";
+            // BFF(proxy.go)는 status.message에 HTTP 상태문구("Internal Server Error")를 붙이고
+            // 백엔드 원본 에러는 responseData.error에 담는다. 일반 문구가 구체적 원인을
+            // 덮지 않도록 responseData.error를 먼저 본다.
+            const rd = d && d.responseData;
+            const msg = (rd && (rd.error || rd.message))
+                || (d && d.error)
+                || (d && d.message)
+                || (d && d.status && d.status.message)
+                || error.message
+                || "Unknown error";
             if (status === 409) {
                 alert("This role is already assigned to the group.");
             } else if (status === 404) {

--- a/front/assets/js/pages/settings/accountnaccess/groups/groups.js
+++ b/front/assets/js/pages/settings/accountnaccess/groups/groups.js
@@ -5,9 +5,12 @@ const AppState = {
     groups: {
         tree: [],
         list: [],
-        selectedGroup: null
+        selectedGroup: null,
+        platformRoles: [],
+        memberCount: 0
     },
     users: { all: [] },
+    roles: { all: [] },
     ui: {
         viewMode: false
     }
@@ -50,10 +53,53 @@ const GroupManager = {
     async loadGroupUsers(id) {
         try {
             const users = await webconsolejs["common/api/services/groups_api"].getGroupUsers(id);
+            AppState.groups.memberCount = (users || []).length;
             UIManager.showGroupUsers(users || []);
         } catch (error) {
             console.error("Error loading group users:", error);
+            AppState.groups.memberCount = 0;
             UIManager.showGroupUsers([]);
+        }
+        UIManager.updateInheritNotice();
+    },
+
+    async loadGroupPlatformRoles(id) {
+        try {
+            const roles = await webconsolejs["common/api/services/groups_api"].getGroupPlatformRoles(id);
+            AppState.groups.platformRoles = roles || [];
+            UIManager.showGroupPlatformRoles(AppState.groups.platformRoles);
+        } catch (error) {
+            console.error("Error loading group platform roles:", error);
+            AppState.groups.platformRoles = [];
+            UIManager.showGroupPlatformRoles([]);
+            if (webconsolejs && webconsolejs['common/util'] && webconsolejs['common/util'].showToast) {
+                const d = error.response && error.response.data;
+                const msg = (d && (d.status && d.status.message)) || (d && d.message) || error.message || 'Platform role load failed.';
+                webconsolejs['common/util'].showToast('Platform role query error: ' + msg, 'error');
+            }
+        }
+    },
+
+    async assignPlatformRole(groupId, roleId) {
+        try {
+            await webconsolejs["common/api/services/groups_api"].assignGroupPlatformRole(groupId, roleId);
+            const count = AppState.groups.memberCount;
+            alert(count > 0
+                ? `Platform role assigned. ${count} member(s) of this group now inherit this role.`
+                : "Platform role assigned. It will apply to any user added to this group.");
+            await GroupManager.loadGroupPlatformRoles(groupId);
+        } catch (error) {
+            console.error("Error assigning platform role:", error);
+            const status = error.response && error.response.status;
+            const d = error.response && error.response.data;
+            const msg = (d && (d.status && d.status.message)) || (d && d.error) || (d && d.message) || error.message || "Unknown error";
+            if (status === 409) {
+                alert("This role is already assigned to the group.");
+            } else if (status === 404) {
+                alert("Failed to assign platform role: group or role not found.");
+            } else {
+                alert("Failed to assign platform role: " + msg);
+            }
         }
     },
 
@@ -161,6 +207,7 @@ const UIManager = {
                     AppState.groups.selectedGroup = nodeData.data;
                     UIManager.showDetailPanel(nodeData.data);
                     GroupManager.loadGroupUsers(nodeData.data.id);
+                    GroupManager.loadGroupPlatformRoles(nodeData.data.id);
                 }
             }
         });
@@ -186,6 +233,12 @@ const UIManager = {
         document.getElementById('btn-edit').disabled = false;
         document.getElementById('btn-delete').disabled = false;
         document.getElementById('btn-invite-member').disabled = false;
+        const btnAssignRole = document.getElementById('btn-assign-platform-role');
+        if (btnAssignRole) btnAssignRole.disabled = false;
+
+        // 상속 고지의 인원수는 멤버 조회 완료 후 갱신되므로, 우선 group.user_count로 표기
+        AppState.groups.memberCount = group.user_count !== undefined ? group.user_count : 0;
+        UIManager.updateInheritNotice();
     },
 
     clearDetailPanel() {
@@ -199,13 +252,49 @@ const UIManager = {
             if (el) el.textContent = '-';
         });
 
-        ['btn-add-child', 'btn-edit', 'btn-delete', 'btn-invite-member'].forEach(id => {
+        ['btn-add-child', 'btn-edit', 'btn-delete', 'btn-invite-member', 'btn-assign-platform-role'].forEach(id => {
             const btn = document.getElementById(id);
             if (btn) btn.disabled = true;
         });
 
         const membersList = document.getElementById('group-members-list');
         if (membersList) membersList.innerHTML = '<p class="text-muted">Select a group to view members.</p>';
+
+        AppState.groups.platformRoles = [];
+        AppState.groups.memberCount = 0;
+        const rolesList = document.getElementById('group-platform-roles-list');
+        if (rolesList) rolesList.innerHTML = '<p class="text-muted">Select a group to view platform roles.</p>';
+        const inheritCount = document.getElementById('role-inherit-member-count');
+        if (inheritCount) inheritCount.textContent = 'every member';
+    },
+
+    // 상속 영향 고지 — 그룹에 배정된 role은 소속 사용자 전원이 상속받는다
+    updateInheritNotice() {
+        const el = document.getElementById('role-inherit-member-count');
+        if (!el) return;
+        const count = AppState.groups.memberCount;
+        el.textContent = count === 1 ? '1 member' : `all ${count} member(s)`;
+    },
+
+    showGroupPlatformRoles(roles) {
+        const list = document.getElementById('group-platform-roles-list');
+        if (!list) return;
+        if (!roles || roles.length === 0) {
+            list.innerHTML = '<p class="text-muted">No platform roles assigned to this group.</p>';
+            return;
+        }
+        list.innerHTML = roles.map(r => {
+            const name = r.role_name || r.roleName || '-';
+            const assignedAt = r.created_at || r.createdAt;
+            const assignedText = assignedAt ? new Date(assignedAt).toLocaleDateString() : '';
+            return `<div class="d-flex align-items-center justify-content-between mb-2">
+                <div class="d-flex align-items-center">
+                    <span class="badge bg-azure-lt me-2">Platform</span>
+                    <span class="fw-bold">${name}</span>
+                </div>
+                ${assignedText ? `<span class="text-muted small">Assigned ${assignedText}</span>` : ''}
+            </div>`;
+        }).join('');
     },
 
     populateParentSelect(list, excludeId) {
@@ -342,6 +431,106 @@ const ModalManager = {
         document.getElementById('delete-group-name').textContent = group.name || '';
         const modal = new bootstrap.Modal(document.getElementById('delete-group-modal'));
         modal.show();
+    },
+
+    // users.js와 동일한 방식: 전체 역할 목록을 가져와 role type으로 필터
+    getRoleTypes(role) {
+        if (Array.isArray(role.role_types) && role.role_types.length > 0) {
+            return role.role_types;
+        }
+        if (Array.isArray(role.roleTypes) && role.roleTypes.length > 0) {
+            return role.roleTypes;
+        }
+        const roleSubs = role.role_subs || role.roleSubs || [];
+        return roleSubs
+            .map(sub => sub.role_type || sub.roleType)
+            .filter(Boolean);
+    },
+
+    filterRolesByType(roles, roleType) {
+        if (!roleType) return roles;
+        const normalizedType = roleType.toLowerCase();
+        return roles.filter(role => {
+            const roleTypes = this.getRoleTypes(role);
+            return roleTypes.some(type => String(type).toLowerCase() === normalizedType);
+        });
+    },
+
+    async openAssignPlatformRole(group) {
+        if (!group) return;
+
+        document.getElementById('assign-role-group-name').value =
+            group.name + (group.organization_code ? ` (${group.organization_code})` : '');
+
+        const select = document.getElementById('assign-role-select');
+        const hint = document.getElementById('assign-role-hint');
+        const impact = document.getElementById('assign-role-impact');
+        const submit = document.getElementById('assign-role-submit');
+
+        select.innerHTML = '<option value="">Loading roles...</option>';
+        select.disabled = true;
+        hint.textContent = '';
+        impact.style.display = 'none';
+        submit.disabled = true;
+
+        new bootstrap.Modal(document.getElementById('assign-platform-role-modal')).show();
+
+        try {
+            if (!AppState.roles.all.length) {
+                const allRoles = await webconsolejs['common/api/services/roles_api'].getRoleList();
+                AppState.roles.all = allRoles || [];
+            }
+            const platformRoles = this.filterRolesByType(AppState.roles.all, 'platform');
+            const assignedIds = new Set(
+                (AppState.groups.platformRoles || []).map(r => String(r.role_id || r.roleId))
+            );
+            const selectable = platformRoles.filter(r => !assignedIds.has(String(r.id)));
+
+            select.innerHTML = '<option value="">Select role</option>';
+            selectable.forEach(role => {
+                const option = document.createElement('option');
+                option.value = role.id;
+                option.textContent = role.name + (role.description ? ` — ${role.description}` : '');
+                select.appendChild(option);
+            });
+            select.disabled = false;
+            submit.disabled = false;
+
+            if (selectable.length === 0) {
+                select.innerHTML = '<option value="">No assignable platform role</option>';
+                hint.textContent = platformRoles.length === 0
+                    ? 'No platform role is defined yet.'
+                    : 'All platform roles are already assigned to this group.';
+                select.disabled = true;
+                submit.disabled = true;
+            }
+        } catch (error) {
+            console.error('Failed to load role list:', error);
+            select.innerHTML = '<option value="">Failed to load roles</option>';
+            hint.textContent = 'Could not load the platform role list. Please retry.';
+        }
+    },
+
+    // 상속 영향 고지 — 선택한 role이 몇 명에게 전파되는지 명시
+    showAssignImpact() {
+        const select = document.getElementById('assign-role-select');
+        const impact = document.getElementById('assign-role-impact');
+        const text = document.getElementById('assign-role-impact-text');
+        if (!select || !impact || !text) return;
+
+        if (!select.value) {
+            impact.style.display = 'none';
+            return;
+        }
+
+        const roleName = select.options[select.selectedIndex].textContent.split(' — ')[0];
+        const count = AppState.groups.memberCount;
+        const groupName = AppState.groups.selectedGroup ? AppState.groups.selectedGroup.name : 'this group';
+
+        text.innerHTML = count > 0
+            ? `<strong>${count}</strong> member(s) of <strong>${groupName}</strong> will inherit <strong>${roleName}</strong> immediately, on top of the roles granted to them directly.`
+            : `<strong>${groupName}</strong> has no member yet. <strong>${roleName}</strong> will be inherited by every user added to this group later.`;
+        impact.style.display = 'block';
     }
 };
 
@@ -432,9 +621,46 @@ window.submitDeleteGroup = async function() {
 
 window.refreshGroups = async function() {
     AppState.groups.selectedGroup = null;
+    AppState.roles.all = [];
     UIManager.clearDetailPanel();
     await GroupManager.loadTree();
     await GroupManager.loadList();
+};
+
+window.openAssignPlatformRole = async function() {
+    if (!AppState.groups.selectedGroup) {
+        alert("Please select a group first.");
+        return;
+    }
+    await ModalManager.openAssignPlatformRole(AppState.groups.selectedGroup);
+};
+
+window.onAssignRoleChanged = function() {
+    ModalManager.showAssignImpact();
+};
+
+window.submitAssignPlatformRole = async function() {
+    const roleId = document.getElementById('assign-role-select').value;
+    if (!roleId) {
+        alert("Please select a platform role.");
+        return;
+    }
+    if (!AppState.groups.selectedGroup) return;
+
+    const groupId = AppState.groups.selectedGroup.id;
+    const groupName = AppState.groups.selectedGroup.name;
+    const count = AppState.groups.memberCount;
+
+    // 상속 영향 최종 확인 — 그룹 배정은 소속 사용자 전원의 권한을 올린다
+    const confirmMsg = count > 0
+        ? `Assign this platform role to "${groupName}"?\n\n${count} member(s) of this group will inherit it immediately.`
+        : `Assign this platform role to "${groupName}"?\n\nThis group has no member yet. Any user added later will inherit it.`;
+    if (!confirm(confirmMsg)) return;
+
+    const modal = bootstrap.Modal.getInstance(document.getElementById('assign-platform-role-modal'));
+    if (modal) modal.hide();
+
+    await GroupManager.assignPlatformRole(groupId, roleId);
 };
 
 window.openInviteMember = async function() {

--- a/front/templates/pages/settings/accountnaccess/organizations/groups.html
+++ b/front/templates/pages/settings/accountnaccess/organizations/groups.html
@@ -96,6 +96,29 @@
               </div>
             </div>
 
+            <!-- Platform Roles -->
+            <div class="mt-4">
+              <div class="d-flex justify-content-between align-items-center mb-3">
+                <h4 class="mb-0">Platform Roles</h4>
+                <button id="btn-assign-platform-role" class="btn btn-sm btn-primary"
+                        onclick="openAssignPlatformRole()" disabled>
+                  + Assign Platform Role
+                </button>
+              </div>
+              <div class="alert alert-info py-2 mb-3">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon alert-icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                  <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0"></path>
+                  <path d="M12 9h.01"></path>
+                  <path d="M11 12h1v4h1"></path>
+                </svg>
+                Roles assigned here are inherited by <strong id="role-inherit-member-count">every member</strong> of this group, in addition to any roles granted to them directly.
+              </div>
+              <div id="group-platform-roles-list">
+                <p class="text-muted">Select a group to view platform roles.</p>
+              </div>
+            </div>
+
             <!-- Members Tab -->
             <div class="mt-4">
               <div class="d-flex justify-content-between align-items-center mb-3">
@@ -281,6 +304,46 @@
   </div>
 </div>
 
+<!-- Assign Platform Role Modal -->
+<div class="modal modal-blur fade" id="assign-platform-role-modal" tabindex="-1"
+     style="display:none;" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Assign Platform Role</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Group</label>
+          <input type="text" class="form-control" id="assign-role-group-name" readonly />
+        </div>
+        <div class="mb-3">
+          <label class="form-label required">Platform Role</label>
+          <select class="form-select" id="assign-role-select" onchange="onAssignRoleChanged()">
+            <option value="">Select role</option>
+          </select>
+          <div class="form-hint" id="assign-role-hint"></div>
+        </div>
+        <div id="assign-role-impact" class="alert alert-warning" style="display:none;">
+          <svg xmlns="http://www.w3.org/2000/svg" class="icon alert-icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+            <path d="M12 9v4"></path>
+            <path d="M10.363 3.591l-8.106 13.534a1.914 1.914 0 0 0 1.636 2.871h16.214a1.914 1.914 0 0 0 1.636 -2.871l-8.106 -13.534a1.914 1.914 0 0 0 -3.274 0z"></path>
+            <path d="M12 16h.01"></path>
+          </svg>
+          <span id="assign-role-impact-text"></span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="assign-role-submit"
+                onclick="submitAssignPlatformRole()">Assign</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Import Result Modal -->
 <div class="modal modal-blur fade" id="import-result-modal" tabindex="-1" style="display:none;" aria-hidden="true">
   <div class="modal-dialog modal-sm modal-dialog-centered">
@@ -312,4 +375,5 @@
 
 <!-- javascript -->
 {{ javascriptTag("common/api/services/groups_api.js") | raw }}
+{{ javascriptTag("common/api/services/roles_api.js") | raw }}
 {{ javascriptTag("pages/settings/accountnaccess/groups/groups.js") | raw }}


### PR DESCRIPTION
## Summary

**Settings > Organizations > Groups — 그룹에 Platform Role 직접 배정 UI 신설**
- 백엔드(`AssignGroupPlatformRole`/`GetGroupPlatformRoles`)와 BFF `conf/api.yaml` 등록은 이미 돼 있었으나 이를 호출하는 UI가 없어, Users 화면은 "사용자→역할" 배정이 되는데 "그룹→역할"만 비대칭적으로 빠져 있던 것을 해소
- 그룹 상세 패널에 **Platform Roles** 섹션과 `[Assign Platform Role]` 버튼, 배정 모달(`#assign-platform-role-modal`) 추가
- 역할 목록 로드는 Users 화면과 동일한 방식 — `filterRolesByType()`으로 platform 타입만 필터링해 노출

**상속 영향 3중 고지**

그룹에 배정한 역할은 그룹 소속 사용자 전원이 상속받으므로, 배정 전에 영향 범위를 세 지점에서 노출한다.
- 섹션 상단 상시 배너 — 상속 대상 인원수 표시 (`#role-inherit-member-count`)
- 모달 내 경고 박스 — 역할 선택 시 "N명이 즉시 상속" 문구로 갱신 (`#assign-role-impact`)
- 제출 직전 확인창 — 배정 대상 그룹명·인원수 재확인

멤버가 0명인 그룹은 "이후 이 그룹에 추가되는 사용자가 상속받는다"는 문구로 분기 처리.

**오류 표시 개선**
- 배정 실패 시 generic HTTP status 대신 백엔드 응답의 상세 메시지를 노출 — 중복 배정 / 그룹·역할 없음 / 기타 오류를 구분해 안내

## 범위

- **Platform Role만** 다룬다. Workspace Role 배정 UI와 배정 해제는 미등록 오퍼레이션 9종(`removeGroupPlatformRole` 포함)에 의존하므로 별도 티켓으로 분리했다.
- 따라서 이 PR 머지 시점의 화면은 **배정만 가능하고 해제는 불가**하다. 해제 경로는 후속 PR에서 오퍼레이션 등록과 함께 제공한다.
