### PR TITLE
fix: cb-tumblebug v0.12.28/29 스펙 변경 반영 — Policy postCommands 전환 + Node User Password 보완

### DIFF
--- a/front/assets/js/common/api/services/mci_api.js
+++ b/front/assets/js/common/api/services/mci_api.js
@@ -297,7 +297,6 @@ export async function mciDynamicReview(mciName, mciDesc, Express_Server_Config_A
     rootDiskSize: (config.rootDiskSize !== "" && config.rootDiskSize !== undefined) ? parseInt(config.rootDiskSize) : 0,
     rootDiskType: config.rootDiskType,
     ...(config.zone ? { zone: config.zone } : {}),
-    ...(config.nodeUserPassword ? { nodeUserPassword: config.nodeUserPassword } : {}),
     ...(config.label && Object.keys(config.label).length > 0 ? { label: config.label } : {}),
     ...(config.vNetTemplateId ? { vNetTemplateId: config.vNetTemplateId } : {}),
     ...(config.sgTemplateId ? { sgTemplateId: config.sgTemplateId } : {})
@@ -349,7 +348,6 @@ export async function mciDynamic(mciName, mciDesc, Express_Server_Config_Arr, ns
     rootDiskSize: (config.rootDiskSize !== "" && config.rootDiskSize !== undefined) ? parseInt(config.rootDiskSize) : 0,
     rootDiskType: config.rootDiskType,
     ...(config.zone ? { zone: config.zone } : {}),
-    ...(config.nodeUserPassword ? { nodeUserPassword: config.nodeUserPassword } : {}),
     ...(config.label && Object.keys(config.label).length > 0 ? { label: config.label } : {}),
     ...(config.vNetTemplateId ? { vNetTemplateId: config.vNetTemplateId } : {}),
     ...(config.sgTemplateId ? { sgTemplateId: config.sgTemplateId } : {})
@@ -415,7 +413,6 @@ export async function vmDynamicReview(mciId, nsId, config) {
       "rootDiskSize": (config.rootDiskSize !== "" && config.rootDiskSize !== undefined) ? parseInt(config.rootDiskSize) : 0,
       "rootDiskType": config.rootDiskType,
       ...(config.zone ? { zone: config.zone } : {}),
-      ...(config.nodeUserPassword ? { nodeUserPassword: config.nodeUserPassword } : {}),
       ...(config.label && Object.keys(config.label).length > 0 ? { label: config.label } : {}),
       ...(config.vNetTemplateId ? { vNetTemplateId: config.vNetTemplateId } : {}),
       ...(config.sgTemplateId ? { sgTemplateId: config.sgTemplateId } : {})
@@ -451,7 +448,6 @@ export async function vmDynamic(mciId, nsId, Express_Server_Config_Arr) {
         "rootDiskSize": (obj.rootDiskSize !== "" && obj.rootDiskSize !== undefined) ? parseInt(obj.rootDiskSize) : 0,
         "rootDiskType": obj.rootDiskType,
         ...(obj.zone ? { zone: obj.zone } : {}),
-        ...(obj.nodeUserPassword ? { nodeUserPassword: obj.nodeUserPassword } : {}),
         ...(obj.label && Object.keys(obj.label).length > 0 ? { label: obj.label } : {}),
         ...(obj.vNetTemplateId ? { vNetTemplateId: obj.vNetTemplateId } : {}),
         ...(obj.sgTemplateId ? { sgTemplateId: obj.sgTemplateId } : {})

--- a/front/assets/js/pages/operation/manage/mci.js
+++ b/front/assets/js/pages/operation/manage/mci.js
@@ -2836,14 +2836,16 @@ function transformPolicyResponse(resp) {
       const {
         actionType = '',
         placementAlgo = '',
-        postCommand = {},
+        postCommands = [],
         nodeGroupDynamicReq = {}
       } = autoAction;
 
+      // postCommands는 다단계 phase 배열(cb-tumblebug v0.12.29+).
+      // 현재 화면은 단일 명령만 표시하므로 첫 phase를 읽는다.
       const {
         command = [],
         userName = ''
-      } = postCommand;
+      } = (postCommands[0] || {});
 
       const {
         imageId: commonImage = '',
@@ -3246,10 +3248,10 @@ function buildPolicyRequestData(data) {
       autoAction: {
         actionType: data.actionType,
         placementAlgo: data.placementAlgo,
-        postCommand: {
-          command: data.command ? [data.command] : [],
-          userName: data.userName
-        },
+        // 명령이 있을 때만 phase 1개로 전송 (cb-tumblebug v0.12.29+ postCommands 배열 구조)
+        ...(data.command ? {
+          postCommands: [{ command: [data.command], userName: data.userName || "cb-user" }]
+        } : {}),
         nodeGroupDynamicReq: {
           imageId: data.commonImage,
           specId: data.commonSpec,
@@ -3262,8 +3264,7 @@ function buildPolicyRequestData(data) {
           name: data.name,
           rootDiskSize: data.rootDiskSize,
           rootDiskType: data.rootDiskType,
-          nodeGroupSize: data.nodeGroupSize,
-          vmUserPassword: ""
+          nodeGroupSize: data.nodeGroupSize
         }
       },
       autoCondition: {

--- a/front/templates/partials/operation/manage/_mcicreate.html
+++ b/front/templates/partials/operation/manage/_mcicreate.html
@@ -232,7 +232,15 @@
                   </div>
                 </div>
               </div>
-              <div class="form-group mb-2">
+              <!--
+                Node User Password — Express(dynamic) 모드에서는 숨긴다.
+                cb-tumblebug v0.12.28이 dynamic 경로에서 이 필드를 의도적으로 폐지했다
+                (Linux는 SSH 키페어로 접근, Windows용 패스워드는 서버가 랜덤 생성).
+                입력을 받아도 서버가 무시하므로 노출하면 거짓 UI가 된다.
+                엘리먼트는 남겨둔다 — 비-dynamic PostInfra를 쓰는 Expert 모드(WEB-TECH-052)에서
+                모드 게이팅으로 다시 노출할 예정이다.
+              -->
+              <div class="form-group mb-2" id="ep_node_user_password_group" style="display: none">
                 <label class="form-label">Node User Password</label>
                 <input
                   type="password"


### PR DESCRIPTION
## 변경 사항

cb-tumblebug 변경 2건에 대한 대응이다. 두 건 모두 `mci.js`/`mci_api.js`/`mcicreate.js` 같은 파일군을 건드려 하나로 묶었다.

| 변경 | 유입 릴리즈 | 증상 |
|---|---|---|
| `model.AutoAction.postCommand` → `postCommands` 배열 | v0.12.29 (2026-08-03) | Policy 등록·조회 양방향 명령 유실 |
| `model.CreateNodeGroupDynamicReq.nodeUserPassword` 폐지 | v0.12.28 (2026-08-02) | 입력란이 화면에 남아 **입력해도 무시되는 거짓 UI** |

원격 mc-infra-manager(`15.164.139.37:1323`, v0.12.30) 라이브 스펙에서 두 필드 모두 부재를 확인했다.

### 1. Policy — `postCommands` 배열 전환

`front/assets/js/pages/operation/manage/mci.js`

```js
// REQ (buildPolicyRequestData)
- postCommand: { command: data.command ? [data.command] : [], userName: data.userName },
+ ...(data.command ? {
+   postCommands: [{ command: [data.command], userName: data.userName || "cb-user" }]
+ } : {}),

// RESP (transformPolicyResponse)
- const { command = [], userName = '' } = postCommand;
+ const { command = [], userName = '' } = (postCommands[0] || {});
```

명령이 비면 키를 생략한다. `postCommands`는 다단계 phase 배열이지만 현재 화면은 단일 명령만 다루므로 첫 phase를 읽는다.

### 2. Node User Password — 전송 제거 + 입력란 숨김

upstream이 **의도적으로 제거**한 필드다. cb-tumblebug 커밋 `4dcb9ce8`:

> A node user password is intentionally NOT accepted here. Linux nodes are accessed via SSH key pairs, and a random password is generated internally for the CSP-side requirement (Windows).

- `mci_api.js` dynamic payload **4곳**(`mciDynamicReview`/`mciDynamic`/`vmDynamicReview`/`vmDynamic`)에서 전송 제거
- `_mcicreate.html`의 입력란을 `#ep_node_user_password_group`으로 감싸 숨김

**엘리먼트는 삭제하지 않았다.** 비-dynamic `PostInfra`(`model.CreateNodeGroupReq`)에는 `nodeUserPassword`·`nodeUserName`이 v0.13.0에도 존재하므로, 해당 API를 쓰는 **Expert 모드에서 모드 게이팅으로 다시 노출**한다. 삭제 후 재작성하는 낭비를 피하기 위한 선택이다.

### 3. `vmUserPassword` 잔재 제거

`nodeGroupDynamicReq`에 `vmUserPassword: ""`를 보내고 있었으나 이 필드는 **v0.12.25 시점에도 스키마에 존재한 적이 없다.** VM→Node 리네이밍 때 남은 잔재로, 같은 함수라 함께 정리했다.
