### PR TITLE
feat: Infra JSON Export/Import — 기존 Infra 구성을 내보내고 NodeGroup으로 되가져오기

### DIFF
--- a/front/assets/js/pages/operation/manage/mci.js
+++ b/front/assets/js/pages/operation/manage/mci.js
@@ -3900,3 +3900,28 @@ export async function executeSaveAsTemplate() {
     bootstrap.Modal.getInstance(document.getElementById('save-as-template-modal'))?.hide();
   }).catch(() => {});
 }
+
+// ─── MCI를 JSON으로 Export (Node Import에서 재사용할 파일 생성) ────────────
+export async function exportInfraAsJson() {
+  const mciId = window.currentMciId;
+  const nsId = window.currentNsId;
+  if (mciId == undefined || mciId == "") {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Validation', 'Please select an Infra first')
+    return;
+  }
+
+  try {
+    const infraDynamicReq = await webconsolejs["common/api/services/infratemplate_api"].getInfraReqFromInfra(nsId, mciId);
+    const payload = { infraDynamicReq };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    a.href = url;
+    a.download = `${mciId}-nodegroups-${date}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  } catch (e) {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Error', 'Failed to export Infra as JSON: ' + (e?.message || e));
+  }
+}

--- a/front/assets/js/pages/operation/manage/mci.js
+++ b/front/assets/js/pages/operation/manage/mci.js
@@ -3902,6 +3902,20 @@ export async function executeSaveAsTemplate() {
 }
 
 // ─── MCI를 JSON으로 Export (Node Import에서 재사용할 파일 생성) ────────────
+function exportDateStamp() {
+  return new Date().toISOString().slice(0, 10).replace(/-/g, '');
+}
+
+function downloadJson(payload, filename) {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 export async function exportInfraAsJson() {
   const mciId = window.currentMciId;
   const nsId = window.currentNsId;
@@ -3912,16 +3926,60 @@ export async function exportInfraAsJson() {
 
   try {
     const infraDynamicReq = await webconsolejs["common/api/services/infratemplate_api"].getInfraReqFromInfra(nsId, mciId);
-    const payload = { infraDynamicReq };
-    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
-    a.href = url;
-    a.download = `${mciId}-nodegroups-${date}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadJson({ infraDynamicReq }, `${mciId}-nodegroups-${exportDateStamp()}.json`);
   } catch (e) {
     webconsolejs['partials/layout/modal'].commonShowDefaultModal('Error', 'Failed to export Infra as JSON: ' + (e?.message || e));
+  }
+}
+
+// ─── 선택한 Node가 속한 NodeGroup만 JSON으로 Export ────────────────────────
+// Node List / Status 카드의 Action 항목. 형제 액션(Delete/Create MyImage)과 동일하게
+// 단일 선택(selectedVmId) 규약을 따르므로 결과는 NodeGroup 1개다.
+// 산출물은 전체 Export와 같은 형상이라 Import 모달이 그대로 받아들인다.
+export async function exportSelectedNodeGroupAsJson() {
+  const mciId = window.currentMciId;
+  const nsId = window.currentNsId;
+  if (mciId == undefined || mciId == "") {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Validation', 'Please select an Infra first')
+    return;
+  }
+  // 형제 액션들은 currentVmId로 가드하는데 그 값은 체크 해제 시 초기화되지 않는다.
+  // selectedVmId가 실제 선택 상태를 반영하므로 이쪽을 쓴다.
+  if (!selectedVmId) {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Validation', 'Please select a Node')
+    return;
+  }
+
+  const infra = (window.totalMciListObj || []).find(m => m.id === mciId);
+  const node = ((infra && infra.node) || []).find(n => n.id === selectedVmId);
+  const nodeGroupId = node && node.nodeGroupId;
+  if (!nodeGroupId) {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Error', 'Could not determine the NodeGroup of the selected node.')
+    return;
+  }
+
+  try {
+    const req = await webconsolejs["common/api/services/infratemplate_api"].getInfraReqFromInfra(nsId, mciId);
+    const groups = (req && req.nodeGroups) || [];
+    // 1차 정확 일치 → 2차 대소문자 무시 일치
+    const norm = v => String(v == null ? "" : v).trim().toLowerCase();
+    const wanted = new Set([nodeGroupId]);
+    let filtered = groups.filter(g => wanted.has(g.name));
+    if (filtered.length === 0) {
+      const wantedNorm = new Set([norm(nodeGroupId)]);
+      filtered = groups.filter(g => wantedNorm.has(norm(g.name)));
+    }
+    if (filtered.length === 0) {
+      webconsolejs['partials/layout/modal'].commonShowDefaultModal('Error', 'Could not find the NodeGroup definition for the selected node.')
+      return;
+    }
+
+    // infra 레벨 필드(description/installMonAgent/postCommand 등)를 보존해야
+    // import 시 carry-through 동작이 전체 Export와 동일해진다.
+    // nodeGroupSize는 원본 정의 값을 그대로 둔다 — 선택 노드 수로 축소하지 않는다.
+    const payload = { infraDynamicReq: { ...req, nodeGroups: filtered } };
+    downloadJson(payload, `${mciId}-${nodeGroupId}-nodegroup-${exportDateStamp()}.json`);
+  } catch (e) {
+    webconsolejs['partials/layout/modal'].commonShowDefaultModal('Error', 'Failed to export NodeGroup as JSON: ' + (e?.message || e));
   }
 }

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -1,4 +1,5 @@
 import { TabulatorFull as Tabulator } from "tabulator-tables";
+import { Dropzone } from "dropzone";
 //import { selectedMciObj } from "./mci";
 //document.addEventListener("DOMContentLoaded", initMciCreate) // page가 아닌 partials에서는 제거
 
@@ -649,7 +650,16 @@ export async function expressDone_btn() {
       return;
     }
   }
