### PR TITLE
fix: Infra 생성 postCommand를 postCommands 배열 구조로 전환

### DIFF
--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -318,10 +318,10 @@ export async function mciDynamicReview(mciName, mciDesc, Express_Server_Config_A
       "installMonAgent": "no",
       "label": labels || {},
       "policyOnPartialFailure": "continue",
-      "postCommand": {
-        "command": command,
-        "userName": "cb-user"
-      },
+      // 단일 명령은 phase 1개로 표현 (cb-tumblebug v0.12.29+ postCommands 배열 구조)
+      ...(command.length ? {
+        "postCommands": [{ "command": command, "userName": "cb-user" }]
+      } : {}),
       "nodeGroups": nodeGroups,
       "systemLabel": ""
     }
@@ -370,10 +370,10 @@ export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, ns
       "label": labels || {},
       "nodeGroups": nodeGroups,
       "policyOnPartialFailure": policyOnPartialFailure,
-      "postCommand": {
-        "command": command,
-        "userName": "cb-user"
-      }
+      // 단일 명령은 phase 1개로 표현 (cb-tumblebug v0.12.29+ postCommands 배열 구조)
+      ...(command.length ? {
+        "postCommands": [{ "command": command, "userName": "cb-user" }]
+      } : {})
     }
   }
 


### PR DESCRIPTION
## 변경 사항

cb-tumblebug이 **v0.12.29(2026-08-03)** 에서 `model.InfraDynamicReq`의 필드를 교체했으나 콘솔이 구 구조를 그대로 전송하고 있었다.

| 구분 | v0.12.28 이전 | v0.12.29 이후 |
|---|---|---|
| 필드명 | `postCommand` (단수) | `postCommands` (복수) |
| 타입 | `model.InfraCmdReq` 객체 | `model.PostCommandReq[]` 배열 (다단계 phase) |

Go의 JSON 언마샬은 모르는 필드를 무시하므로 **HTTP 에러도 JS 에러도 발생하지 않는다.**
Infra는 정상 생성되고 **부트스트랩 명령만 조용히 유실**된다.

## 수정 내용

`front/assets/js/common/api/services/mci_api.js` 2지점.

| 함수 | operationId | 경로 |
|---|---|---|
| `mciDynamicReview()` | `PostInfraDynamicReview` | `POST /ns/{nsId}/infraDynamicReview` |
| `mciDynamic()` | `PostInfraDynamic` | `POST /ns/{nsId}/infraDynamic` |

```js
// before
"postCommand": {
  "command": command,
  "userName": "cb-user"
},

// after — 단일 명령은 phase 1개로 표현, 빈 명령이면 키 자체를 생략
...(command.length ? {
  "postCommands": [{ "command": command, "userName": "cb-user" }]
} : {}),
```

빈 값일 때 키를 생략하는 조건부 스프레드는 같은 파일이 이미 쓰는 관용구다(`...(config.zone ? { zone: config.zone } : {})`).

`userName`은 **유지**한다 — `model.PostCommandReq`는 구 `model.InfraCmdReq`의 3개 필드(`command`/`userName`/`timeoutMinutes`)를 그대로 승계했다.

```
model.PostCommandReq  (v0.12.29 / v0.12.30 / v0.13.0 동일)
  required: [command]
  command, continueOnError, labelSelector, nodeGroupId, nodeId, timeoutMinutes, userName
```
