### PR TITLE
fix: cb-tumblebug v0.12.29 스펙 변경 반영 — Infra Template/JSON Import postCommands 전환

### DIFF
--- a/front/assets/js/pages/operations/manage/workloads/infratemplates.js
+++ b/front/assets/js/pages/operations/manage/workloads/infratemplates.js
@@ -113,7 +113,9 @@ function renderDetail(data) {
     });
   }
 
-  const commands = req.postCommand?.command || [];
+  // postCommands는 다단계 phase 배열(cb-tumblebug v0.12.29+). 이 화면은 phase 구분 없이
+  // 전 phase의 command를 순서대로 이어붙여 표시한다(최소안 — 다단계 UI는 범위 밖).
+  const commands = (req.postCommands || []).flatMap(pc => pc.command || []);
   document.getElementById('detail-postCommand').textContent = commands.length ? commands.join('\n') : '-';
 
   document.getElementById('detail-raw-json').textContent = JSON.stringify(req, null, 2);

--- a/front/assets/js/partials/operation/manage/mcicreate.js
+++ b/front/assets/js/partials/operation/manage/mcicreate.js
@@ -1811,7 +1811,8 @@ function renderTemplateSelectDetail(template) {
 	}
 
 	const block = document.getElementById("template-select-postcommand-block");
-	const commands = req.postCommand?.command || [];
+	// postCommands는 다단계 phase 배열(cb-tumblebug v0.12.29+) — 전 phase를 순서대로 이어붙인다.
+	const commands = (req.postCommands || []).flatMap(pc => pc.command || []);
 	if (commands.length > 0) {
 		block.classList.remove("d-none");
 		document.getElementById("template-select-postcommand").textContent = commands.join("\n");
@@ -1960,7 +1961,7 @@ export async function deployFromSelectedTemplate() {
 }
 
 // nodeGroups[] 원소(InfraDynamicReq 스키마, template/JSON import 공용) → express_form 매핑.
-// req는 상위 InfraDynamicReq(postCommand.command를 idx===0에만 carry-through하기 위해 필요), idx는 groups.forEach의 인덱스.
+// req는 상위 InfraDynamicReq(postCommands[].command를 idx===0에만 carry-through하기 위해 필요), idx는 groups.forEach의 인덱스.
 function mapNodeGroupToExpressForm(g, req, idx) {
 	var express_form = {};
 	express_form["provider"] = (g.specId || "").split("+")[0];
@@ -1974,8 +1975,11 @@ function mapNodeGroupToExpressForm(g, req, idx) {
 	express_form["commonImage"] = g.imageId || "";
 	express_form["imageId"] = g.imageId || "";
 	express_form["specId"] = g.specId || "";
-	// infra 단위 postCommand는 첫 NodeGroup에만 반영(기존 command 처리 관례와 동일)
-	express_form["command"] = idx === 0 ? (req?.postCommand?.command || []).join("\n") : "";
+	// infra 단위 postCommands는 첫 NodeGroup에만 반영(기존 command 처리 관례와 동일).
+	// 다단계 phase 배열이므로 전 phase의 command를 순서대로 이어붙인다.
+	express_form["command"] = idx === 0
+		? (req?.postCommands || []).flatMap(pc => pc.command || []).join("\n")
+		: "";
 
 	// 정식 매핑 승격 5필드(CreateNodeGroupDynamicReq) — 값이 있을 때만 carry-through
 	if (g.zone) express_form["zone"] = g.zone;
@@ -2070,7 +2074,7 @@ function appendNodeGroupsToForm(req) {
 }
 
 // 선택한 template의 nodeGroups를 기존 NodeGroup 목록에 추가(append) — 수정 후 배포용 프리필
-// infra 단위 값(description/policyOnPartialFailure/installMonAgent/sgTemplateId/vNetTemplateId/postCommand.userName·timeoutMinutes)은
+// infra 단위 값(description/policyOnPartialFailure/installMonAgent/sgTemplateId/vNetTemplateId/postCommands[0].userName·timeoutMinutes)은
 // 이 모듈 상태에 보관만 하고, 실제 배포 payload 병합은 WEB-TECH-019(FR-05-02)에서 처리한다.
 let templatePrefillInfraState = null;
 
@@ -2091,8 +2095,9 @@ export function addTemplateToForm() {
 		installMonAgent: req.installMonAgent || "",
 		vNetTemplateId: req.vNetTemplateId || "",
 		sgTemplateId: req.sgTemplateId || "",
-		postCommandUserName: req.postCommand?.userName || "",
-		postCommandTimeoutMinutes: req.postCommand?.timeoutMinutes
+		// postCommands는 다단계 phase 배열 — 첫 phase 기준으로 이관(model.PostCommandReq에 두 필드 모두 존재)
+		postCommandUserName: req.postCommands?.[0]?.userName || "",
+		postCommandTimeoutMinutes: req.postCommands?.[0]?.timeoutMinutes
 	};
 	// Create MCI 경로에서만 — Extend VM은 기존 MCI의 description을 유지한다
 	if (!isVm && !$("#mci_desc").val() && templatePrefillInfraState.description) {


### PR DESCRIPTION
## 변경 사항

cb-tumblebug이 **v0.12.29**에서 `model.InfraDynamicReq`의 필드를 교체했다(`WEB-BUG-062`와 동일 원인).

| 구분 | 이전 | 이후 |
|---|---|---|
| 필드명 | `postCommand` (단수) | `postCommands` (복수) |
| 타입 | `model.InfraCmdReq` 객체 | `model.PostCommandReq[]` 배열 |

Infra Template 응답의 `infraDynamicReq`가 **같은 스키마**라서 상세 표시·선택 미리보기·폼 프리필이 함께 깨져 있었다. 전 지점이 `req.postCommand?.command` optional chaining이라 **JS 에러 없이** 조용히 `-`로 표시되거나 빈 값으로 유실됐다.

## 수정 내용

`front/assets/js/pages/operations/manage/workloads/infratemplates.js`, `front/assets/js/partials/operation/manage/mcicreate.js` 5지점.

```js
// before
const commands = req.postCommand?.command || [];

// after — postCommands는 다단계 phase 배열. 현재 화면은 phase 구분 없는
// 단일 명령만 다루므로 전 phase를 순서대로 이어붙인다 (최소안)
const commands = (req.postCommands || []).flatMap(pc => pc.command || []);
```

`userName`/`timeoutMinutes` 프리필은 **제거가 아니라 이관**했다 — `model.PostCommandReq`에 두 필드 모두 존재한다(`WEB-BUG-062`에서 실증됨). `postCommands[0]` 기준으로 읽도록 바꿨다. 다만 이 값을 저장하는 `templatePrefillInfraState.postCommandUserName/TimeoutMinutes`는 코드 전체에서 어디서도 읽히지 않는 죽은 값이라, 필드명 정정 외에 실동작 변화는 없다.

### PR #255 머지로 영향 범위가 넓어진 지점

`mapNodeGroupToExpressForm()`이 Template 배포와 JSON Import(`#255`, 2026-08-21 머지)가 **공유하는 함수**가 됐다. 수정 지점은 1곳(`mcicreate.js:1978`)인데 Template과 JSON Import 두 기능이 함께 정상화된다.

```
addTemplateToForm()        (템플릿 배포)  ─┐
                                          ├─→ appendNodeGroupsToForm() → mapNodeGroupToExpressForm()
applyImportedNodeGroups()  (JSON Import) ─┘
```
