### PR TITLE
fix: K8s Remote Command 터미널 동작 보완

### DIFF
--- a/front/assets/js/common/api/services/remotecmd_api.js
+++ b/front/assets/js/common/api/services/remotecmd_api.js
@@ -59,6 +59,7 @@ export async function postRemoteCmd(nsid, resourceId, targetId, cmdarr, targetTy
             queryParams.k8sClusterContainerName = targetId.containerName;
         }
 
+        // PostCmdK8sCluster의 body 스펙(model.K8sClusterContainerCmdReq)은 command만 받는다
         data = {
             pathParams: {
                 nsId: nsid,
@@ -66,15 +67,14 @@ export async function postRemoteCmd(nsid, resourceId, targetId, cmdarr, targetTy
             },
             queryParams: queryParams,
             Request: {
-                command: cmdarr,
-                userName: "cb-user"
+                command: cmdarr
             }
         };
     }
 
     let controller;
     if (targetType === 'cluster') {
-        controller = "/api/" + "mc-infra-manager/" + "Postclusterremotecmd";
+        controller = "/api/" + "mc-infra-manager/" + "PostCmdK8sCluster";
     } else {
         controller = "/api/" + "mc-infra-manager/" + "PostCmdInfra";
     }

--- a/front/assets/js/pages/operation/manage/pmk.js
+++ b/front/assets/js/pages/operation/manage/pmk.js
@@ -2109,25 +2109,30 @@ export function showClusterTerminalModal() {
         return;
     }
 
-    // 입력 필드 초기화
-    const namespaceInput = document.getElementById('modalNamespace');
-    const podNameInput = document.getElementById('modalPodName');
-
-    if (namespaceInput) {
-        namespaceInput.value = '';
+    // Namespace는 상단에서 선택한 Project를 그대로 쓴다 — 입력받지 않고 보여주기만 한다
+    const namespaceText = document.getElementById('modalNamespaceText');
+    if (namespaceText) {
+        namespaceText.textContent = getTerminalNamespace() || '-';
     }
+
+    const podNameInput = document.getElementById('modalPodName');
     if (podNameInput) {
         podNameInput.value = '';
     }
 
-    // 모달 표시
+    // 모달 표시 — getOrCreateInstance로 인스턴스 중복 생성을 막는다
+    // (인스턴스를 새로 만들면 이전 인스턴스의 backdrop이 고아가 되어 화면에 남는다)
     const modalElement = document.getElementById('clusterTerminalModal');
     if (modalElement) {
-        const modalInstance = new bootstrap.Modal(modalElement);
-        modalInstance.show();
+        bootstrap.Modal.getOrCreateInstance(modalElement).show();
     } else {
         alert("Terminal modal not found");
     }
+}
+
+// 터미널이 접속할 K8s Namespace — 상단에서 선택한 Project를 사용한다
+function getTerminalNamespace() {
+    return webconsolejs["common/api/services/workspace_api"].getCurrentProject().NsId;
 }
 
 // Cluster Terminal 연결 함수
@@ -2140,16 +2145,19 @@ export async function connectToClusterTerminal() {
         return;
     }
 
-    // 모달에서 값 가져오기
-    const namespaceInput = document.getElementById('modalNamespace');
+    // Namespace는 상단 Project 값을 그대로 쓴다 (입력받지 않는다)
+    const namespace = getTerminalNamespace();
+    if (!namespace) {
+        alert("Please select a project first.");
+        return;
+    }
+
     const podNameInput = document.getElementById('modalPodName');