-  
+
+  // 1-1. 이름 중복 검증 — precheck(review) 호출 앞에 두어 확정 실패에 네트워크 왕복을 쓰지 않는다.
+  // currentEditingIndex 제외가 필수: 이름을 안 바꾼 항목을 다시 Done 하면 자기 자신과 충돌한다.
+  var nameErr = checkNodeGroupNameAvailable($("#ep_name").val(), currentEditingIndex);
+  if (nameErr) {
+    alert(nameErr);
+    $("#ep_name").focus();
+    return;
+  }
+
   // 2. VM 개수 숫자 검증
   var vmAddCnt = $("#ep_vm_add_cnt").val();
   if (isNaN(vmAddCnt) || parseInt(vmAddCnt) < 1) {
@@ -770,6 +780,74 @@ function showPrecheckConfirmModal(title, content) {
     modalEl.addEventListener("hidden.bs.modal", function () { resolve(confirmed); }, { once: true });
     bootstrap.Modal.getOrCreateInstance(modalEl).show();
   });
+}
+
+// alert형(#commonDefaultModal) — 확인만 받고 진행 여부를 묻지 않는다.
+// commonShowDefaultModal은 white-space를 세팅하지 않는데 showPrecheckConfirmModal이 같은
+// 엘리먼트에 pre-line을 영구로 남기므로 호출 순서에 의존한다. 여기서 명시 세팅해 의존을 없앤다.
+function showAlertModal(title, content) {
+  var modalEl = document.getElementById("commonDefaultModal");
+  if (!modalEl) {
+    alert(title + "\n\n" + content);
+    return;
+  }
+  document.getElementById("commonDefaultModal-title").innerText = title;
+  var contentEl = document.getElementById("commonDefaultModal-content");
+  contentEl.style.whiteSpace = "pre-line";
+  contentEl.innerText = content;
+  bootstrap.Modal.getOrCreateInstance(modalEl).show();
+}
+
+// 배포 직전 NodeGroup 이름 최종 검증. 통과하면 true, 막으면 false(모달 표시).
+function validateNodeGroupNamesBeforeDeploy() {
+  if (Express_Server_Config_Arr.length === 0) {
+    showAlertModal("NodeGroup Required", "Add at least one NodeGroup before Deploy.");
+    return false;
+  }
+
+  var missing = [];
+  Express_Server_Config_Arr.forEach(function (cfg, i) {
+    if (!normalizeNodeGroupName(cfg && cfg.name)) missing.push(i + 1);
+  });
+  if (missing.length > 0) {
+    showAlertModal(
+      "NodeGroup Name Required",
+      missing.length + " NodeGroup(s) have no name (position: " + missing.join(", ") + ").\n"
+      + "Click each item in the NodeGroup list and enter a unique name, then Deploy again."
+    );
+    return false;
+  }
+
+  var seen = new Set();
+  var dupes = [];
+  Express_Server_Config_Arr.forEach(function (cfg) {
+    var key = normalizeNodeGroupName(cfg && cfg.name);
+    if (seen.has(key)) dupes.push(String(cfg.name).trim());
+    else seen.add(key);
+  });
+  if (dupes.length > 0) {
+    showAlertModal(
+      "Duplicate NodeGroup Name",
+      "These NodeGroup names are used more than once: " + dupes.join(", ") + ".\n"
+      + "NodeGroup names must be unique. Please rename them and Deploy again."
+    );
+    return false;
+  }
+
+  var existing = getExistingNodeGroupNames();
+  var clash = Express_Server_Config_Arr
+    .filter(function (cfg) { return existing.has(normalizeNodeGroupName(cfg && cfg.name)); })
+    .map(function (cfg) { return String(cfg.name).trim(); });
+  if (clash.length > 0) {
+    showAlertModal(
+      "Duplicate NodeGroup Name",
+      "These NodeGroup names already exist in this Infra: " + clash.join(", ") + ".\n"
+      + "Please rename them and Deploy again."
+    );
+    return false;
+  }
+
+  return true;
 }
 
 