-
-    const userNamespace = namespaceInput ? namespaceInput.value.trim() : '';
-    const userPodName = podNameInput ? podNameInput.value.trim() : '';
-
-    // 사용자가 입력한 값이 있으면 사용, 없으면 기본값 사용
-    const namespace = userNamespace || 'default';
-    const podName = userPodName || 'cluster-pod';
+    const podName = podNameInput ? podNameInput.value.trim() : '';
+    if (!podName) {
+        alert("Please enter the target pod name.");
+        return;
+    }
 
     try {
         // 클러스터 데이터에서 실제 정보 가져오기
@@ -2160,14 +2168,10 @@ export async function connectToClusterTerminal() {
             return;
         }
 
-        // 연결 모달 닫기
-        const terminalModal = document.getElementById('clusterTerminalModal');
-        if (terminalModal) {
-            const modalInstance = bootstrap.Modal.getInstance(terminalModal);
-            if (modalInstance) {
-                modalInstance.hide();
-            }
-        }
+        // 연결 모달이 완전히 닫힌 뒤에 터미널 모달을 연다.
+        // hide 트랜지션 도중에 다음 모달을 show 하면 backdrop 회계가 깨져
+        // 닫은 뒤에도 backdrop이 화면에 남는다.
+        await hideModal('clusterTerminalModal');
 
         await webconsolejs["partials/operation/manage/remotecmd"].initClusterTerminal(
             'cluster-xterm-container',
@@ -2179,15 +2183,43 @@ export async function connectToClusterTerminal() {
         );
 
         const modalElement = document.getElementById('cluster-cmdtestmodal');
-        if (modalElement) {
-            const modalInstance = new bootstrap.Modal(modalElement);
-            modalInstance.show();
-        } else {
+        if (!modalElement) {
             alert("Terminal modal element not found");
+            return;
         }
+
+        // 닫을 때 터미널·Dropzone을 정리한다 (열 때마다 인스턴스가 쌓이지 않도록)
+        if (!modalElement.dataset.disposeBound) {
+            modalElement.addEventListener('hidden.bs.modal', function () {
+                webconsolejs["partials/operation/manage/remotecmd"].disposeClusterTerminal();
+            });
+            modalElement.dataset.disposeBound = 'true';
+        }
+
+        bootstrap.Modal.getOrCreateInstance(modalElement).show();
     } catch (error) {
         alert("Error initializing terminal: " + error.message);
     }
+}
+
+// 모달을 닫고 hidden 이벤트까지 기다린다
+function hideModal(modalId) {
+    return new Promise((resolve) => {
+        const el = document.getElementById(modalId);
+        if (!el) return resolve();
+
+        const instance = bootstrap.Modal.getInstance(el);
+        if (!instance || !el.classList.contains('show')) return resolve();
+
+        const done = () => {
+            el.removeEventListener('hidden.bs.modal', done);
+            resolve();
+        };
+        el.addEventListener('hidden.bs.modal', done);
+        instance.hide();
+        // 트랜지션 이벤트가 오지 않는 경우를 대비한 안전장치
+        setTimeout(done, 1000);
+    });
 }
 
 // Cluster Terminal 버튼 상태 업데이트

--- a/front/assets/js/pages/operation/manage/pmk.js
+++ b/front/assets/js/pages/operation/manage/pmk.js
@@ -2109,10 +2109,10 @@ export function showClusterTerminalModal() {
         return;
     }
 
-    // Namespace는 상단에서 선택한 Project를 그대로 쓴다 — 입력받지 않고 보여주기만 한다
-    const namespaceText = document.getElementById('modalNamespaceText');
-    if (namespaceText) {
-        namespaceText.textContent = getTerminalNamespace() || '-';
+    // 입력 필드 초기화
+    const namespaceInput = document.getElementById('modalNamespace');
+    if (namespaceInput) {
+        namespaceInput.value = '';
     }
 
     const podNameInput = document.getElementById('modalPodName');
@@ -2130,11 +2130,6 @@ export function showClusterTerminalModal() {
     }
 }
 
-// 터미널이 접속할 K8s Namespace — 상단에서 선택한 Project를 사용한다
-function getTerminalNamespace() {
-    return webconsolejs["common/api/services/workspace_api"].getCurrentProject().NsId;
-}
-
 // Cluster Terminal 연결 함수
 export async function connectToClusterTerminal() {
     const nsId = webconsolejs["common/api/services/workspace_api"].getCurrentProject().NsId
@@ -2145,12 +2140,10 @@ export async function connectToClusterTerminal() {
         return;
     }
 
-    // Namespace는 상단 Project 값을 그대로 쓴다 (입력받지 않는다)
-    const namespace = getTerminalNamespace();
-    if (!namespace) {
-        alert("Please select a project first.");
-        return;
-    }
+    // K8s Namespace는 클러스터 안의 네임스페이스로, 상단 Project(=tumblebug nsId)와는 다른 계층이다.
+    // 사용자가 입력하며, 비워두면 K8s 기본값인 default를 쓴다.
+    const namespaceInput = document.getElementById('modalNamespace');
+    const namespace = (namespaceInput ? namespaceInput.value.trim() : '') || 'default';
 
     const podNameInput = document.getElementById('modalPodName');
     const podName = podNameInput ? podNameInput.value.trim() : '';

--- a/front/assets/js/partials/operation/manage/remotecmd.js
+++ b/front/assets/js/partials/operation/manage/remotecmd.js
@@ -9,6 +9,7 @@ import { postRemoteCmd, postFileToMci } from '../../../common/api/services/remot
 
 let terminalInstance = null;
 let dropzoneInstance = null;
+let clusterScriptHandler = null;
 
 // 터미널 관련 함수들
 export async function initTerminal(id, nsId, mciId, targetId, targetType) {
@@ -319,22 +320,47 @@ export async function initClusterTerminal(id, nsId, clusterId, namespace, podNam
         });
     }
 
-    document.getElementById("show-content-btn").addEventListener("click", async function () {
-        if (fileContents.length > 0) {
-            for (const cmdarr of fileContents) {
-                try {
-                    await processCommand(nsId, clusterId, { namespace, podName, containerName }, cmdarr, terminalInstance, () => {
-                        prompt();
-                    }, 'cluster');
-                } catch (error) {
-                    alert("An error occurred while processing the command.");
-                    console.error(error);
-                }
-            }
-        } else {
-            alert("No file content available or file not loaded.");
+    // 터미널을 열 때마다 리스너가 쌓이지 않도록 이전 핸들러를 먼저 떼어낸다
+    const scriptBtn = document.getElementById("show-content-btn");
+    if (scriptBtn) {
+        if (clusterScriptHandler) {
+            scriptBtn.removeEventListener("click", clusterScriptHandler);
         }
-    });
+        clusterScriptHandler = async function () {
+            if (fileContents.length > 0) {
+                for (const cmdarr of fileContents) {
+                    try {
+                        await processCommand(nsId, clusterId, { namespace, podName, containerName }, cmdarr, terminalInstance, () => {
+                            prompt();
+                        }, 'cluster');
+                    } catch (error) {
+                        alert("An error occurred while processing the command.");
+                        console.error(error);
+                    }
+                }
+            } else {
+                alert("No file content available or file not loaded.");
+            }
+        };
+        scriptBtn.addEventListener("click", clusterScriptHandler);
+    }
+}
+
+// 터미널 모달을 닫을 때 호출 — 터미널·Dropzone·리스너를 정리한다
+export function disposeClusterTerminal() {
+    if (terminalInstance) {
+        terminalInstance.dispose();
+        terminalInstance = null;
+    }
+    if (dropzoneInstance) {
+        dropzoneInstance.destroy();
+        dropzoneInstance = null;
+    }
+    const scriptBtn = document.getElementById("show-content-btn");
+    if (scriptBtn && clusterScriptHandler) {
+        scriptBtn.removeEventListener("click", clusterScriptHandler);
+    }
+    clusterScriptHandler = null;
 }
 
 // MCI/NodeGroup용 단발성 명령어 실행 초기화 함수

--- a/front/assets/js/partials/operation/manage/remotecmd.js
+++ b/front/assets/js/partials/operation/manage/remotecmd.js
@@ -289,32 +289,39 @@ export async function initClusterTerminal(id, nsId, clusterId, namespace, podNam
         }
     });
 
-    dropzoneInstance = new Dropzone("#dropzone-custom", {
-        autoProcessQueue: false,
-        addRemoveLinks: true,
-        acceptedFiles: ".sh",
-        init: function () {
-            this.on("addedfile", function (file) {
-                if (file.name.endsWith(".sh")) {
-                    const reader = new FileReader();
-                    reader.onload = function (event) {
-                        const fileText = event.target.result;
-                        const modifiedContent = fileText
-                            .split('\n')
-                            .map(line => line.trim())
-                            .filter(line => line.length > 0);
-                        fileContents.push(modifiedContent);
-                    };
-                    reader.onerror = function () {
-                        alert("Failed to read file");
-                    };
-                    reader.readAsText(file);
-                } else {
-                    alert("Only shell script files (.sh) are allowed.");
-                }
-            });
-        }
-    });
+    // Dropzone은 url 옵션이 없으면 "No URL provided."로 throw한다. 이 초기화가
+    // initClusterTerminal 본문에서 동기로 실행되므로, 실패하면 터미널 창 자체가 뜨지 않는다.
+    // (autoProcessQueue: false라 실제 업로드는 아래 버튼 핸들러가 처리하고 url은 쓰이지 않는다)
+    const clusterDropzoneEl = document.querySelector("#dropzone-custom");
+    if (clusterDropzoneEl && !clusterDropzoneEl.dropzone) {
+        dropzoneInstance = new Dropzone("#dropzone-custom", {
+            url: "#",
+            autoProcessQueue: false,
+            addRemoveLinks: true,
+            acceptedFiles: ".sh",
+            init: function () {
+                this.on("addedfile", function (file) {
+                    if (file.name.endsWith(".sh")) {
+                        const reader = new FileReader();
+                        reader.onload = function (event) {
+                            const fileText = event.target.result;
+                            const modifiedContent = fileText
+                                .split('\n')
+                                .map(line => line.trim())
+                                .filter(line => line.length > 0);
+                            fileContents.push(modifiedContent);
+                        };
+                        reader.onerror = function () {
+                            alert("Failed to read file");
+                        };
+                        reader.readAsText(file);
+                    } else {
+                        alert("Only shell script files (.sh) are allowed.");
+                    }
+                });
+            }
+        });
+    }
 
     document.getElementById("show-content-btn").addEventListener("click", async function () {
         if (fileContents.length > 0) {
@@ -978,10 +985,17 @@ async function processCommand(nsid, resourceId, targetId, command, term, callbac
         clearInterval(loadingInterval);
         term.write('\r                          \r');
 
-        const response = result.results[0];
+        const response = Array.isArray(result && result.results) ? result.results[0] : null;
+        if (!response) {
+            const message = (result && (result.message || result.error)) || 'No command result returned by the remote command API';
+            writeAutoWrap(term, " > Error: \x1b[1m\x1b[31m" + message + "\x1b[0m");
+            callback({ error: message });
+            return;
+        }
+
         const callErr = response.err;
-        const stdout = response.stdout;
-        const stderr = response.stderr;
+        const stdout = toOutputChunks(response.stdout);
+        const stderr = toOutputChunks(response.stderr);
 
         if (callErr && Object.keys(callErr).length > 0) {
             const formattedError = JSON.stringify(callErr, null, 2);
@@ -990,16 +1004,16 @@ async function processCommand(nsid, resourceId, targetId, command, term, callbac
             return;
         }
 
-        if (stderr && Object.values(stderr).some(value => value.trim() !== '')) {
+        if (stderr.some(value => value.trim() !== '')) {
             term.write('\r\n\x1b[1m\x1b[31mSTDERR RESPONSE:\r\n');
-            Object.values(stderr).forEach(value => {
+            stderr.forEach(value => {
                 writeAutoWrap(term, value);
             });
             term.write("\x1b[0m\r\n");
         }
 
-        if (stdout && Object.values(stdout).some(value => value.trim() !== '')) {
-            Object.values(stdout).forEach(value => {
+        if (stdout.some(value => value.trim() !== '')) {
+            stdout.forEach(value => {
                 writeAutoWrap(term, value);
             });
         } else {
@@ -1013,6 +1027,14 @@ async function processCommand(nsid, resourceId, targetId, command, term, callbac
         term.write(`Error: ${error.message}\r\n`);
         callback({ error: error.message });
     }
+}
+
+// PostCmdInfra는 stdout/stderr를 map[int]string(객체)으로, PostCmdK8sCluster는
+// 단일 문자열로 돌려준다. 두 형태를 출력 단위 배열로 통일한다.
+function toOutputChunks(value) {
+    if (!value) return [];
+    if (typeof value === 'string') return [value];
+    return Object.values(value).map(v => (typeof v === 'string' ? v : String(v)));
 }
 
 function writeAutoWrap(term, text) {

--- a/front/assets/js/partials/operation/manage/remotecmd.js
+++ b/front/assets/js/partials/operation/manage/remotecmd.js
@@ -257,15 +257,11 @@ export async function initClusterTerminal(id, nsId, clusterId, namespace, podNam
         term.write('\r\n\r\n $ ');
     }
 
-    // SSH Private IP 메시지 제거 - 기존 로직은 유지하되 화면에 표시하지 않음
-    const ipcmd = "client_ip=$(echo $SSH_CLIENT | awk '{print $1}'); echo SSH Private IP is: $client_ip";
-
-    await processCommand(nsId, clusterId, { namespace, podName, containerName }, [ipcmd], term, () => {
-        prompt();
-    }, 'cluster');
-
-    // 터미널 초기화 후 바로 프롬프트 표시
-    // prompt();
+    // 터미널을 열자마자 프롬프트만 띄운다.
+    // (VM 경로에서 쓰던 SSH_CLIENT IP 조회 명령을 여기서도 보내고 있었으나,
+    //  K8s는 cb-tumblebug이 명령 문자열을 공백으로 잘라 argv로 직접 exec 하므로
+    //  셸 문법($(), ;, 파이프)이 동작하지 않아 터미널을 열 때마다 에러만 찍혔다)
+    prompt();
 
     let userInput = '';
     term.onData(async (data) => {

--- a/front/templates/pages/operations/manage/workloads/pmkworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/pmkworkloads.html
@@ -1118,18 +1118,26 @@
 
       <div class="modal-body">
         <div class="form-group mb-3">
-          <label class="form-label">Namespace</label>
-          <div class="form-control-plaintext fw-bold" id="modalNamespaceText">-</div>
-          <div class="form-text">Taken from the selected project</div>
+          <label for="modalNamespace" class="form-label">K8s Namespace</label>
+          <input
+            type="text"
+            class="form-control"
+            id="modalNamespace"
+            placeholder="default"
+          />
+          <div class="form-text">
+            Namespace inside the Kubernetes cluster &mdash; not the console project.
+            Defaults to "default".
+          </div>
         </div>
-        
+
         <div class="form-group mb-3">
           <label for="modalPodName" class="form-label">Pod Name</label>
           <input
             type="text"
             class="form-control"
             id="modalPodName"
-            placeholder="cluster-pod"
+            placeholder="coredns-69775bf776-47wvd"
           />
           <div class="form-text">Enter the target pod name</div>
         </div>

--- a/front/templates/pages/operations/manage/workloads/pmkworkloads.html
+++ b/front/templates/pages/operations/manage/workloads/pmkworkloads.html
@@ -1118,14 +1118,9 @@
 
       <div class="modal-body">
         <div class="form-group mb-3">
-          <label for="modalNamespace" class="form-label">Namespace</label>
-          <input
-            type="text"
-            class="form-control"
-            id="modalNamespace"
-            placeholder="default"
-          />
-          <div class="form-text">Enter the Kubernetes namespace</div>
+          <label class="form-label">Namespace</label>
+          <div class="form-control-plaintext fw-bold" id="modalNamespaceText">-</div>
+          <div class="form-text">Taken from the selected project</div>
         </div>
         
         <div class="form-group mb-3">

--- a/front/templates/partials/operation/manage/_clusterinfo.html
+++ b/front/templates/partials/operation/manage/_clusterinfo.html
@@ -8,10 +8,10 @@
     </h3>
     <!-- Terminal Button -->
     <div class="d-flex align-items-center gap-3">
+      <!-- data-bs-toggle을 쓰지 않는다 — onclick의 showClusterTerminalModal()이 직접 연다.
+           둘 다 두면 모달 인스턴스가 2개 생성돼 backdrop이 화면에 남는다 -->
       <a
         class="btn btn-outline-secondary"
-        data-bs-toggle="modal"
-        data-bs-target="#clusterTerminalModal"
         onclick="webconsolejs['pages/operation/manage/pmk'].showClusterTerminalModal()"
       >
         Terminal


### PR DESCRIPTION
## 변경 사항


### 1. 존재하지 않는 operationId 호출 (원 티켓)

`remotecmd_api.js`가 `targetType === 'cluster'`일 때 `conf/api.yaml`에 없는
`Postclusterremotecmd`를 호출해 BFF에서 404로 막혔다. cb-tumblebug v0.12.9 API 개편 때
이 호출부만 누락된 건이다.

`PostCmdK8sCluster`(`POST /ns/{nsId}/cmd/k8sCluster/{k8sClusterId}`)로 교체했다.
pathParams·queryParams는 이미 스펙과 맞아 그대로 두고, `model.K8sClusterContainerCmdReq`에
없는 `userName`만 요청 본문에서 제거했다.

원격 cb-tumblebug 대상 실증:

| 요청 | 결과 |
|---|---|
| `Postclusterremotecmd` | `404 action not found` — 백엔드 도달 못함 |
| `PostCmdK8sCluster` (없는 클러스터) | `The K8sCluster(...) does not exist` — 백엔드 도달 |
| `PostCmdK8sCluster` (실클러스터) | `200` — 경로·파라미터·바디 전부 수용 |

### 2. 터미널 창이 아예 열리지 않던 문제

`initClusterTerminal`이 `new Dropzone("#dropzone-custom", {...})`를 **동기로** 호출하는데
`url` 옵션이 없어 Dropzone이 `"No URL provided."`로 throw했다. 그 결과
`connectToClusterTerminal`의 catch가 alert만 띄우고 터미널 모달을 열지 못했다.
**operationId만 고쳐서는 사용자가 결과를 볼 수 없어** 함께 수정했다.

`url` 지정(`autoProcessQueue: false`라 실제로 사용되지 않는다) + 이미 붙어 있으면
재초기화하지 않는 가드. Infra 쪽 `initTerminal`과 같은 패턴이다.

### 3. 터미널 열 때 자동 전송하던 SSH용 첫 명령

VM 경로에서 쓰던 `client_ip=$(echo $SSH_CLIENT | awk '{print $1}'); echo ...`를
K8s에도 그대로 보내고 있었다. cb-tumblebug은 K8s 명령을 `strings.Fields(cmd)`로 잘라
**셸 없이 argv로 직접 exec** 하므로 `$( )`·`;`·파이프가 동작하지 않고, 터미널을 열 때마다
실패해 에러만 찍혔다. 자동 전송을 없애고 프롬프트만 띄운다.

### 4. 응답 형태 정규화

두 백엔드의 응답 계약이 다르다.

| operationId | stdout/stderr 타입 |
|---|---|
| `PostCmdInfra` (`model.SshCmdResultForAPI`) | `map[int]string` |
| `PostCmdK8sCluster` (`model.K8sClusterContainerCmdResult`) | `string` |

기존 `processCommand`는 `Object.values(stdout)`로 객체만 가정했다. 문자열이 오면
문자 단위로 쪼개져 우연히 같은 화면이 나올 뿐이라 `toOutputChunks()`로 명시 통일했다.

또한 `result.results[0]`을 무조건 인덱싱하던 부분에 `Array.isArray()` 가드를 추가했다.
실제로 kubeconfig 미준비 클러스터는 `{"results": null}`을 돌려줘(실측) 가드 없이는 TypeError로 죽는다.

> cb-tumblebug swagger는 이 API 200 응답을 `...CmdResult`(단수)로 적어놨지만
> 핸들러는 `...CmdResults`(복수, `results` 배열)를 반환한다 — swagger 주석 오류.
> 실응답 기준으로 구현했다.

### 5. `K8s Namespace` 라벨 명확화

MCMP에서 `namespace`는 세 계층이 같은 단어를 쓴다.

| 계층 | 용어 | 값 예시 |
|---|---|---|
| cb-tumblebug | `namespace` (nsId) | `default` |
| mc-iam-manager | `project` ↔ `namespace` 1:1 (project object 안에 namespace) | project `default` → nsid `default` |
| mc-web-console | 상단 셀렉터에 **project**로 노출 | `default` |
| **Kubernetes** | `namespace` — 위와 무관한 별개 개념 | `default`, `kube-system` … |

모달 입력칸이 그냥 `Namespace`라 상단 project와 같은 것으로 오해되기 쉬웠다.
라벨을 **`K8s Namespace`** 로 바꾸고(메뉴가 `K8s Workloads`라 톤 일치),
도움말에 project가 아니라는 점과 기본값을 명시했다.

```
K8s Namespace
[ default                          ]
Namespace inside the Kubernetes cluster — not the console project. Defaults to "default".
```

Pod Name placeholder도 실재하지 않는 `cluster-pod`에서 실제 형태(`coredns-69775bf776-47wvd`)로 바꿨고,
비어 있으면 요청을 보내지 않고 안내한다 (기존 기본값 `cluster-pod`는 무조건 실패했다).

실환경에서 두 값이 독립적으로 나가는 것을 확인했다.

```
"pathParams":  {"nsId": "default", ...}                 ← 상단 project
"queryParams": {"k8sClusterNamespace": "kube-system"}   ← 입력한 K8s namespace
```

### 6. 모달을 닫아도 backdrop이 남던 문제

터미널 모달을 닫으면 창은 사라지지만 `modal-backdrop`이 화면에 남아
**이후 화면 조작이 전부 막혔다**. 목록 행 위치의 최상단 엘리먼트가 `modal-backdrop fade show`였고,
두 번째로 터미널을 열려고 하면 클릭이 backdrop에 막혀 실패했다.

원인은 **모달이 두 번 열리는 것**이다. `_clusterinfo.html`의 Terminal 앵커에
`data-bs-toggle="modal" data-bs-target="#clusterTerminalModal"`이 있는데,
같은 앵커의 `onclick`이 호출하는 `showClusterTerminalModal()`도 `new bootstrap.Modal(...).show()`를 한다.
인스턴스 2개가 각자 backdrop을 만들고 하나만 정리된다.