@@ -972,7 +1050,10 @@ async function precheckNodeGroup(express_form) {
 
 // express_form을 Express_Server_Config_Arr에 반영(신규 push 또는 수정 모드 갱신) + <li> 렌더
 function addServerConfigToList(express_form) {
-  var server_name = express_form.name;
+  // 이름이 비어 있으면(중복 충돌로 clear된 경우) 클릭 대상을 식별할 수 있도록 placeholder 라벨을 쓴다.
+  // btn-info는 "NodeGroup 칩"의 안정적 마커이므로 유지하고, 상태는 별도 클래스로만 표현한다.
+  var hasName = !!(express_form.name && String(express_form.name).trim());
+  var server_name = hasName ? express_form.name : NO_NAME_LABEL;
   var server_cnt = parseInt(express_form.subGroupSize);
 
   // 수정 모드인지 신규 추가 모드인지 판단
@@ -988,6 +1069,7 @@ function addServerConfigToList(express_form) {
     var displayServerCnt = '(' + server_cnt + ')';
     var listItem = $("#" + vmEleId + "_server_list li").eq(currentEditingIndex + 1); // +1은 plusIcon 때문
     listItem.text(server_name + displayServerCnt);
+    listItem.toggleClass("nodegroup-name-missing border border-danger", !hasName);
 
     // 수정 모드 플래그 초기화
     currentEditingIndex = -1;
@@ -998,7 +1080,8 @@ function addServerConfigToList(express_form) {
     Express_Server_Config_Arr.push(express_form);
 
     var displayServerCnt = '(' + server_cnt + ')';
-    add_server_html += '<li class="removebullet btn btn-info" onclick="webconsolejs[\'partials/operation/manage/mcicreate\'].view_express(\'' + express_data_cnt + '\')">'
+    var missingClass = hasName ? '' : ' nodegroup-name-missing border border-danger';
+    add_server_html += '<li class="removebullet btn btn-info' + missingClass + '" onclick="webconsolejs[\'partials/operation/manage/mcicreate\'].view_express(\'' + express_data_cnt + '\')">'
       + server_name + displayServerCnt
       + '</li>';
 
@@ -1291,6 +1374,9 @@ export function deployMci() {
 	// }    
 }
 export async function createMciDynamic() {
+	// 이름 검증은 review 호출보다 앞에 둔다 — 확정 실패에 네트워크 왕복을 낭비하지 않는다.
+	if (!validateNodeGroupNamesBeforeDeploy()) return;
+
 	// var namespace = webconsolejs["common/api/services/workspace_api"].getCurrentProject()
 	// nsid = namespace.Name
 	var selectedWorkspaceProject = await webconsolejs["partials/layout/navbar"].workspaceProjectInit();
@@ -1384,6 +1470,9 @@ export async function createMciDynamic() {
 }
 
 export async function createVmDynamic() {
+    // vmDynamic 호출 전에 막아야 scheduleDiskAttachForConfigs·완료 alert·페이지 이동이 실행되지 않는다.
+    if (!validateNodeGroupNamesBeforeDeploy()) return;
+
     var selectedWorkspaceProject = await webconsolejs["partials/layout/navbar"].workspaceProjectInit();
     var selectedNsId = selectedWorkspaceProject.nsId;
     var mciId = window.currentMciId;
@@ -1898,15 +1987,86 @@ function mapNodeGroupToExpressForm(g, req, idx) {
 	return express_form;
 }
 
+// ─── NodeGroup 이름 중복 검사 ─────────────────────────────────────────────
+// Tumblebug이 리소스 id를 정규화하므로 g1/G1은 서버에서 충돌한다 → 대소문자 무시 비교.
+const NO_NAME_LABEL = "(name required)";
+
+function normalizeNodeGroupName(n) {
+	return String(n == null ? "" : n).trim().toLowerCase();
+}
+
+// Add Node 경로에서 대상 Infra에 이미 존재하는 NodeGroup 이름 집합.
+// Create Infra 경로(대상 Infra 없음)에서는 빈 Set.
+// 조회 실패는 "기존 이름 없음"으로 취급하고 차단하지 않는다 — 최종 안전망은 백엔드다.
+function getExistingNodeGroupNames() {
+	const names = new Set();
+	if (!isVm) return names;
+	const infra = (window.totalMciListObj || []).find(m => m.id === window.currentMciId);
+	((infra && infra.node) || []).forEach(function (n) {
+		if (n && n.nodeGroupId) names.add(normalizeNodeGroupName(n.nodeGroupId));
+	});
+	return names;
+}
+
+// 현재 시점에 점유된 이름 집합(기존 Infra ∪ 폼에 쌓인 것). skipIndex는 수정 모드에서 자기 자신 제외용.
+function collectTakenNodeGroupNames(skipIndex) {
+	const taken = getExistingNodeGroupNames();
+	Express_Server_Config_Arr.forEach(function (cfg, i) {
+		if (i === skipIndex) return;
+		const key = normalizeNodeGroupName(cfg && cfg.name);
+		if (key) taken.add(key);
+	});
+	return taken;
+}
+
+// 사용 가능하면 null, 아니면 영문 사유 문자열
+function checkNodeGroupNameAvailable(name, selfIndex) {
+	const key = normalizeNodeGroupName(name);
+	if (!key) return null; // 빈 값은 필수항목 검증이 따로 처리
+	if (getExistingNodeGroupNames().has(key)) {
+		return "NodeGroup name '" + String(name).trim() + "' already exists in this Infra. Please use a different name.";
+	}
+	const dup = Express_Server_Config_Arr.some(function (cfg, i) {
+		return i !== selfIndex && normalizeNodeGroupName(cfg && cfg.name) === key;
+	});
+	if (dup) {
+		return "NodeGroup name '" + String(name).trim() + "' is already used by another NodeGroup in this list. Please use a different name.";
+	}
+	return null;
+}
+
+// import 대상 nodeGroups의 충돌 여부를 미리 계산(표시 전용). 반환: boolean[] (행 순서 그대로)
+function detectNodeGroupNameConflicts(groups) {
+	const taken = collectTakenNodeGroupNames(-1);
+	return (groups || []).map(function (g) {
+		const key = normalizeNodeGroupName(g && g.name);
+		if (!key) return false;
+		if (taken.has(key)) return true;
+		taken.add(key); // 파일 내부 중복도 두 번째부터 충돌로 잡는다
+		return false;
+	});
+}
+
 // nodeGroups[] 전체를 폼에 append(항상 신규 추가 모드) — template/JSON import 공용
+// 이름이 이미 점유돼 있으면 비워서 넣는다. 필수항목이므로 사용자가 직접 입력해야 Deploy가 통과한다.
 function appendNodeGroupsToForm(req) {
 	const groups = req?.nodeGroups || [];
 	// 항상 append 모드로 동작 — 모달 오픈 시점에 편집 중이던 상태가 남아있지 않도록 방어
 	currentEditingIndex = -1;
+	const taken = collectTakenNodeGroupNames(-1);
+	let cleared = 0;
 	groups.forEach(function (g, idx) {
-		addServerConfigToList(mapNodeGroupToExpressForm(g, req, idx));
+		const express_form = mapNodeGroupToExpressForm(g, req, idx);
+		const key = normalizeNodeGroupName(express_form.name);
+		if (key && taken.has(key)) {
+			express_form.name = "";
+			cleared++;
+		} else if (key) {
+			taken.add(key);
+		}
+		addServerConfigToList(express_form);
 	});
-	return groups.length;
+	return { added: groups.length, cleared: cleared };
 }
 
 // 선택한 template의 nodeGroups를 기존 NodeGroup 목록에 추가(append) — 수정 후 배포용 프리필
@@ -1948,31 +2108,64 @@ export function addTemplateToForm() {
 // (JSON을 직접 받는 배포 전용 백엔드 엔드포인트가 없음), 실제 배포는 기존 Deploy 버튼으로 제출한다.
 
 let importedNodeGroupsReq = null;
+let importJsonDropzone = null;
+// 드롭존과 파일선택 input을 동기화할 때 removedfile 핸들러가 미리보기를 지우지 않도록 막는 플래그
+let isSyncingImportSources = false;
 
 function resetImportJsonPreview() {
 	const hint = document.getElementById("import-json-preview-hint");
 	const content = document.getElementById("import-json-preview-content");
 	if (hint) hint.classList.remove("d-none");
 	if (content) content.classList.add("d-none");
+	const warnEl = document.getElementById("import-json-conflict-warning");
+	if (warnEl) {
+		warnEl.textContent = "";
+		warnEl.classList.add("d-none");
+	}
 	const btn = document.getElementById("btn-add-imported-nodegroups");
 	if (btn) btn.disabled = true;
 }
 
-function renderImportJsonPreview(req) {
+function renderImportJsonPreview(req, conflicts) {
 	const hint = document.getElementById("import-json-preview-hint");
 	const content = document.getElementById("import-json-preview-content");
 	if (!content) return;
 	if (hint) hint.classList.add("d-none");
 	content.classList.remove("d-none");
 
+	const groups = req.nodeGroups || [];
+	const flags = conflicts || [];
+	const conflictCount = flags.filter(Boolean).length;
+
+	// 충돌 경고 배너 — 이름이 비워진 채 추가된다는 사실을 Add 누르기 전에 알린다
+	const warnEl = document.getElementById("import-json-conflict-warning");
+	if (warnEl) {
+		if (conflictCount > 0) {
+			warnEl.textContent = conflictCount + " NodeGroup name(s) are already in use. "
+				+ "Their names will be cleared — enter a unique name for each before Deploy.";
+			warnEl.classList.remove("d-none");
+		} else {
+			warnEl.textContent = "";
+			warnEl.classList.add("d-none");
+		}
+	}
+
 	const tbody = document.getElementById("import-json-nodegroup-rows");
 	tbody.innerHTML = "";
-	(req.nodeGroups || []).forEach(g => {
+	groups.forEach((g, idx) => {
 		const tr = document.createElement("tr");
 		const rootDisk = [g.rootDiskType, g.rootDiskSize].filter(v => v !== undefined && v !== "" && v !== 0).join(" / ");
-		[g.name, g.specId, g.imageId, g.nodeGroupSize, g.connectionName, rootDisk, g.zone].forEach(val => {
+		[g.name, g.specId, g.imageId, g.nodeGroupSize, g.connectionName, rootDisk, g.zone].forEach((val, col) => {
 			const td = document.createElement("td");
 			td.textContent = (val === undefined || val === null || val === "") ? "-" : String(val);
+			// Name 컬럼(col 0)이 충돌이면 강조 + 배지. textContent 패턴을 깨지 않도록 배지만 append.
+			if (col === 0 && flags[idx]) {
+				td.classList.add("text-danger");
+				const badge = document.createElement("span");
+				badge.className = "badge bg-orange-lt ms-1";
+				badge.textContent = "Duplicate";
+				td.appendChild(badge);
+			}
 			tr.appendChild(td);
 		});
 		tbody.appendChild(tr);
@@ -1987,14 +2180,79 @@ export function openImportJsonModal() {
 
 	const modalEl = document.getElementById("import-nodegroups-json-modal");
 	templateDeploySucceeded = false;
+	// 트랜지션 완료 후 초기화 — setTimeout 추측값 대신 shown 이벤트를 쓴다(fade 150ms)
+	modalEl.addEventListener("shown.bs.modal", initImportJsonDropzone, { once: true });
 	modalEl.addEventListener("hidden.bs.modal", function () {
+		clearImportJsonDropzoneFiles();
 		if (!templateDeploySucceeded) revertDeployAlgorithmSelect();
 	}, { once: true });
 	bootstrap.Modal.getOrCreateInstance(modalEl).show();
 }
 
+// 드롭존에 쌓인 파일 비우기 — 미리보기를 지우는 removedfile 핸들러가 재진입하지 않도록 플래그로 감싼다
+function clearImportJsonDropzoneFiles() {
+	if (!importJsonDropzone) return;
+	isSyncingImportSources = true;
+	try { importJsonDropzone.removeAllFiles(true); } finally { isSyncingImportSources = false; }
+}
+
+function initImportJsonDropzone() {
+	const el = document.getElementById("import-json-dropzone");
+	if (!el) return;
+	// 중복 초기화 가드 — Dropzone은 이미 붙은 엘리먼트에 다시 붙이면 예외를 던진다
+	if (el.dropzone) {
+		importJsonDropzone = el.dropzone;
+		clearImportJsonDropzoneFiles();
+		return;
+	}
+	importJsonDropzone = new Dropzone(el, {
+		// <div> 기반이라 form action이 없다 — autoProcessQueue:false여도 url은 필수다
+		url: "/",
+		autoProcessQueue: false,
+		maxFiles: 1,
+		acceptedFiles: ".json,application/json",
+		maxFilesize: 10,
+		addRemoveLinks: true,
+		clickable: true,
+		dictDefaultMessage: "Drop a JSON file here or click to browse",
+		init: function () {
+			const dz = this;
+			dz.on("addedfile", async function (file) {
+				// maxFiles:1 — 새 파일이 이전 것을 대체한다
+				if (dz.files.length > 1) {
+					isSyncingImportSources = true;
+					try { dz.removeFile(dz.files[0]); } finally { isSyncingImportSources = false; }
+				}
+				// 두 진입점(드롭/파일선택)의 상태가 어긋나지 않도록 input을 비운다
+				const inp = document.getElementById("import-nodegroups-json-file");
+				if (inp) inp.value = "";
+				await loadImportJsonFile(file);
+			});
+			dz.on("removedfile", function () {
+				if (isSyncingImportSources) return; // 프로그램적 제거는 미리보기를 지우지 않는다
+				importedNodeGroupsReq = null;
+				resetImportJsonPreview();
+			});
+			dz.on("error", function (file, msg) {
+				dz.removeFile(file);
+				webconsolejs["common/utils/toast"].showToast(
+					webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR,
+					typeof msg === "string" ? msg : "Invalid file"
+				);
+			});
+		}
+	});
+}
+
+// onchange 어댑터 — 시그니처와 export 이름을 유지해 HTML 인라인 핸들러를 그대로 둔다
 export async function handleImportJsonFileChange(input) {
 	const file = input.files && input.files[0];
+	if (file) clearImportJsonDropzoneFiles();
+	await loadImportJsonFile(file);
+}
+
+// 파싱·검증·미리보기 — 드롭존과 파일선택이 공유하는 실제 진입점
+export async function loadImportJsonFile(file) {
 	if (!file) {
 		importedNodeGroupsReq = null;
 		resetImportJsonPreview();
@@ -2018,7 +2276,7 @@ export async function handleImportJsonFileChange(input) {
 		});
 
 		importedNodeGroupsReq = req;
-		renderImportJsonPreview(req);
+		renderImportJsonPreview(req, detectNodeGroupNameConflicts(groups));
 		const btn = document.getElementById("btn-add-imported-nodegroups");
 		if (btn) btn.disabled = false;
 	} catch (e) {
@@ -2030,7 +2288,16 @@ export async function handleImportJsonFileChange(input) {
 
 export function applyImportedNodeGroups() {
 	if (!importedNodeGroupsReq) return;
-	const count = appendNodeGroupsToForm(importedNodeGroupsReq);
-	webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.SUCCESS, count + " NodeGroup(s) added from JSON.");
+	const result = appendNodeGroupsToForm(importedNodeGroupsReq);
+	const msg = result.cleared > 0
+		? result.added + " NodeGroup(s) added from JSON. " + result.cleared
+			+ " name(s) were already in use and have been cleared — enter a unique name for each before Deploy."
+		: result.added + " NodeGroup(s) added from JSON.";
+	webconsolejs["common/utils/toast"].showToast(
+		result.cleared > 0
+			? webconsolejs["common/utils/toast"].TOAST_TYPES.WARNING
+			: webconsolejs["common/utils/toast"].TOAST_TYPES.SUCCESS,
+		msg
+	);
 	bootstrap.Modal.getInstance(document.getElementById("import-nodegroups-json-modal"))?.hide();
 }

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -1671,9 +1671,11 @@ let templateModalSourceSelectId = "mci_deploy_algorithm"; // 모달을 연 selec
 let templateDeploySucceeded = false;
 let templateDeployInFlight = false;
 
+const MODAL_DEPLOY_ALGORITHM_VALUES = ["template", "import_json"]; // 별도 모달을 여는 select 값 — 모달 트리거일 뿐 실제 배포 알고리즘이 아님
+
 function revertDeployAlgorithmSelect() {
 	const sel = document.getElementById(templateModalSourceSelectId);
-	if (sel && sel.value === "template") sel.value = deployAlgorithmPrev[templateModalSourceSelectId] || "express";
+	if (sel && MODAL_DEPLOY_ALGORITHM_VALUES.includes(sel.value)) sel.value = deployAlgorithmPrev[templateModalSourceSelectId] || "express";
 }
 
 // 템플릿 미리보기 초기화 (선택 없음 → 안내문구 표시)
@@ -1735,7 +1737,7 @@ function initTemplateDeploySelect() {
 		if (!sel) return;
 		deployAlgorithmPrev[selId] = sel.value;
 		sel.addEventListener("change", async function () {
-			if (this.value !== "template") {
+			if (!MODAL_DEPLOY_ALGORITHM_VALUES.includes(this.value)) {
 				deployAlgorithmPrev[selId] = this.value;
 				return;
 			}
@@ -1750,7 +1752,11 @@ function initTemplateDeploySelect() {
 				}
 			}
 			templateModalSourceSelectId = selId;
-			await openTemplateSelectModal();
+			if (this.value === "import_json") {
+				openImportJsonModal();
+			} else {
+				await openTemplateSelectModal();
+			}
 		});
 	});
 }
@@ -1864,6 +1870,45 @@ export async function deployFromSelectedTemplate() {
 	}
 }
 
+// nodeGroups[] 원소(InfraDynamicReq 스키마, template/JSON import 공용) → express_form 매핑.
+// req는 상위 InfraDynamicReq(postCommand.command를 idx===0에만 carry-through하기 위해 필요), idx는 groups.forEach의 인덱스.
+function mapNodeGroupToExpressForm(g, req, idx) {
+	var express_form = {};
+	express_form["provider"] = (g.specId || "").split("+")[0];
+	express_form["connectionName"] = g.connectionName || "";
+	express_form["name"] = g.name || "";
+	express_form["description"] = g.description || "";
+	express_form["subGroupSize"] = String(g.nodeGroupSize != null ? g.nodeGroupSize : 1);
+	express_form["rootDiskSize"] = g.rootDiskSize;
+	express_form["rootDiskType"] = g.rootDiskType || "";
+	express_form["commonSpec"] = g.specId || "";
+	express_form["commonImage"] = g.imageId || "";
+	express_form["imageId"] = g.imageId || "";
+	express_form["specId"] = g.specId || "";
+	// infra 단위 postCommand는 첫 NodeGroup에만 반영(기존 command 처리 관례와 동일)
+	express_form["command"] = idx === 0 ? (req?.postCommand?.command || []).join("\n") : "";
+
+	// 정식 매핑 승격 5필드(CreateNodeGroupDynamicReq) — 값이 있을 때만 carry-through
+	if (g.zone) express_form["zone"] = g.zone;
+	if (g.nodeUserPassword) express_form["nodeUserPassword"] = g.nodeUserPassword;
+	if (g.label && Object.keys(g.label).length > 0) express_form["label"] = g.label;
+	if (g.vNetTemplateId) express_form["vNetTemplateId"] = g.vNetTemplateId;
+	if (g.sgTemplateId) express_form["sgTemplateId"] = g.sgTemplateId;
+
+	return express_form;
+}
+
+// nodeGroups[] 전체를 폼에 append(항상 신규 추가 모드) — template/JSON import 공용
+function appendNodeGroupsToForm(req) {
+	const groups = req?.nodeGroups || [];
+	// 항상 append 모드로 동작 — 모달 오픈 시점에 편집 중이던 상태가 남아있지 않도록 방어
+	currentEditingIndex = -1;
+	groups.forEach(function (g, idx) {
+		addServerConfigToList(mapNodeGroupToExpressForm(g, req, idx));
+	});
+	return groups.length;
+}
+
 // 선택한 template의 nodeGroups를 기존 NodeGroup 목록에 추가(append) — 수정 후 배포용 프리필
 // infra 단위 값(description/policyOnPartialFailure/installMonAgent/sgTemplateId/vNetTemplateId/postCommand.userName·timeoutMinutes)은
 // 이 모듈 상태에 보관만 하고, 실제 배포 payload 병합은 WEB-TECH-019(FR-05-02)에서 처리한다.
@@ -1877,36 +1922,8 @@ export function addTemplateToForm() {
 	}
 	const template = selected[0];
 	const req = template.infraDynamicReq || {};
-	const groups = req.nodeGroups || [];
 
-	// 항상 append 모드로 동작 — 모달 오픈 시점에 편집 중이던 상태가 남아있지 않도록 방어
-	currentEditingIndex = -1;
-
-	groups.forEach(function (g, idx) {
-		var express_form = {};
-		express_form["provider"] = (g.specId || "").split("+")[0];
-		express_form["connectionName"] = g.connectionName || "";
-		express_form["name"] = g.name || "";
-		express_form["description"] = g.description || "";
-		express_form["subGroupSize"] = String(g.nodeGroupSize != null ? g.nodeGroupSize : 1);
-		express_form["rootDiskSize"] = g.rootDiskSize;
-		express_form["rootDiskType"] = g.rootDiskType || "";
-		express_form["commonSpec"] = g.specId || "";
-		express_form["commonImage"] = g.imageId || "";
-		express_form["imageId"] = g.imageId || "";
-		express_form["specId"] = g.specId || "";
-		// infra 단위 postCommand는 첫 NodeGroup에만 반영(기존 command 처리 관례와 동일)
-		express_form["command"] = idx === 0 ? (req.postCommand?.command || []).join("\n") : "";
-
-		// 정식 매핑 승격 5필드(CreateNodeGroupDynamicReq) — template에 값이 있을 때만 carry-through
-		if (g.zone) express_form["zone"] = g.zone;
-		if (g.nodeUserPassword) express_form["nodeUserPassword"] = g.nodeUserPassword;
-		if (g.label && Object.keys(g.label).length > 0) express_form["label"] = g.label;
-		if (g.vNetTemplateId) express_form["vNetTemplateId"] = g.vNetTemplateId;
-		if (g.sgTemplateId) express_form["sgTemplateId"] = g.sgTemplateId;
-
-		addServerConfigToList(express_form);
-	});
+	appendNodeGroupsToForm(req);
 
 	templatePrefillInfraState = {
 		description: req.description || "",
@@ -1923,4 +1940,97 @@ export function addTemplateToForm() {
 	}
 
 	bootstrap.Modal.getInstance(document.getElementById("infra-template-select-modal"))?.hide();
+}
+
+// ─── JSON 파일로 NodeGroup Import ───────────────────────────────────────
+// "진짜 Node Import" — export한 JSON(InfraDynamicReq 형상, mci.js exportInfraAsJson()이 만드는 것과 동일 포맷)을
+// 읽어 Add Node 폼을 채운다. addTemplateToForm()과 동일하게 항상 "폼에 NodeGroup 추가" 경로로만 동작하고
+// (JSON을 직접 받는 배포 전용 백엔드 엔드포인트가 없음), 실제 배포는 기존 Deploy 버튼으로 제출한다.
+
+let importedNodeGroupsReq = null;
+
+function resetImportJsonPreview() {
+	const hint = document.getElementById("import-json-preview-hint");
+	const content = document.getElementById("import-json-preview-content");
+	if (hint) hint.classList.remove("d-none");
+	if (content) content.classList.add("d-none");
+	const btn = document.getElementById("btn-add-imported-nodegroups");
+	if (btn) btn.disabled = true;
+}
+
+function renderImportJsonPreview(req) {
+	const hint = document.getElementById("import-json-preview-hint");
+	const content = document.getElementById("import-json-preview-content");
+	if (!content) return;
+	if (hint) hint.classList.add("d-none");
+	content.classList.remove("d-none");
+
+	const tbody = document.getElementById("import-json-nodegroup-rows");
+	tbody.innerHTML = "";
+	(req.nodeGroups || []).forEach(g => {
+		const tr = document.createElement("tr");
+		const rootDisk = [g.rootDiskType, g.rootDiskSize].filter(v => v !== undefined && v !== "" && v !== 0).join(" / ");
+		[g.name, g.specId, g.imageId, g.nodeGroupSize, g.connectionName, rootDisk, g.zone].forEach(val => {
+			const td = document.createElement("td");
+			td.textContent = (val === undefined || val === null || val === "") ? "-" : String(val);
+			tr.appendChild(td);
+		});
+		tbody.appendChild(tr);
+	});
+}
+
+export function openImportJsonModal() {
+	const fileInput = document.getElementById("import-nodegroups-json-file");
+	if (fileInput) fileInput.value = "";
+	importedNodeGroupsReq = null;
+	resetImportJsonPreview();
+
+	const modalEl = document.getElementById("import-nodegroups-json-modal");
+	templateDeploySucceeded = false;
+	modalEl.addEventListener("hidden.bs.modal", function () {
+		if (!templateDeploySucceeded) revertDeployAlgorithmSelect();
+	}, { once: true });
+	bootstrap.Modal.getOrCreateInstance(modalEl).show();
+}
+
+export async function handleImportJsonFileChange(input) {
+	const file = input.files && input.files[0];
+	if (!file) {
+		importedNodeGroupsReq = null;
+		resetImportJsonPreview();
+		return;
+	}
+	try {
+		const text = await file.text();
+		const parsed = JSON.parse(text);
+		// { infraDynamicReq: { nodeGroups: [...] } } 래핑 형태와 { nodeGroups: [...] } 형태 둘 다 허용
+		const req = parsed.infraDynamicReq || parsed;
+		const groups = req.nodeGroups;
+		if (!Array.isArray(groups) || groups.length === 0) {
+			throw new Error("JSON must contain a non-empty 'nodeGroups' array (optionally wrapped in 'infraDynamicReq').");
+		}
+		const REQUIRED_FIELDS = ["name", "specId", "imageId", "nodeGroupSize", "connectionName"];
+		groups.forEach(function (g, i) {
+			const missing = REQUIRED_FIELDS.filter(k => g[k] === undefined || g[k] === null || g[k] === "");
+			if (missing.length > 0) {
+				throw new Error("nodeGroups[" + i + "] is missing required field(s): " + missing.join(", "));
+			}
+		});
+
+		importedNodeGroupsReq = req;
+		renderImportJsonPreview(req);
+		const btn = document.getElementById("btn-add-imported-nodegroups");
+		if (btn) btn.disabled = false;
+	} catch (e) {
+		importedNodeGroupsReq = null;
+		resetImportJsonPreview();
+		webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.ERROR, "Invalid JSON file: " + (e?.message || e));
+	}
+}
+
+export function applyImportedNodeGroups() {
+	if (!importedNodeGroupsReq) return;
+	const count = appendNodeGroupsToForm(importedNodeGroupsReq);
+	webconsolejs["common/utils/toast"].showToast(webconsolejs["common/utils/toast"].TOAST_TYPES.SUCCESS, count + " NodeGroup(s) added from JSON.");
+	bootstrap.Modal.getInstance(document.getElementById("import-nodegroups-json-modal"))?.hide();
 }

--- a/front/templates/pages/operations/manage/workloads/mciworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/mciworkloads.html
@@ -329,7 +329,10 @@
                       </svg>
                       Save as Template
                     </a>
-                    <a class="dropdown-item" href="#">
+                    <a
+                      class="dropdown-item"
+                      onclick="webconsolejs['pages/operation/manage/mci'].exportInfraAsJson()"
+                    >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         class="icon dropdown-item-icon"
@@ -352,7 +355,7 @@
                         ></path>
                         <path d="M9 12a3 3 0 1 0 6 0a3 3 0 0 0 -6 0"></path>
                       </svg>
-                      Export
+                      Export as JSON
                     </a>
                   </div>
                 </div>
@@ -653,6 +656,7 @@
                   <option value="simple">Simple</option>
                   <option value="expert">Expert</option>
                   <option value="template">Template</option>
+                  <option value="import_json">Import from JSON</option>
                 </select>
               </div>
 
@@ -832,6 +836,7 @@
                   <option value="simple">Simple</option>
                   <option value="expert">Expert</option>
                   <option value="template">Template</option>
+                  <option value="import_json">Import from JSON</option>
                 </select>
               </div>
 
@@ -1786,6 +1791,69 @@
           onclick="webconsolejs['partials/operation/manage/mcicreate'].deployFromSelectedTemplate()"
         >
           Deploy from Template
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Import NodeGroups from JSON (진짜 Node Import — export한 JSON을 읽어 Add Node 처리) -->
+<div class="modal modal-blur fade" id="import-nodegroups-json-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-xl modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Import NodeGroups from JSON</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="text-muted mb-2">
+          Select a JSON file exported from an existing Infra ("Export" action). Its NodeGroups will be added to the
+          form below — review/edit them before clicking Deploy.
+        </p>
+        <input
+          type="file"
+          class="form-control"
+          id="import-nodegroups-json-file"
+          accept=".json"
+          onchange="webconsolejs['partials/operation/manage/mcicreate'].handleImportJsonFileChange(this)"
+        />
+
+        <!-- 파싱된 NodeGroups 미리보기 -->
+        <div id="import-json-preview" class="mt-3">
+          <p id="import-json-preview-hint" class="text-muted mb-0">
+            Choose a JSON file to preview its NodeGroups.
+          </p>
+          <div id="import-json-preview-content" class="d-none">
+            <h4 class="mb-1">NodeGroups</h4>
+            <div class="table-responsive" style="overflow-x:auto">
+              <table class="table table-vcenter table-sm">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Spec ID</th>
+                    <th>Image ID</th>
+                    <th>Size</th>
+                    <th>Connection</th>
+                    <th>Root Disk</th>
+                    <th>Zone</th>
+                  </tr>
+                </thead>
+                <tbody id="import-json-nodegroup-rows"></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button
+          type="button"
+          id="btn-add-imported-nodegroups"
+          class="btn btn-primary"
+          disabled
+          onclick="webconsolejs['partials/operation/manage/mcicreate'].applyImportedNodeGroups()"
+        >
+          Add NodeGroup(s)
         </button>
       </div>
     </div>

--- a/front/templates/pages/operations/manage/workloads/mciworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/mciworkloads.html
@@ -1807,9 +1807,20 @@
       </div>
       <div class="modal-body">
         <p class="text-muted mb-2">
-          Select a JSON file exported from an existing Infra ("Export" action). Its NodeGroups will be added to the
-          form below — review/edit them before clicking Deploy.
+          Select a JSON file exported from an existing Infra ("Export as JSON" or "Export NodeGroup as JSON" action).
+          Its NodeGroups will be added to the form below — review/edit them before clicking Deploy.
         </p>
+
+        <!-- 드래그앤드롭 영역 — Terminal popup과 동일한 Dropzone 사용 -->
+        <div class="dropzone dz-clickable" id="import-json-dropzone">
+          <div class="dz-message">
+            <h3 class="dropzone-msg-title">Drop a JSON file here</h3>
+            <span class="dropzone-msg-desc">or click to browse (.json, max 10MB)</span>
+          </div>
+        </div>
+
+        <!-- 파일 선택 input은 유지 — 키보드/스크린리더 접근성 및 기존 자동화 호환 -->
+        <div class="form-label mt-3 text-muted">Or select a file</div>
         <input
           type="file"
           class="form-control"
@@ -1820,6 +1831,7 @@
 
         <!-- 파싱된 NodeGroups 미리보기 -->
         <div id="import-json-preview" class="mt-3">
+          <div id="import-json-conflict-warning" class="alert alert-warning d-none" role="alert"></div>
           <p id="import-json-preview-hint" class="text-muted mb-0">
             Choose a JSON file to preview its NodeGroups.
           </p>

--- a/front/templates/partials/operation/manage/_serverlist_status.html
+++ b/front/templates/partials/operation/manage/_serverlist_status.html
@@ -308,7 +308,10 @@
             </svg>
             Delete
           </a>
-          <a class="dropdown-item" href="#">
+          <a
+            class="dropdown-item"
+            onclick="webconsolejs['pages/operation/manage/mci'].exportSelectedNodeGroupAsJson()"
+          >
             <svg
               xmlns="http://www.w3.org/2000/svg"
               class="icon dropdown-item-icon"
@@ -327,7 +330,7 @@
               ></path>
               <path d="M9 12a3 3 0 1 0 6 0a3 3 0 0 0 -6 0"></path>
             </svg>
-            Export
+            Export NodeGroup as JSON
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary

**Infra Workloads — Infra 구성을 JSON으로 내보내고, 그 JSON에서 NodeGroup을 되가져오는 경로 신설**

"Deploy from Template"은 template 형상 그대로만 배포할 수 있어, 기존 Infra의 NodeGroup 구성을 시작점으로 삼아 수정 후 배포하는 경로가 없었다. Export → 수정 → Import 라운드트립으로 이 갭을 메운다.

### Export

- **Infra 전체** — `List of Infra` Action 드롭다운의 `Export as JSON`. `GetInfraReqFromInfra`(mc-infra-manager) 경유로 `InfraDynamicReq` 형상을 받는다. 파일명 `{infraId}-nodegroups-{YYYYMMDD}.json`
- **선택 노드의 NodeGroup** — `Infra Info > Default 탭 > Node List / Status` Action의 `Export NodeGroup as JSON`. 원래 `onclick`이 없는 dead link였던 자리를 배선했다. 파일명 `{infraId}-{nodeGroupId}-nodegroup-{YYYYMMDD}.json`
- 신규 백엔드 API 0. cb-spider 직접 호출 없음

### Import

- Deployment Algorithm에 `Import from JSON` 추가 — **Create Infra(`#mci_deploy_algorithm`)와 Add Node(`#vm_deploy_algorithm`) 양쪽**
- 드래그앤드롭 + 파일 선택 **병행** 지원
- 업로드 시 `nodeGroups` 배열과 필수 5필드(`name`/`specId`/`imageId`/`nodeGroupSize`/`connectionName`)를 검증하고, 누락 시 몇 번째 원소의 어떤 필드가 빠졌는지 표시
- `{infraDynamicReq:{...}}` 래핑과 `{nodeGroups:[...]}` 평면 형태를 모두 허용 — 두 Export 산출물을 그대로 재업로드할 수 있다
- 적용 전 미리보기 테이블로 무엇이 추가될지 확인

### NodeGroup 이름 중복 방지

Export JSON의 `nodeGroups[].name`은 원본 이름 그대로라 **같은 Infra에 되가져오면 반드시 충돌**한다. 그런데 프론트에 이름 중복 검증이 없어 Deploy 이후 백엔드 오류로만 드러났고, 그 오류마저 잘 보이지 않았다 — Create Infra는 배포 요청을 `await` 없이 던지고 즉시 페이지를 이동해 오류가 화면 전환 뒤 토스트로 뜨고, Add Node는 응답 status를 보지 않고 무조건 완료 alert을 띄워 **실패해도 성공처럼 보였다**.

- **충돌한 이름은 비워서 넣는다.** 자동 suffix를 붙이지 않는 이유는 의도하지 않은 이름이 조용히 들어가는 것을 막기 위해서다. 이름은 필수항목이므로 사용자가 직접 입력해야 Deploy가 통과한다
- 점유 판정 범위: 대상 Infra의 기존 NodeGroup(Add Node 경로) + 폼에 쌓인 것 + 파일 내부 중복. Tumblebug이 리소스 id를 정규화하므로 **대소문자를 무시**한다
- 미리보기에 경고 배너와 `Duplicate` 배지, 빈 이름 항목은 `(name required)` 라벨과 붉은 테두리로 구분
- `createMciDynamic`/`createVmDynamic` 최상단에서 Deploy를 차단한다. Add Node는 `vmDynamic` 앞이라 디스크 attach 예약·완료 alert·페이지 이동이 실행되지 않는다. 빈 배열 배포도 함께 막았다
- `expressDone_btn`에도 검사를 넣어 **수동 입력 경로의 중복까지 닫았다** (기존에는 손으로 같은 이름을 두 번 넣어도 통과했다)


## 범위

- Import는 항상 **append 모드** — 기존 NodeGroup 목록을 덮어쓰지 않는다
- Import는 **폼을 채우는 데까지**다. 실제 배포는 기존 Deploy 버튼으로 제출한다 (JSON을 직접 받는 배포 전용 백엔드 엔드포인트가 없음)
- 노드 스코프 Export의 `nodeGroupSize`는 **원본 정의 값을 유지**한다. Node List는 단일 선택이라 "선택 노드 수"로 잡으면 size 3짜리가 조용히 1로 축소된다
- **infra 단위 값은 아직 배포 payload에 병합되지 않는다** — `description`/`policyOnPartialFailure`/`installMonAgent`/`sgTemplateId`/`vNetTemplateId`/`postCommand`는 template prefill과 동일하게 WEB-TECH-019(FR-05-02) 소관이다. Export한 Infra를 그대로 Import하면 NodeGroup 구성만 복원된다는 뜻이라 후속에서 다뤄야 한다

